### PR TITLE
refactor(api): invite-validation → src/api modules (Effort 1)

### DIFF
--- a/src/api/invite-validation/types.ts
+++ b/src/api/invite-validation/types.ts
@@ -1,0 +1,4 @@
+export const inviteValidationKeys = {
+  all: ["invites", "validation"] as const,
+  byToken: (token: string) => ["invites", "validation", token] as const,
+};

--- a/src/api/invite-validation/useInviteValidationQuery.ts
+++ b/src/api/invite-validation/useInviteValidationQuery.ts
@@ -1,8 +1,8 @@
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { queryOptions, useQuery, useMutation } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 import type { InviteValidation } from "@/types/invites";
-import { inviteKeys } from "./groups/invites/types";
+import { inviteKeys } from "@/hooks/queries/groups/invites/types";
 
 async function validateInviteToken(
   token: string,
@@ -23,14 +23,20 @@ async function validateInviteToken(
   return null;
 }
 
-export function useInviteValidationQuery(token: string | null) {
-  return useQuery({
-    queryKey: inviteKeys.validation(token || ""),
-    queryFn: () => validateInviteToken(token!),
-    enabled: !!token,
+export function inviteValidationQuery(token: string) {
+  return queryOptions({
+    queryKey: inviteKeys.validation(token),
+    queryFn: () => validateInviteToken(token),
     staleTime: 0, // Always fresh check for invites
     gcTime: 0, // Don't cache invite validations
     retry: false, // Don't retry failed validations
+  });
+}
+
+export function useInviteValidationQuery(token: string | null) {
+  return useQuery({
+    ...inviteValidationQuery(token!),
+    enabled: !!token,
   });
 }
 

--- a/src/api/invite-validation/useInviteValidationQuery.ts
+++ b/src/api/invite-validation/useInviteValidationQuery.ts
@@ -2,7 +2,7 @@ import { queryOptions, useQuery, useMutation } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 import type { InviteValidation } from "@/types/invites";
-import { inviteKeys } from "@/hooks/queries/groups/invites/types";
+import { inviteValidationKeys } from "./types";
 
 async function validateInviteToken(
   token: string,
@@ -25,7 +25,7 @@ async function validateInviteToken(
 
 export function inviteValidationQuery(token: string) {
   return queryOptions({
-    queryKey: inviteKeys.validation(token),
+    queryKey: inviteValidationKeys.byToken(token),
     queryFn: () => validateInviteToken(token),
     staleTime: 0, // Always fresh check for invites
     gcTime: 0, // Don't cache invite validations

--- a/src/components/invite/useInviteValidation.ts
+++ b/src/components/invite/useInviteValidation.ts
@@ -3,7 +3,7 @@ import { useToast } from "@/components/ui/use-toast";
 import {
   useInviteValidationQuery,
   useInviteMutation,
-} from "@/hooks/queries/useInviteValidationQuery";
+} from "@/api/invite-validation/useInviteValidationQuery";
 
 export function useInviteValidation(inviteToken: string | undefined) {
   const { toast } = useToast();


### PR DESCRIPTION
Move the loose `useInviteValidationQuery.ts` into a feature-sliced `src/api/invite-validation/` module with a per-file `queryOptions` factory (`inviteValidationQuery`). No behavior change; the exported hook names are unchanged and only the consumer's import path is repointed.

## Manual verification
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass
- `pnpm test` — pass (290 tests)
- Surface: validating a group invite link (`/invite/:token`)

Part of #52.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K513rsQz6Lg1HbbfYiafrE)_