### PR TITLE
feat(admin): edit set times in festival timezone

### DIFF
--- a/src/pages/admin/festivals/SetFormDialog.tsx
+++ b/src/pages/admin/festivals/SetFormDialog.tsx
@@ -34,7 +34,6 @@ import {
   convertLocalTimeToUTC,
 } from "@/lib/timeUtils";
 import { StageSelector } from "./StageSelector";
-import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 
 // Form validation schema
 const setFormSchema = z.object({
@@ -54,6 +53,7 @@ interface SetFormDialogProps {
   onClose: () => void;
   editingSet: FestivalSet | null;
   editionId: string;
+  timezone?: string;
 }
 
 export function SetFormDialog({
@@ -61,10 +61,11 @@ export function SetFormDialog({
   onClose,
   editingSet,
   editionId,
+  timezone,
 }: SetFormDialogProps) {
   const { data: artists = [] } = useArtistsQuery();
   const { user } = useAuth();
-  const { festival } = useFestivalEdition();
+  const tz = timezone ?? "Europe/Lisbon";
 
   // Track if user has manually edited the name
   const [hasManuallyEditedName, setHasManuallyEditedName] = useState(false);
@@ -101,14 +102,8 @@ export function SetFormDialog({
           name: editingSet.name,
           description: editingSet.description || "",
           stage_id: editingSet.stage_id || "none",
-          time_start: toDatetimeLocalInTimeZone(
-            editingSet.time_start,
-            festival.timezone,
-          ),
-          time_end: toDatetimeLocalInTimeZone(
-            editingSet.time_end,
-            festival.timezone,
-          ),
+          time_start: toDatetimeLocalInTimeZone(editingSet.time_start, tz),
+          time_end: toDatetimeLocalInTimeZone(editingSet.time_end, tz),
           estimated_date: "",
           artist_ids: editingSet.artists?.map((a) => a.id) || [],
         });
@@ -126,7 +121,7 @@ export function SetFormDialog({
         });
       }
     }
-  }, [isOpen, editingSet, form, festival.timezone]);
+  }, [isOpen, editingSet, form, tz]);
 
   // Generate set name from selected artists
   const generateSetName = useCallback(
@@ -163,10 +158,10 @@ export function SetFormDialog({
       stage_id:
         data.stage_id && data.stage_id !== "none" ? data.stage_id : null,
       time_start: data.time_start
-        ? convertLocalTimeToUTC(data.time_start, festival.timezone)
+        ? convertLocalTimeToUTC(data.time_start, tz)
         : null,
       time_end: data.time_end
-        ? convertLocalTimeToUTC(data.time_end, festival.timezone)
+        ? convertLocalTimeToUTC(data.time_end, tz)
         : null,
     };
 
@@ -315,7 +310,7 @@ export function SetFormDialog({
             />
 
             <p className="text-xs text-muted-foreground">
-              Times in {festival.timezone}
+              Times in {tz}
             </p>
             <div className="grid grid-cols-3 gap-4">
               <FormField

--- a/src/pages/admin/festivals/SetFormDialog.tsx
+++ b/src/pages/admin/festivals/SetFormDialog.tsx
@@ -29,8 +29,12 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { ArtistMultiSelect } from "./SetsManagement/ArtistMultiSelect";
-import { toDatetimeLocal, toISOString } from "@/lib/timeUtils";
+import {
+  toDatetimeLocalInTimeZone,
+  convertLocalTimeToUTC,
+} from "@/lib/timeUtils";
 import { StageSelector } from "./StageSelector";
+import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 
 // Form validation schema
 const setFormSchema = z.object({
@@ -60,6 +64,7 @@ export function SetFormDialog({
 }: SetFormDialogProps) {
   const { data: artists = [] } = useArtistsQuery();
   const { user } = useAuth();
+  const { festival } = useFestivalEdition();
 
   // Track if user has manually edited the name
   const [hasManuallyEditedName, setHasManuallyEditedName] = useState(false);
@@ -96,8 +101,14 @@ export function SetFormDialog({
           name: editingSet.name,
           description: editingSet.description || "",
           stage_id: editingSet.stage_id || "none",
-          time_start: toDatetimeLocal(editingSet.time_start),
-          time_end: toDatetimeLocal(editingSet.time_end),
+          time_start: toDatetimeLocalInTimeZone(
+            editingSet.time_start,
+            festival.timezone,
+          ),
+          time_end: toDatetimeLocalInTimeZone(
+            editingSet.time_end,
+            festival.timezone,
+          ),
           estimated_date: "",
           artist_ids: editingSet.artists?.map((a) => a.id) || [],
         });
@@ -115,7 +126,7 @@ export function SetFormDialog({
         });
       }
     }
-  }, [isOpen, editingSet, form]);
+  }, [isOpen, editingSet, form, festival.timezone]);
 
   // Generate set name from selected artists
   const generateSetName = useCallback(
@@ -151,8 +162,12 @@ export function SetFormDialog({
       festival_edition_id: editionId,
       stage_id:
         data.stage_id && data.stage_id !== "none" ? data.stage_id : null,
-      time_start: data.time_start ? toISOString(data.time_start) : null,
-      time_end: data.time_end ? toISOString(data.time_end) : null,
+      time_start: data.time_start
+        ? convertLocalTimeToUTC(data.time_start, festival.timezone)
+        : null,
+      time_end: data.time_end
+        ? convertLocalTimeToUTC(data.time_end, festival.timezone)
+        : null,
     };
 
     let setId: string;
@@ -299,6 +314,9 @@ export function SetFormDialog({
               )}
             />
 
+            <p className="text-xs text-muted-foreground">
+              Times in {festival.timezone}
+            </p>
             <div className="grid grid-cols-3 gap-4">
               <FormField
                 control={form.control}

--- a/src/pages/admin/festivals/SetsManagement/SetManagement.tsx
+++ b/src/pages/admin/festivals/SetsManagement/SetManagement.tsx
@@ -7,6 +7,7 @@ import { FestivalSet } from "@/api/sets/types";
 import { useSetsByEditionQuery } from "@/api/sets/useSetsByEdition";
 import { useDeleteSetMutation } from "@/api/sets/useDeleteSet";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
+import { useFestivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { SetFormDialog } from "../SetFormDialog";
 import { SetsTable } from "../SetsTable";
 
@@ -18,6 +19,7 @@ export function SetManagement() {
     festivalSlug,
     editionSlug,
   });
+  const festivalQuery = useFestivalBySlugQuery(festivalSlug);
   const setsQuery = useSetsByEditionQuery(editionQuery.data?.id);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingSet, setEditingSet] = useState<FestivalSet | null>(null);
@@ -96,6 +98,7 @@ export function SetManagement() {
         onClose={handleCloseDialog}
         editingSet={editingSet}
         editionId={editionQuery.data.id}
+        timezone={festivalQuery.data?.timezone}
       />
     </Card>
   );


### PR DESCRIPTION
Makes the admin set-time form read and write in the festival timezone: pre-fill via `toDatetimeLocalInTimeZone`, submit via `convertLocalTimeToUTC`, with a "Times in {timezone}" label near the inputs.
An admin entering 18:00 sees 18:00 on the schedule regardless of their device zone.

Closes #78

## Verification
- Edit a set with browser tz far from the festival's; the time inputs pre-fill in festival time, not device time.
- Enter 18:00, save, reopen — inputs still read 18:00 and the schedule shows 18:00.
- Clearing a time saves null (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLgAHCzTppjx4nT8BLg3vs)_