### PR TITLE
fix(db): restrict festival-assets storage writes to admins

### DIFF
--- a/supabase/migrations/20260520000000_fix_festival_assets_rls_policies.sql
+++ b/supabase/migrations/20260520000000_fix_festival_assets_rls_policies.sql
@@ -1,0 +1,8 @@
+-- Fix festival-assets storage RLS: drop permissive write policies that allowed
+-- any authenticated user to upload/update/delete festival logos.
+-- Postgres ORs permissive policies together, so these bypassed the intended
+-- admin-only restriction added by "Admins can ... festival assets".
+
+DROP POLICY IF EXISTS "Allow authenticated users to upload festival logos" ON storage.objects;
+DROP POLICY IF EXISTS "Allow users to update their festival logos" ON storage.objects;
+DROP POLICY IF EXISTS "Allow users to delete festival logos" ON storage.objects;


### PR DESCRIPTION
## Summary

The `festival-logos` migration created INSERT/UPDATE/DELETE storage policies gated only on `auth.role() = 'authenticated'`, which OR-combined with the later admin-only policies and let any authenticated user write festival assets. This migration drops those three permissive write policies.

## Manual test steps

1. Apply the migration to a Supabase instance with this branch checked out.
2. Sign in as a **non-admin** authenticated user and try to upload/update/delete a file in the `festival-assets` bucket (`festival-logos/` folder) — each operation should now be **denied** by RLS.
3. Sign in as an **admin** user and repeat — upload/update/delete should still **succeed**.
4. Without signing in (anonymous), confirm festival assets are still publicly **readable**.

https://claude.ai/code/session_01DXGpafRd5ytK6UTuKFNrQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXGpafRd5ytK6UTuKFNrQH)_