### PR TITLE
feat(schedule): render set times in festival timezone across the app

### DIFF
--- a/src/components/FestivalTimeHint.tsx
+++ b/src/components/FestivalTimeHint.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+
+interface FestivalTimeHintProps {
+  timezone?: string;
+  className?: string;
+}
+
+export function FestivalTimeHint({ timezone, className }: FestivalTimeHintProps) {
+  if (!timezone) return null;
+
+  return (
+    <span className={cn("w-full text-xs text-purple-200/70", className)}>
+      Times in {timezone}
+    </span>
+  );
+}

--- a/src/lib/timeUtils.test.ts
+++ b/src/lib/timeUtils.test.ts
@@ -72,6 +72,24 @@ describe("formatTimeRange", () => {
   it("returns null for both invalid times", () => {
     expect(formatTimeRange("invalid", "also-invalid")).toBeNull();
   });
+
+  it("formats in the given timezone instead of the browser zone", () => {
+    // 14:00 UTC is 14:00 in Lisbon (WET, UTC+0 in December) and 09:00 in New York (UTC-5).
+    const lisbon = formatTimeRange(
+      "2024-12-15T14:00:00Z",
+      "2024-12-15T16:00:00Z",
+      true,
+      "Europe/Lisbon",
+    );
+    const newYork = formatTimeRange(
+      "2024-12-15T14:00:00Z",
+      "2024-12-15T16:00:00Z",
+      true,
+      "America/New_York",
+    );
+    expect(lisbon).toBe("Dec 15, 14:00 - 16:00");
+    expect(newYork).toBe("Dec 15, 09:00 - 11:00");
+  });
 });
 
 describe("formatDateTime", () => {

--- a/src/lib/timeUtils.ts
+++ b/src/lib/timeUtils.ts
@@ -5,6 +5,7 @@ export function formatTimeRange(
   startTime: string | null,
   endTime: string | null,
   use24Hour: boolean = false,
+  timezone?: string,
 ): string | null {
   if (!startTime && !endTime) return null;
 
@@ -20,27 +21,33 @@ export function formatTimeRange(
   const timeFormat = use24Hour ? "HH:mm" : "h:mm a";
   const dateTimeFormat = use24Hour ? "MMM d, HH:mm" : "MMM d, h:mm a";
 
+  function formatWith(date: Date, dateFormat: string) {
+    return timezone
+      ? formatInTimeZone(date, timezone, dateFormat)
+      : format(date, dateFormat);
+  }
+
   // Only start time
   if (validStart && !validEnd) {
-    return `Starts: ${format(validStart, dateTimeFormat)}`;
+    return `Starts: ${formatWith(validStart, dateTimeFormat)}`;
   }
 
   // Only end time
   if (!validStart && validEnd) {
-    return `Ends: ${format(validEnd, dateTimeFormat)}`;
+    return `Ends: ${formatWith(validEnd, dateTimeFormat)}`;
   }
 
   // Both times
   if (validStart && validEnd) {
     if (isSameDay(validStart, validEnd)) {
       // Same day: "Dec 15, 2:00 PM - 4:00 PM" or "Dec 15, 14:00 - 16:00"
-      return `${format(validStart, dateTimeFormat)} - ${format(
+      return `${formatWith(validStart, dateTimeFormat)} - ${formatWith(
         validEnd,
         timeFormat,
       )}`;
     } else {
       // Different days: "Dec 15, 2:00 PM - Dec 16, 1:00 AM" or "Dec 15, 14:00 - Dec 16, 01:00"
-      return `${format(validStart, dateTimeFormat)} - ${format(
+      return `${formatWith(validStart, dateTimeFormat)} - ${formatWith(
         validEnd,
         dateTimeFormat,
       )}`;

--- a/src/pages/EditionView/tabs/ArtistsTab/SetCard/SetMetadata.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/SetCard/SetMetadata.tsx
@@ -5,9 +5,11 @@ import { StageBadge } from "@/components/StageBadge";
 import { useFestivalSet } from "../FestivalSetContext";
 import { useStageQuery } from "@/api/stages/useStageQuery";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
+import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 
 export function SetMetadata() {
   const { set, use24Hour } = useFestivalSet();
+  const { festival } = useFestivalEdition();
   const { canShowStage, canShowDay, canShowTime } = useScheduleReveal();
   const stageQuery = useStageQuery(canShowStage ? set?.stage_id : null);
   const uniqueGenres = set.artists
@@ -19,11 +21,13 @@ export function SetMetadata() {
     );
 
   const timeRangeFormatted = canShowTime
-    ? formatTimeRange(set.time_start, set.time_end, use24Hour)
+    ? formatTimeRange(set.time_start, set.time_end, use24Hour, festival.timezone)
     : null;
 
   const dayOnlyFormatted =
-    canShowDay && !canShowTime ? formatDayOnly(set.time_start) : null;
+    canShowDay && !canShowTime
+      ? formatDayOnly(set.time_start, festival.timezone)
+      : null;
 
   return (
     <div className="flex items-center flex-wrap gap-2">

--- a/src/pages/EditionView/tabs/ArtistsTab/SetCard/SetMetadata.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/SetCard/SetMetadata.tsx
@@ -65,6 +65,11 @@ export function SetMetadata() {
             <span>{dayOnlyFormatted}</span>
           </div>
         )}
+        {(timeRangeFormatted || dayOnlyFormatted) && (
+          <span className="text-xs text-purple-200/60">
+            {festival.timezone}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/pages/SetDetails/MultiArtistSetInfoCard.tsx
+++ b/src/pages/SetDetails/MultiArtistSetInfoCard.tsx
@@ -15,6 +15,7 @@ import { IndividualArtistCard } from "./IndividualArtistCard";
 import { StagePin } from "@/components/StagePin";
 import { MarkdownText } from "@/components/ui/markdown-text";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
+import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 
 interface MultiArtistSetInfoCardProps {
   set: FestivalSet;
@@ -35,12 +36,15 @@ export function MultiArtistSetInfoCard({
       index ===
       self.findIndex((g) => g.music_genre_id === genre.music_genre_id),
   );
+  const { festival } = useFestivalEdition();
   const { canShowStage, canShowDay, canShowTime } = useScheduleReveal();
   const timeRangeFormatted = canShowTime
-    ? formatTimeRange(set.time_start, set.time_end, use24Hour)
+    ? formatTimeRange(set.time_start, set.time_end, use24Hour, festival.timezone)
     : null;
   const dayOnlyFormatted =
-    canShowDay && !canShowTime ? formatDayOnly(set.time_start) : null;
+    canShowDay && !canShowTime
+      ? formatDayOnly(set.time_start, festival.timezone)
+      : null;
 
   return (
     <div className="lg:col-span-2 space-y-6">

--- a/src/pages/SetDetails/MultiArtistSetInfoCard.tsx
+++ b/src/pages/SetDetails/MultiArtistSetInfoCard.tsx
@@ -16,6 +16,7 @@ import { StagePin } from "@/components/StagePin";
 import { MarkdownText } from "@/components/ui/markdown-text";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
+import { FestivalTimeHint } from "@/components/FestivalTimeHint";
 
 interface MultiArtistSetInfoCardProps {
   set: FestivalSet;
@@ -106,9 +107,7 @@ export function MultiArtistSetInfoCard({
                   </div>
                 )}
                 {(timeRangeFormatted || dayOnlyFormatted) && (
-                  <span className="w-full text-xs text-purple-200/70">
-                    Times in {festival.timezone}
-                  </span>
+                  <FestivalTimeHint timezone={festival.timezone} />
                 )}
               </div>
             </div>

--- a/src/pages/SetDetails/MultiArtistSetInfoCard.tsx
+++ b/src/pages/SetDetails/MultiArtistSetInfoCard.tsx
@@ -105,6 +105,11 @@ export function MultiArtistSetInfoCard({
                     <span className="text-sm">{dayOnlyFormatted}</span>
                   </div>
                 )}
+                {(timeRangeFormatted || dayOnlyFormatted) && (
+                  <span className="w-full text-xs text-purple-200/70">
+                    Times in {festival.timezone}
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/src/pages/SetDetails/SetInfoCard.tsx
+++ b/src/pages/SetDetails/SetInfoCard.tsx
@@ -84,6 +84,11 @@ export function SetInfoCard({
                     <span className="text-sm">{dayOnlyFormatted}</span>
                   </div>
                 )}
+                {(timeRangeFormatted || dayOnlyFormatted) && (
+                  <span className="w-full text-xs text-purple-200/70">
+                    Times in {festival.timezone}
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/src/pages/SetDetails/SetInfoCard.tsx
+++ b/src/pages/SetDetails/SetInfoCard.tsx
@@ -15,6 +15,7 @@ import { GenreBadge } from "@/components/GenreBadge";
 import { StagePin } from "@/components/StagePin";
 import { MarkdownText } from "@/components/ui/markdown-text";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
+import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 
 interface SetInfoCardProps {
   set: FestivalSet;
@@ -28,12 +29,15 @@ export function SetInfoCard({
   use24Hour = false,
 }: SetInfoCardProps) {
   const artist = set.artists[0];
+  const { festival } = useFestivalEdition();
   const { canShowStage, canShowDay, canShowTime } = useScheduleReveal();
   const timeRangeFormatted = canShowTime
-    ? formatTimeRange(set.time_start, set.time_end, use24Hour)
+    ? formatTimeRange(set.time_start, set.time_end, use24Hour, festival.timezone)
     : null;
   const dayOnlyFormatted =
-    canShowDay && !canShowTime ? formatDayOnly(set.time_start) : null;
+    canShowDay && !canShowTime
+      ? formatDayOnly(set.time_start, festival.timezone)
+      : null;
   return (
     <div className="lg:col-span-2">
       <Card className="bg-white/10 backdrop-blur-md border-purple-400/30 h-full">

--- a/src/pages/SetDetails/SetInfoCard.tsx
+++ b/src/pages/SetDetails/SetInfoCard.tsx
@@ -16,6 +16,7 @@ import { StagePin } from "@/components/StagePin";
 import { MarkdownText } from "@/components/ui/markdown-text";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
+import { FestivalTimeHint } from "@/components/FestivalTimeHint";
 
 interface SetInfoCardProps {
   set: FestivalSet;
@@ -85,9 +86,7 @@ export function SetInfoCard({
                   </div>
                 )}
                 {(timeRangeFormatted || dayOnlyFormatted) && (
-                  <span className="w-full text-xs text-purple-200/70">
-                    Times in {festival.timezone}
-                  </span>
+                  <FestivalTimeHint timezone={festival.timezone} />
                 )}
               </div>
             </div>

--- a/src/pages/admin/festivals/SetsManagement/SetManagement.tsx
+++ b/src/pages/admin/festivals/SetsManagement/SetManagement.tsx
@@ -7,6 +7,7 @@ import { FestivalSet } from "@/api/sets/types";
 import { useSetsByEditionQuery } from "@/api/sets/useSetsByEdition";
 import { useDeleteSetMutation } from "@/api/sets/useDeleteSet";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
+import { useFestivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { SetFormDialog } from "../SetFormDialog";
 import { SetsTable } from "../SetsTable";
 
@@ -18,6 +19,7 @@ export function SetManagement() {
     festivalSlug,
     editionSlug,
   });
+  const festivalQuery = useFestivalBySlugQuery(festivalSlug);
   const setsQuery = useSetsByEditionQuery(editionQuery.data?.id);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingSet, setEditingSet] = useState<FestivalSet | null>(null);
@@ -88,6 +90,7 @@ export function SetManagement() {
           onEdit={handleEdit}
           onDelete={handleDelete}
           editionId={editionQuery.data.id}
+          timezone={festivalQuery.data?.timezone}
         />
       </CardContent>
 

--- a/src/pages/admin/festivals/SetsTable.tsx
+++ b/src/pages/admin/festivals/SetsTable.tsx
@@ -18,6 +18,7 @@ interface SetsTableProps {
   onEdit: (set: FestivalSet) => void;
   onDelete: (set: FestivalSet) => void;
   editionId: string;
+  timezone?: string;
 }
 
 export function SetsTable({
@@ -25,6 +26,7 @@ export function SetsTable({
   onEdit,
   onDelete,
   editionId,
+  timezone,
 }: SetsTableProps) {
   const { data: stages = [] } = useStagesByEditionQuery(editionId);
 
@@ -62,7 +64,12 @@ export function SetsTable({
               <TableCell>{getStageName(set.stage_id)}</TableCell>
               <TableCell>
                 {set.time_start && set.time_end
-                  ? formatTimeRange(set.time_start, set.time_end, true)
+                  ? formatTimeRange(
+                      set.time_start,
+                      set.time_end,
+                      true,
+                      timezone,
+                    )
                   : "—"}
               </TableCell>
               <TableCell>

--- a/src/pages/admin/festivals/SetsTable.tsx
+++ b/src/pages/admin/festivals/SetsTable.tsx
@@ -47,6 +47,11 @@ export function SetsTable({
 
   return (
     <div className="rounded-md border">
+      {timezone && (
+        <div className="border-b px-4 py-2 text-xs text-muted-foreground">
+          Times in {timezone}
+        </div>
+      )}
       <Table>
         <TableHeader>
           <TableRow>

--- a/src/pages/admin/festivals/SetsTable.tsx
+++ b/src/pages/admin/festivals/SetsTable.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Edit2, Trash2 } from "lucide-react";
 import { formatTimeRange } from "@/lib/timeUtils";
 import { FestivalSet } from "@/api/sets/types";
+import { FestivalTimeHint } from "@/components/FestivalTimeHint";
 
 interface SetsTableProps {
   sets: FestivalSet[];
@@ -48,9 +49,10 @@ export function SetsTable({
   return (
     <div className="rounded-md border">
       {timezone && (
-        <div className="border-b px-4 py-2 text-xs text-muted-foreground">
-          Times in {timezone}
-        </div>
+        <FestivalTimeHint
+          timezone={timezone}
+          className="block border-b px-4 py-2 text-muted-foreground"
+        />
       )}
       <Table>
         <TableHeader>


### PR DESCRIPTION
Adds an optional `timezone` param to `formatTimeRange` and threads `festival.timezone` into the set-detail cards, artist SetCard metadata, and the admin SetsTable so set times render in festival time outside the Schedule tab.
Reveal-level masking (day-only vs full time) is unchanged — only the render zone moves.

Closes #77

## Verification
- Open a set-detail page with browser tz far from the festival's; start/end time and day read in festival time.
- Artist tab SetCard metadata and admin SetsTable show the same festival-time values.
- Callers that omit the new `timezone` arg are unchanged (byte-identical output); `pnpm test` covers the new tz case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLgAHCzTppjx4nT8BLg3vs)_