### PR TITLE
feat(schedule): render horizontal timeline in festival timezone

### DIFF
--- a/src/pages/EditionView/tabs/ScheduleTab/FestivalTimeBadge.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/FestivalTimeBadge.tsx
@@ -1,0 +1,15 @@
+import { Globe } from "lucide-react";
+import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
+
+export function FestivalTimeBadge() {
+  const { festival } = useFestivalEdition();
+
+  return (
+    <div className="flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-amber-400/20 border border-amber-400/40 text-amber-100">
+      <Globe className="h-4 w-4 shrink-0" />
+      <span className="text-sm font-medium">
+        All times in festival time · {festival.timezone}
+      </span>
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/TimelineTab.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/TimelineTab.tsx
@@ -1,5 +1,11 @@
+import { FestivalTimeBadge } from "./FestivalTimeBadge";
 import { Timeline } from "./horizontal/Timeline";
 
 export function ScheduleTabTimeline() {
-  return <Timeline />;
+  return (
+    <>
+      <FestivalTimeBadge />
+      <Timeline />
+    </>
+  );
 }

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/SetBlock.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/SetBlock.tsx
@@ -6,9 +6,10 @@ import { VoteButtons } from "../VoteButtons";
 
 interface SetBlockProps {
   set: ScheduleSet;
+  timezone: string;
 }
 
-export function SetBlock({ set }: SetBlockProps) {
+export function SetBlock({ set, timezone }: SetBlockProps) {
   return (
     <Card className="bg-white/10 backdrop-blur-md border-purple-400/30 hover:border-purple-400/50 transition-colors">
       <CardContent className="p-3">
@@ -16,7 +17,11 @@ export function SetBlock({ set }: SetBlockProps) {
 
         <div className="space-y-1 text-sm text-purple-200">
           {set.startTime && set.endTime && (
-            <TimeDisplay startTime={set.startTime} endTime={set.endTime} />
+            <TimeDisplay
+              startTime={set.startTime}
+              endTime={set.endTime}
+              timezone={timezone}
+            />
           )}
         </div>
 

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageRow.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageRow.tsx
@@ -8,9 +8,10 @@ interface StageRowProps {
     sets: HorizontalTimelineSet[];
   };
   totalWidth: number;
+  timezone: string;
 }
 
-export function StageRow({ stage, totalWidth }: StageRowProps) {
+export function StageRow({ stage, totalWidth, timezone }: StageRowProps) {
   return (
     <div key={stage.name} className="flex items-start">
       {/* Timeline Track */}
@@ -34,7 +35,7 @@ export function StageRow({ stage, totalWidth }: StageRowProps) {
               }}
             >
               <div className="h-full pr-1">
-                <SetBlock set={set} />
+                <SetBlock set={set} timezone={timezone} />
               </div>
             </div>
           );

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeDisplay.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeDisplay.tsx
@@ -1,27 +1,34 @@
 import { Clock } from "lucide-react";
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { formatTimeOnly } from "@/lib/timeUtils";
 import { useMemo } from "react";
 
 interface TimeDisplayProps {
   startTime: Date;
   endTime: Date;
+  timezone: string;
 }
 
-function formatCompactTime(startTime: Date, endTime: Date): string {
-  const start = format(startTime, "H");
-  const end = format(endTime, "H");
+function formatCompactTime(
+  startTime: Date,
+  endTime: Date,
+  timezone: string,
+): string {
+  const startHour = formatInTimeZone(startTime, timezone, "H");
+  const endHour = formatInTimeZone(endTime, timezone, "H");
 
-  const startMinutes = startTime.getMinutes();
-  const endMinutes = endTime.getMinutes();
+  const startMinutes = Number(formatInTimeZone(startTime, timezone, "m"));
+  const endMinutes = Number(formatInTimeZone(endTime, timezone, "m"));
 
-  const startStr = startMinutes === 0 ? start : format(startTime, "H:mm");
-  const endStr = endMinutes === 0 ? end : format(endTime, "H:mm");
+  const startStr =
+    startMinutes === 0 ? startHour : formatInTimeZone(startTime, timezone, "H:mm");
+  const endStr =
+    endMinutes === 0 ? endHour : formatInTimeZone(endTime, timezone, "H:mm");
 
   return `${startStr}-${endStr}`;
 }
 
-export function TimeDisplay({ startTime, endTime }: TimeDisplayProps) {
+export function TimeDisplay({ startTime, endTime, timezone }: TimeDisplayProps) {
   const useCompact = useMemo(() => {
     const duration = (endTime.getTime() - startTime.getTime()) / (1000 * 60);
     return duration <= 60;
@@ -32,11 +39,12 @@ export function TimeDisplay({ startTime, endTime }: TimeDisplayProps) {
       <Clock className="h-3 w-3 flex-shrink-0" />
       <span className="text-xs whitespace-nowrap overflow-hidden text-ellipsis">
         {useCompact
-          ? formatCompactTime(startTime, endTime)
+          ? formatCompactTime(startTime, endTime, timezone)
           : formatTimeOnly(
               startTime.toISOString(),
               endTime.toISOString(),
               true,
+              timezone,
             )}
       </span>
     </div>

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -1,10 +1,12 @@
-import { format, differenceInMinutes } from "date-fns";
+import { differenceInMinutes } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { useEffect, useState, useRef } from "react";
 
 interface TimeScaleProps {
   timeSlots: Date[];
   totalWidth: number;
   scrollContainerRef: React.RefObject<HTMLDivElement>;
+  timezone: string;
 }
 
 const dateFormat = "MMMM d";
@@ -13,6 +15,7 @@ export function TimeScale({
   timeSlots,
   totalWidth,
   scrollContainerRef,
+  timezone,
 }: TimeScaleProps) {
   const [scrollLeft, setScrollLeft] = useState(0);
   const timeScaleRef = useRef<HTMLDivElement>(null);
@@ -23,18 +26,21 @@ export function TimeScale({
       if (index === 0) {
         changes.push({ date: timeSlot, position: 0 });
       } else {
-        const prevDate = format(timeSlots[index - 1], "yyyy-MM-dd");
-        const currentDate = format(timeSlot, "yyyy-MM-dd");
+        const prevDate = formatInTimeZone(
+          timeSlots[index - 1],
+          timezone,
+          "yyyy-MM-dd",
+        );
+        const currentDate = formatInTimeZone(timeSlot, timezone, "yyyy-MM-dd");
         if (prevDate !== currentDate) {
-          // Calculate position based on midnight of the new date, not the timeSlot time
-          const midnightOfNewDate = new Date(timeSlot);
-          midnightOfNewDate.setHours(0, 0, 0, 0);
+          // Position based on festival-timezone midnight of the new date
+          const midnightOfNewDate = fromZonedTime(
+            `${currentDate}T00:00:00`,
+            timezone,
+          );
 
           // Calculate position relative to festival start
           const festivalStart = timeSlots[0];
-          const festivalStartMidnight = new Date(festivalStart);
-          festivalStartMidnight.setHours(0, 0, 0, 0);
-
           const minutesFromStart = differenceInMinutes(
             midnightOfNewDate,
             festivalStart,
@@ -108,7 +114,9 @@ export function TimeScale({
           opacity: scrolledIntoCurrentDay >= 0 ? 1 : 0,
         }}
       >
-        {currentDate ? format(currentDate.date, dateFormat) : "Loading..."}
+        {currentDate
+          ? formatInTimeZone(currentDate.date, timezone, dateFormat)
+          : "Loading..."}
       </div>
 
       {/* Upcoming day sticky label - appears when approaching next day */}
@@ -123,7 +131,7 @@ export function TimeScale({
             ), // Fade in effect
           }}
         >
-          {format(nextDate.date, dateFormat)}
+          {formatInTimeZone(nextDate.date, timezone, dateFormat)}
         </div>
       )}
 
@@ -170,7 +178,7 @@ export function TimeScale({
                 style={{ left: `${index * 120}px` }}
               >
                 <div className="text-sm font-medium text-purple-300 mb-2 mt-10">
-                  {format(timeSlot, "HH:mm")}
+                  {formatInTimeZone(timeSlot, timezone, "HH:mm")}
                 </div>
                 <div className="w-px h-4 bg-purple-400/30"></div>
               </div>

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -6,13 +6,13 @@ import { TimelineContainer } from "./TimelineContainer";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { useSetsByEditionQuery as useEditionSetsQuery } from "@/api/sets/useSetsByEdition";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
-import { format } from "date-fns";
+import { getFestivalHour } from "@/lib/timeUtils";
 import { useStagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNotRevealedPlaceholder } from "../ScheduleNotRevealedPlaceholder";
 
 export function Timeline() {
-  const { edition } = useFestivalEdition();
+  const { edition, festival } = useFestivalEdition();
   const { canShowTime } = useScheduleReveal();
   const { data: editionSets = [], isLoading: setsLoading } =
     useEditionSetsQuery(edition?.id);
@@ -21,6 +21,7 @@ export function Timeline() {
   const { scheduleDays, loading, error } = useScheduleData({
     sets: editionSets,
     stages: stagesQuery.data,
+    timezone: festival.timezone,
   });
   const {
     day: selectedDay,
@@ -36,11 +37,8 @@ export function Timeline() {
     // Apply filters to scheduleDays
     const filteredScheduleDays = scheduleDays.map((day) => {
       // Filter by day
-      if (selectedDay !== "all") {
-        const dayDate = format(day.date, "yyyy-MM-dd");
-        if (dayDate !== selectedDay) {
-          return { ...day, stages: [] }; // Empty day if not selected
-        }
+      if (selectedDay !== "all" && day.date !== selectedDay) {
+        return { ...day, stages: [] }; // Empty day if not selected
       }
 
       // Filter stages and sets
@@ -57,7 +55,11 @@ export function Timeline() {
           sets: stage.sets.filter((set) => {
             // Filter by time
             if (selectedTime !== "all" && set.startTime) {
-              const hour = set.startTime.getHours();
+              const hour = getFestivalHour(
+                set.startTime.toISOString(),
+                festival.timezone,
+              );
+              if (hour === null) return false;
               switch (selectedTime) {
                 case "morning":
                   return hour >= 6 && hour < 12;
@@ -89,6 +91,7 @@ export function Timeline() {
     selectedTime,
     selectedStages,
     stagesQuery.data,
+    festival.timezone,
   ]);
 
   if (loading || setsLoading) {
@@ -123,7 +126,10 @@ export function Timeline() {
     <div className="space-y-8">
       <div className="relative bg-white/5 rounded-lg p-4">
         <StageLabels stages={timelineData.stages} />
-        <TimelineContainer timelineData={timelineData} />
+        <TimelineContainer
+          timelineData={timelineData}
+          timezone={festival.timezone}
+        />
       </div>
     </div>
   );

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -5,9 +5,13 @@ import type { TimelineData } from "@/lib/timelineCalculator";
 
 interface TimelineContainerProps {
   timelineData: TimelineData;
+  timezone: string;
 }
 
-export function TimelineContainer({ timelineData }: TimelineContainerProps) {
+export function TimelineContainer({
+  timelineData,
+  timezone,
+}: TimelineContainerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   return (
@@ -20,6 +24,7 @@ export function TimelineContainer({ timelineData }: TimelineContainerProps) {
         timeSlots={timelineData.timeSlots}
         totalWidth={timelineData.totalWidth}
         scrollContainerRef={scrollContainerRef}
+        timezone={timezone}
       />
 
       {/* Stage Rows */}
@@ -29,6 +34,7 @@ export function TimelineContainer({ timelineData }: TimelineContainerProps) {
             key={stage.name}
             stage={stage}
             totalWidth={timelineData.totalWidth}
+            timezone={timezone}
           />
         ))}
       </div>

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
@@ -1,19 +1,11 @@
-import { Globe } from "lucide-react";
-import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
+import { FestivalTimeBadge } from "../FestivalTimeBadge";
 import { ListSchedule } from "./ListSchedule";
 import { ListFilters } from "./ListFilters";
 
 export function ScheduleTabList() {
-  const { festival } = useFestivalEdition();
-
   return (
     <>
-      <div className="flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-amber-400/20 border border-amber-400/40 text-amber-100">
-        <Globe className="h-4 w-4 shrink-0" />
-        <span className="text-sm font-medium">
-          All times in festival time · {festival.timezone}
-        </span>
-      </div>
+      <FestivalTimeBadge />
 
       <ListFilters />
       <ListSchedule />


### PR DESCRIPTION
Renders the horizontal schedule timeline — set times, hour markers, and day boundaries — in the festival timezone, matching the list view from #87.
Set-block positioning stays tz-invariant (absolute-time math), so only labels/filters move to festival time.

Closes #76

## Verification
- Open a festival's Schedule → horizontal timeline with browser tz set far from the festival's; hour markers and day labels read in festival time.
- A set just after festival-midnight groups under the correct festival day.
- Set blocks land in the same horizontal positions as before (no positioning regression).
- Day and morning/afternoon/evening filters match festival time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLgAHCzTppjx4nT8BLg3vs)_