### PR TITLE
refactor(api): custom-links → src/api modules (Effort 1)

### DIFF
--- a/src/api/custom-links/types.ts
+++ b/src/api/custom-links/types.ts
@@ -1,0 +1,9 @@
+import type { Tables } from "@/integrations/supabase/types";
+
+export type CustomLink = Tables<"custom_links">;
+
+export const customLinksKeys = {
+  all: ["customLinks"] as const,
+  byFestival: (festivalId: string) =>
+    [...customLinksKeys.all, festivalId] as const,
+};

--- a/src/api/custom-links/useCustomLinks.ts
+++ b/src/api/custom-links/useCustomLinks.ts
@@ -27,7 +27,7 @@ export function customLinksQuery(festivalId: string) {
 
 export function useCustomLinksQuery(festivalId: string | undefined) {
   return useQuery({
-    ...customLinksQuery(festivalId!),
+    ...customLinksQuery(festivalId ?? ""),
     enabled: !!festivalId,
   });
 }

--- a/src/api/custom-links/useCustomLinks.ts
+++ b/src/api/custom-links/useCustomLinks.ts
@@ -1,14 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { Tables } from "@/integrations/supabase/types";
-
-export type CustomLink = Tables<"custom_links">;
-
-export const customLinksKeys = {
-  all: ["customLinks"] as const,
-  byFestival: (festivalId: string) =>
-    [...customLinksKeys.all, festivalId] as const,
-};
+import { CustomLink, customLinksKeys } from "./types";
 
 async function fetchCustomLinks(festivalId: string): Promise<CustomLink[]> {
   const { data, error } = await supabase
@@ -26,10 +18,16 @@ async function fetchCustomLinks(festivalId: string): Promise<CustomLink[]> {
   return data || [];
 }
 
+export function customLinksQuery(festivalId: string) {
+  return queryOptions({
+    queryKey: customLinksKeys.byFestival(festivalId),
+    queryFn: () => fetchCustomLinks(festivalId),
+  });
+}
+
 export function useCustomLinksQuery(festivalId: string | undefined) {
   return useQuery({
-    queryKey: customLinksKeys.byFestival(festivalId || ""),
-    queryFn: () => fetchCustomLinks(festivalId!),
+    ...customLinksQuery(festivalId!),
     enabled: !!festivalId,
   });
 }

--- a/src/api/custom-links/useCustomLinksMutation.ts
+++ b/src/api/custom-links/useCustomLinksMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
-import { customLinksKeys } from "./useCustomLinks";
+import { customLinksKeys } from "./types";
 
 interface BulkUpdateCustomLinksData {
   festivalId: string;

--- a/src/pages/EditionView/EditionLayout.tsx
+++ b/src/pages/EditionView/EditionLayout.tsx
@@ -3,7 +3,7 @@ import { MainTabNavigation } from "./TabNavigation/TabNavigation";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { Outlet } from "@tanstack/react-router";
-import { useCustomLinksQuery } from "@/hooks/queries/custom-links/useCustomLinks";
+import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
 
 export default function EditionView() {
   const { festival, edition } = useFestivalEdition();

--- a/src/pages/EditionView/tabs/InfoTab.tsx
+++ b/src/pages/EditionView/tabs/InfoTab.tsx
@@ -7,7 +7,7 @@ import { CustomLinks } from "./InfoTab/CustomLinks";
 import { NoInfo } from "./InfoTab/NoInfo";
 import { LoadingInfo } from "./InfoTab/LoadingInfo";
 import { SocialLinkItem } from "./InfoTab/SocialLinkItem";
-import { useCustomLinksQuery } from "@/hooks/queries/custom-links/useCustomLinks";
+import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
 
 export function InfoTab() {
   const { edition, festival } = useFestivalEdition();

--- a/src/pages/FestivalSelection.tsx
+++ b/src/pages/FestivalSelection.tsx
@@ -14,7 +14,7 @@ import {
   isMainGetuplineDomain,
 } from "@/lib/subdomain";
 import { Link } from "@tanstack/react-router";
-import { useCustomLinksQuery } from "@/hooks/queries/custom-links/useCustomLinks";
+import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 import { TopBar } from "@/components/layout/TopBar";
 import { AppHeader } from "@/components/layout/AppHeader";

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalLinksField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalLinksField.tsx
@@ -4,8 +4,8 @@ import { Input } from "@/components/ui/input";
 import { ExternalLink, Plus, Trash2 } from "lucide-react";
 import { EditableField } from "./shared/EditableField";
 import { EditContainer } from "./shared/EditContainer";
-import { CustomLink } from "@/hooks/queries/custom-links/useCustomLinks";
-import { useBulkUpdateCustomLinksMutation } from "@/hooks/queries/custom-links/useCustomLinksMutation";
+import { CustomLink } from "@/api/custom-links/types";
+import { useBulkUpdateCustomLinksMutation } from "@/api/custom-links/useCustomLinksMutation";
 
 interface FestivalLinksFieldProps {
   festivalId: string;

--- a/src/pages/admin/festivals/info/FestivalInfoDetails.tsx
+++ b/src/pages/admin/festivals/info/FestivalInfoDetails.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Loader2, Edit } from "lucide-react";
 import { useFestivalInfoQuery } from "@/hooks/queries/festival-info/useFestivalInfo";
-import { useCustomLinksQuery } from "@/hooks/queries/custom-links/useCustomLinks";
+import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
 import { FestivalMapField } from "./FestivalFields/FestivalMapField";
 import { FestivalInfoField } from "./FestivalFields/FestivalInfoField";
 import { FestivalSocialField } from "./FestivalFields/FestivalSocialField";


### PR DESCRIPTION
Mechanical move of the `custom-links` feature from `src/hooks/queries/custom-links` to `src/api/custom-links`, adding `queryOptions` factories for the query hooks. No behavior change. Part of #52.

## Manual verification
- Website/social links render on the festival selection page and the edition **Info** tab as before.
- In admin, add/edit a festival custom link — it saves and displays.
- `pnpm run lint && pnpm test && pnpm run build` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K513rsQz6Lg1HbbfYiafrE)_