### PR TITLE
feat(schedule-import): default CSV import timezone to festival timezone

### DIFF
--- a/src/components/Admin/ScheduleImport/CsvUploadStep.tsx
+++ b/src/components/Admin/ScheduleImport/CsvUploadStep.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { parseScheduleCsv } from "@/services/scheduleImport/parseCsv";
 import { callDiffSchedule } from "@/services/scheduleImport/api";
 import { type CsvRow, type DiffResult } from "@/services/scheduleImport/types";
+import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { TimezonePicker } from "./TimezonePicker";
 import { CsvDropZone } from "./CsvDropZone";
 
@@ -14,7 +15,10 @@ type Props = {
 };
 
 export function CsvUploadStep({ festivalEditionId, onDiffReady }: Props) {
-  const [timezone, setTimezone] = useState("Europe/Lisbon");
+  const { festival } = useFestivalEdition();
+  const [timezone, setTimezone] = useState(
+    festival.timezone || "Europe/Lisbon",
+  );
   const [fileName, setFileName] = useState<string | null>(null);
 
   const readFileMutation = useMutation({ mutationFn: readFile });

--- a/src/components/Admin/ScheduleImport/CsvUploadStep.tsx
+++ b/src/components/Admin/ScheduleImport/CsvUploadStep.tsx
@@ -5,20 +5,21 @@ import { Button } from "@/components/ui/button";
 import { parseScheduleCsv } from "@/services/scheduleImport/parseCsv";
 import { callDiffSchedule } from "@/services/scheduleImport/api";
 import { type CsvRow, type DiffResult } from "@/services/scheduleImport/types";
-import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { TimezonePicker } from "./TimezonePicker";
 import { CsvDropZone } from "./CsvDropZone";
 
 type Props = {
   festivalEditionId: string;
+  defaultTimezone?: string;
   onDiffReady: (diff: DiffResult, timezone: string) => void;
 };
 
-export function CsvUploadStep({ festivalEditionId, onDiffReady }: Props) {
-  const { festival } = useFestivalEdition();
-  const [timezone, setTimezone] = useState(
-    festival.timezone || "Europe/Lisbon",
-  );
+export function CsvUploadStep({
+  festivalEditionId,
+  defaultTimezone,
+  onDiffReady,
+}: Props) {
+  const [timezone, setTimezone] = useState(defaultTimezone || "Europe/Lisbon");
   const [fileName, setFileName] = useState<string | null>(null);
 
   const readFileMutation = useMutation({ mutationFn: readFile });

--- a/src/components/Admin/ScheduleImport/ScheduleImportWizard.tsx
+++ b/src/components/Admin/ScheduleImport/ScheduleImportWizard.tsx
@@ -12,6 +12,7 @@ import { CommitResultCard } from "./CommitResultCard";
 type Props = {
   festivalEditionId: string;
   currentRevealLevel: RevealLevel;
+  defaultTimezone?: string;
 };
 
 type WizardState =
@@ -22,6 +23,7 @@ type WizardState =
 export function ScheduleImportWizard({
   festivalEditionId,
   currentRevealLevel,
+  defaultTimezone,
 }: Props) {
   const [state, setState] = useState<WizardState>({ step: "upload" });
 
@@ -38,6 +40,7 @@ export function ScheduleImportWizard({
         <CardContent>
           <CsvUploadStep
             festivalEditionId={festivalEditionId}
+            defaultTimezone={defaultTimezone}
             onDiffReady={(diff, timezone) =>
               setState({ step: "review", diff, timezone })
             }

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/import.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/import.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { editionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
+import { useFestivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { ScheduleImportWizard } from "@/components/Admin/ScheduleImport/ScheduleImportWizard";
 
 export const Route = createFileRoute(
@@ -16,11 +17,14 @@ export const Route = createFileRoute(
 });
 
 function FestivalScheduleImport() {
+  const { festivalSlug } = Route.useParams();
   const edition = Route.useLoaderData();
+  const festivalQuery = useFestivalBySlugQuery(festivalSlug);
   return (
     <ScheduleImportWizard
       festivalEditionId={edition.id}
       currentRevealLevel={edition.schedule_reveal_level ?? "draft"}
+      defaultTimezone={festivalQuery.data?.timezone}
     />
   );
 }


### PR DESCRIPTION
Pre-selects the CSV schedule-import timezone picker with the parent festival's `timezone` instead of the hardcoded `Europe/Lisbon`.
The picker stays overridable per import and the CSV-parse → UTC pipeline is unchanged.

Closes #79

## Verification
- Open the schedule-import wizard for a festival whose timezone isn't Europe/Lisbon; the picker defaults to that festival's timezone.
- Change the picker to another zone; the override is respected through the import.
- Import a CSV; parsed local times convert to UTC exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLgAHCzTppjx4nT8BLg3vs)_