### PR TITLE
refactor(custom-links): adopt route loader and suspense query

### DIFF
--- a/src/pages/EditionView/EditionLayout.tsx
+++ b/src/pages/EditionView/EditionLayout.tsx
@@ -3,11 +3,12 @@ import { MainTabNavigation } from "./TabNavigation/TabNavigation";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { Outlet } from "@tanstack/react-router";
-import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { customLinksQuery } from "@/api/custom-links/useCustomLinks";
 
 export default function EditionView() {
   const { festival, edition } = useFestivalEdition();
-  const customLinksQuery = useCustomLinksQuery(festival.id);
+  const { data: customLinks } = useSuspenseQuery(customLinksQuery(festival.id));
 
   if (!edition) {
     return (
@@ -17,7 +18,6 @@ export default function EditionView() {
     );
   }
 
-  const customLinks = customLinksQuery.data || [];
   const websiteUrl = customLinks.find(
     (link) => link.link_type === "website",
   )?.url;

--- a/src/pages/EditionView/tabs/InfoTab.tsx
+++ b/src/pages/EditionView/tabs/InfoTab.tsx
@@ -7,17 +7,15 @@ import { InfoText } from "./InfoTab/InfoText";
 import { CustomLinks } from "./InfoTab/CustomLinks";
 import { NoInfo } from "./InfoTab/NoInfo";
 import { SocialLinkItem } from "./InfoTab/SocialLinkItem";
-import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
+import { customLinksQuery } from "@/api/custom-links/useCustomLinks";
 
 export function InfoTab() {
   const { edition, festival } = useFestivalEdition();
   const { data: festivalInfo } = useSuspenseQuery(
     festivalInfoQuery(festival.id),
   );
+  const { data: customLinks } = useSuspenseQuery(customLinksQuery(festival.id));
 
-  const customLinksQuery = useCustomLinksQuery(festival?.id || "");
-
-  const customLinks = customLinksQuery.data || [];
   const noInfoAvailable =
     !festivalInfo?.info_text &&
     !festivalInfo?.facebook_url &&

--- a/src/routes/festivals/$festivalSlug.tsx
+++ b/src/routes/festivals/$festivalSlug.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionProvider } from "@/contexts/FestivalEditionContext";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { festivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
+import { customLinksQuery } from "@/api/custom-links/useCustomLinks";
 
 export const Route = createFileRoute("/festivals/$festivalSlug")({
   loader: async ({ params, context }) => {
@@ -10,6 +11,7 @@ export const Route = createFileRoute("/festivals/$festivalSlug")({
       festivalBySlugQuery(params.festivalSlug),
     );
     await context.queryClient.ensureQueryData(festivalInfoQuery(festival.id));
+    await context.queryClient.ensureQueryData(customLinksQuery(festival.id));
   },
   component: FestivalLayout,
 });


### PR DESCRIPTION
Prefetches custom links in the festival route loader and reads them via `useSuspenseQuery`, removing per-component loading branches.
Custom links render on Info/edition views without a client-side loading flash.

## Verification
- Open a festival edition; Info tab and header website/tickets buttons render from custom links with no loading flicker.
- Open a festival with no custom links; Info tab shows other info (or NoInfo) without errors.
- Festival selection list still loads per-festival links (unchanged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhcG4Y4YL7MCQg7CXjyMJb)_