### PR TITLE
docs(claude): repoint data-fetching guidance to src/api (Effort 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```
 src/
+├── api/                # Feature-sliced data-access modules (TanStack Query)
 ├── components/          # Reusable UI components
 │   ├── ui/             # shadcn/ui base components
 │   ├── Admin/          # Admin dashboard components
@@ -48,7 +49,6 @@ src/
 │   ├── Index/          # Main page components
 │   └── legal/          # Legal pages (privacy, terms)
 ├── hooks/              # Custom React hooks
-│   ├── queries/        # TanStack Query hooks
 │   └── useAuth.ts      # Authentication logic
 ├── integrations/
 │   └── supabase/       # Supabase client and types
@@ -90,7 +90,7 @@ src/
 1. **TypeScript**: Full type coverage with generated Supabase types
 2. **Styling**: Use Tailwind utilities and existing component patterns
 3. **Components**: Follow shadcn/ui patterns for new UI components
-4. **Data Fetching**: Use TanStack Query hooks in `hooks/queries/`
+4. **Data Fetching**: Use TanStack Query hooks in `src/api/` — feature-sliced modules, one folder per feature with a shared `types.ts` (entity type + query-key factory) and one `use`-prefixed file per endpoint holding its `queryOptions` factory + hook (see `docs/adr/0001-api-modules.md`)
 5. **Authentication**: Use `useAuth` hook for auth state and actions
 6. **Routing**: Add new routes to `App.tsx` above the catch-all "\*" route
 


### PR DESCRIPTION
Final cleanup for Effort 1 (#52). The data-access layer moved from `src/hooks/queries` to `src/api` (feature-sliced modules), and `src/hooks/queries` no longer exists — this updates `CLAUDE.md` to match.

## Changes
- Project structure tree: add `src/api/` (feature-sliced data-access modules); drop the now-gone `hooks/queries/` sub-entry.
- Data-fetching guideline: point at `src/api/` and describe the per-feature module shape (shared `types.ts` + one `use`-prefixed file per endpoint with a `queryOptions` factory), referencing `docs/adr/0001-api-modules.md`.

Docs-only; no code change. The `docs/HANDOFF*` and `docs/adr` mentions of `hooks/queries` are intentionally left as historical migration/decision records.

Closes the last "Done when" item on #52.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K513rsQz6Lg1HbbfYiafrE)_