### PR TITLE
Add unique constraint on stages name and festival_edition_id

### DIFF
--- a/supabase/migrations/20260508000000_add_stages_unique_constraint.sql
+++ b/supabase/migrations/20260508000000_add_stages_unique_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.stages
+ADD CONSTRAINT stages_name_festival_edition_id_key UNIQUE (name, festival_edition_id);


### PR DESCRIPTION
## Summary
This migration adds a unique constraint to the `stages` table to ensure that stage names are unique within each festival edition.

## Key Changes
- Added a unique constraint `stages_name_festival_edition_id_key` on the combination of `name` and `festival_edition_id` columns in the `stages` table

## Implementation Details
This constraint prevents duplicate stage names from being created for the same festival edition, while still allowing the same stage name to exist across different festival editions. This maintains data integrity and ensures consistent stage identification within each festival's context.

https://claude.ai/code/session_01DpTFYTgNZPgZCCD2YNQsot