### PR TITLE
refactor(artist-notes): prefetch notes via set route loader

### DIFF
--- a/src/pages/SetDetails/SetNotes.tsx
+++ b/src/pages/SetDetails/SetNotes.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import {
   Card,
   CardContent,
@@ -8,7 +9,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Edit3, StickyNote } from "lucide-react";
-import { useArtistNotesQuery } from "@/api/artist-notes/useArtistNotes";
+import { artistNotesQuery } from "@/api/artist-notes/useArtistNotes";
 import { SetNoteItem } from "./notes/SetNoteItem";
 import { CreateNoteForm } from "./notes/CreateNoteForm";
 
@@ -18,11 +19,9 @@ interface SetNotesProps {
 }
 
 export function SetNotes({ setId, userId }: SetNotesProps) {
-  const notesQuery = useArtistNotesQuery(setId);
+  const { data: notes } = useSuspenseQuery(artistNotesQuery(setId));
 
   const [isEditing, setIsEditing] = useState(false);
-
-  const notes = notesQuery.data;
 
   if (!userId) {
     return (
@@ -36,22 +35,6 @@ export function SetNotes({ setId, userId }: SetNotesProps) {
             Sign in to add notes and see notes from group members
           </CardDescription>
         </CardHeader>
-      </Card>
-    );
-  }
-
-  if (notesQuery.isLoading) {
-    return (
-      <Card className="bg-white/10 backdrop-blur-md border-purple-400/30">
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2 text-white">
-            <StickyNote className="h-5 w-5" />
-            <span>Group Notes</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-purple-200">Loading notes...</div>
-        </CardContent>
       </Card>
     );
   }

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/$setSlug.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/$setSlug.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SetDetails } from "@/pages/SetDetails";
 import { filterSortSearchSchema } from "@/lib/searchSchemas";
 import { setBySlugQuery } from "@/api/sets/useSetBySlug";
+import { artistNotesQuery } from "@/api/artist-notes/useArtistNotes";
 
 export const Route = createFileRoute(
   "/festivals/$festivalSlug/editions/$editionSlug/sets/$setSlug",
@@ -9,8 +10,9 @@ export const Route = createFileRoute(
   component: SetDetails,
   validateSearch: filterSortSearchSchema,
   loader: async ({ params, context }) => {
-    await context.queryClient.ensureQueryData(
+    const set = await context.queryClient.ensureQueryData(
       setBySlugQuery(params.setSlug, context.edition.id),
     );
+    await context.queryClient.ensureQueryData(artistNotesQuery(set.id));
   },
 });


### PR DESCRIPTION
Prefetches artist notes in the set-detail route loader and switches `SetNotes` to `useSuspenseQuery`, removing its client-side loading branch.
Notes render on first paint of the set-detail page.

## Verification
- Open a set-detail page for a set that has notes; notes render immediately without a "Loading notes..." flash.
- Open a set-detail page for a set with no notes; the notes card shows the empty state and Add Note button, no error thrown.
- Signed out, open a set-detail page; the "Sign in to add notes" card shows.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhcG4Y4YL7MCQg7CXjyMJb)_