### PR TITLE
refactor(genres): adopt route loader for genres filter

### DIFF
--- a/src/pages/EditionView/tabs/ArtistsTab/filters/FilterSortControls.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/filters/FilterSortControls.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import type { SortOption, FilterSortState } from "@/hooks/useUrlState";
-import { useGenresQuery } from "@/api/genres/useGenres";
+import { genresQuery } from "@/api/genres/useGenres";
 import { SortControls } from "./SortControls";
 import { MobileFilters } from "./MobileFilters";
 import { DesktopFilters } from "./DesktopFilters";
@@ -24,7 +25,7 @@ export function FilterSortControls({
 }: FilterSortControlsProps) {
   const [isFiltersExpanded, setIsFiltersExpanded] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const { data: genres = [] } = useGenresQuery();
+  const { data: genres } = useSuspenseQuery(genresQuery());
 
   useEffect(() => {
     function checkMobile() {

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/index.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/index.tsx
@@ -1,10 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ArtistsTab } from "@/pages/EditionView/tabs/ArtistsTab/ArtistsTab";
 import { filterSortSearchSchema } from "@/lib/searchSchemas";
+import { genresQuery } from "@/api/genres/useGenres";
 
 export const Route = createFileRoute(
   "/festivals/$festivalSlug/editions/$editionSlug/sets/",
 )({
   component: ArtistsTab,
   validateSearch: filterSortSearchSchema,
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(genresQuery());
+  },
 });


### PR DESCRIPTION
Prefetches genres in the sets index route loader and consumes them via `useSuspenseQuery` in `FilterSortControls`, following the PR #90 router-adoption pattern.
Removes the component's empty-array/loading fallback for genres.

## Verification
- Open a festival edition's Vote (sets) tab, expand filters, and confirm the genre filter lists genres without a loading flicker.
- Navigate directly to the sets URL (cold load); the genre filter is populated on first render.
- Confirm GenreBadge (set cards) and admin genre dialogs still render genres unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhcG4Y4YL7MCQg7CXjyMJb)_