### PR TITLE
refactor(api): festival-info → src/api modules (Effort 1)

### DIFF
--- a/src/api/festival-info/types.ts
+++ b/src/api/festival-info/types.ts
@@ -1,0 +1,9 @@
+import type { Tables } from "@/integrations/supabase/types";
+
+export type FestivalInfo = Tables<"festival_info">;
+
+export const festivalInfoKeys = {
+  all: ["festivalInfo"] as const,
+  byFestival: (festivalId: string) =>
+    [...festivalInfoKeys.all, festivalId] as const,
+};

--- a/src/api/festival-info/useFestivalInfo.ts
+++ b/src/api/festival-info/useFestivalInfo.ts
@@ -1,14 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { Tables } from "@/integrations/supabase/types";
-
-export type FestivalInfo = Tables<"festival_info">;
-
-export const festivalInfoKeys = {
-  all: ["festivalInfo"] as const,
-  byFestival: (festivalId: string) =>
-    [...festivalInfoKeys.all, festivalId] as const,
-};
+import { FestivalInfo, festivalInfoKeys } from "./types";
 
 async function fetchFestivalInfo(festivalId: string): Promise<FestivalInfo> {
   const { data, error } = await supabase
@@ -29,10 +21,16 @@ async function fetchFestivalInfo(festivalId: string): Promise<FestivalInfo> {
   return data;
 }
 
+export function festivalInfoQuery(festivalId: string) {
+  return queryOptions({
+    queryKey: festivalInfoKeys.byFestival(festivalId),
+    queryFn: () => fetchFestivalInfo(festivalId),
+  });
+}
+
 export function useFestivalInfoQuery(festivalId: string | undefined) {
   return useQuery({
-    queryKey: festivalInfoKeys.byFestival(festivalId || ""),
-    queryFn: () => fetchFestivalInfo(festivalId!),
+    ...festivalInfoQuery(festivalId!),
     enabled: !!festivalId,
   });
 }

--- a/src/api/festival-info/useFestivalInfoMutation.ts
+++ b/src/api/festival-info/useFestivalInfoMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Tables } from "@/integrations/supabase/types";
-import { festivalInfoKeys } from "./useFestivalInfo";
+import { festivalInfoKeys } from "./types";
 
 export function useFestivalInfoMutation(festivalId: string) {
   const queryClient = useQueryClient();

--- a/src/pages/EditionView/TabNavigation/TabNavigation.tsx
+++ b/src/pages/EditionView/TabNavigation/TabNavigation.tsx
@@ -1,5 +1,5 @@
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/hooks/queries/festival-info/useFestivalInfo";
+import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { DesktopTabButton } from "./DesktopTabButton";
 import { MobileTabButton } from "./MobileTabButton";
 import { config } from "./config";

--- a/src/pages/EditionView/TabNavigation/types.ts
+++ b/src/pages/EditionView/TabNavigation/types.ts
@@ -1,4 +1,4 @@
-import { FestivalInfo } from "@/hooks/queries/festival-info/useFestivalInfo";
+import { FestivalInfo } from "@/api/festival-info/types";
 import { LucideIcon } from "lucide-react";
 import { ComponentType } from "react";
 

--- a/src/pages/EditionView/tabs/InfoTab.tsx
+++ b/src/pages/EditionView/tabs/InfoTab.tsx
@@ -1,5 +1,5 @@
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/hooks/queries/festival-info/useFestivalInfo";
+import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 import { EditionTitle } from "./InfoTab/EditionTitle";
 import { InfoText } from "./InfoTab/InfoText";

--- a/src/pages/EditionView/tabs/MapTab.tsx
+++ b/src/pages/EditionView/tabs/MapTab.tsx
@@ -1,5 +1,5 @@
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/hooks/queries/festival-info/useFestivalInfo";
+import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 
 export function MapTab() {

--- a/src/pages/EditionView/tabs/SocialTab.tsx
+++ b/src/pages/EditionView/tabs/SocialTab.tsx
@@ -1,5 +1,5 @@
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/hooks/queries/festival-info/useFestivalInfo";
+import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 import { ExternalLinkIcon } from "lucide-react";
 

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalInfoField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalInfoField.tsx
@@ -2,7 +2,7 @@ import { useForm } from "react-hook-form";
 import { Textarea } from "@/components/ui/textarea";
 import { EditableField } from "./shared/EditableField";
 import { EditContainer } from "./shared/EditContainer";
-import { useFestivalInfoMutation } from "@/hooks/queries/festival-info/useFestivalInfoMutation";
+import { useFestivalInfoMutation } from "@/api/festival-info/useFestivalInfoMutation";
 import { parseMarkdown } from "@/lib/markdown";
 import { getTextAlignmentClasses } from "@/lib/textAlignment";
 

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalMapField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalMapField.tsx
@@ -3,7 +3,7 @@ import { Input } from "@/components/ui/input";
 import { Loader2, Upload } from "lucide-react";
 import { EditableField } from "./shared/EditableField";
 import { EditContainer } from "./shared/EditContainer";
-import { useFestivalInfoMutation } from "@/hooks/queries/festival-info/useFestivalInfoMutation";
+import { useFestivalInfoMutation } from "@/api/festival-info/useFestivalInfoMutation";
 import { useMapUpload } from "./shared/useMapUpload";
 
 interface FestivalMapFieldProps {

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalSocialField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalSocialField.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import { ExternalLink } from "lucide-react";
 import { EditableField } from "./shared/EditableField";
 import { EditContainer } from "./shared/EditContainer";
-import { useFestivalInfoMutation } from "@/hooks/queries/festival-info/useFestivalInfoMutation";
+import { useFestivalInfoMutation } from "@/api/festival-info/useFestivalInfoMutation";
 
 interface FestivalSocialFieldProps {
   festivalId: string;

--- a/src/pages/admin/festivals/info/FestivalInfoDetails.tsx
+++ b/src/pages/admin/festivals/info/FestivalInfoDetails.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Loader2, Edit } from "lucide-react";
-import { useFestivalInfoQuery } from "@/hooks/queries/festival-info/useFestivalInfo";
+import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
 import { FestivalMapField } from "./FestivalFields/FestivalMapField";
 import { FestivalInfoField } from "./FestivalFields/FestivalInfoField";


### PR DESCRIPTION
Mechanical restructure moving the `festival-info` data-access slice from `src/hooks/queries/festival-info` to `src/api/festival-info` per ADR 0001 — shared `types.ts` (FestivalInfo Row type + query-key factory) plus a per-file `festivalInfoQuery` `queryOptions` factory. No behavior change; consumers only change import paths.

## Manual verification

- `pnpm run typecheck` — pass
- `pnpm run lint` — pass
- `pnpm test` — pass (290 tests)

User-facing surfaces exercised by the moved slice (unchanged): edition Info/Map/Social tabs, tab visibility (TabNavigation), and the admin festival info/map/social fields.

Part of #52.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K513rsQz6Lg1HbbfYiafrE)_