### PR TITLE
refactor(stages): adopt route loader and useSuspenseQuery

### DIFF
--- a/src/pages/EditionView/tabs/ScheduleTab/StageFilterButtons.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/StageFilterButtons.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { MapPin } from "lucide-react";
-import { useStagesByEditionQuery } from "@/api/stages/useStagesByEdition";
-import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
+import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 
 interface StageFilterButtonsProps {
   selectedStages: string[];
@@ -12,8 +13,10 @@ export function StageFilterButtons({
   selectedStages,
   onStageToggle,
 }: StageFilterButtonsProps) {
-  const { edition } = useFestivalEdition();
-  const { data: stages = [] } = useStagesByEditionQuery(edition?.id);
+  const { edition } = useRouteContext({
+    from: "/festivals/$festivalSlug/editions/$editionSlug",
+  });
+  const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
 
   return (
     <div className="space-y-2">

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -1,4 +1,6 @@
 import { useMemo } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
 import { useScheduleData } from "@/hooks/useScheduleData";
 import { calculateTimelineData } from "@/lib/timelineCalculator";
 import { StageLabels } from "./StageLabels";
@@ -7,20 +9,23 @@ import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { useSetsByEditionQuery as useEditionSetsQuery } from "@/api/sets/useSetsByEdition";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
 import { getFestivalHour } from "@/lib/timeUtils";
-import { useStagesByEditionQuery } from "@/api/stages/useStagesByEdition";
+import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNotRevealedPlaceholder } from "../ScheduleNotRevealedPlaceholder";
 
 export function Timeline() {
-  const { edition, festival } = useFestivalEdition();
+  const { festival } = useFestivalEdition();
+  const { edition } = useRouteContext({
+    from: "/festivals/$festivalSlug/editions/$editionSlug/schedule/timeline",
+  });
   const { canShowTime } = useScheduleReveal();
   const { data: editionSets = [], isLoading: setsLoading } =
-    useEditionSetsQuery(edition?.id);
-  const stagesQuery = useStagesByEditionQuery(edition?.id);
+    useEditionSetsQuery(edition.id);
+  const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
 
   const { scheduleDays, loading, error } = useScheduleData({
     sets: editionSets,
-    stages: stagesQuery.data,
+    stages,
     timezone: festival.timezone,
   });
   const {
@@ -30,7 +35,7 @@ export function Timeline() {
   } = useTimelineUrlState("timeline");
 
   const timelineData = useMemo(() => {
-    if (!edition || !edition.start_date || !edition.end_date) {
+    if (!edition.start_date || !edition.end_date) {
       return null;
     }
 
@@ -82,7 +87,7 @@ export function Timeline() {
       new Date(edition.start_date),
       new Date(edition.end_date),
       filteredScheduleDays,
-      stagesQuery.data || [],
+      stages,
     );
   }, [
     edition,
@@ -90,7 +95,7 @@ export function Timeline() {
     selectedDay,
     selectedTime,
     selectedStages,
-    stagesQuery.data,
+    stages,
     festival.timezone,
   ]);
 

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
@@ -1,4 +1,6 @@
 import { useMemo } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
 import { useScheduleData } from "@/hooks/useScheduleData";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { useSetsByEditionQuery as useEditionSetsQuery } from "@/api/sets/useSetsByEdition";
@@ -6,7 +8,7 @@ import { getFestivalDayKey, getFestivalHour } from "@/lib/timeUtils";
 import { TimeSlotGroup } from "./TimeSlotGroup";
 import type { ScheduleSet } from "@/hooks/useScheduleData";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
-import { useStagesByEditionQuery } from "@/api/stages/useStagesByEdition";
+import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNotRevealedPlaceholder } from "../ScheduleNotRevealedPlaceholder";
 
@@ -16,14 +18,17 @@ interface TimeSlot {
 }
 
 export function ListSchedule() {
-  const { edition, festival } = useFestivalEdition();
+  const { festival } = useFestivalEdition();
+  const { edition } = useRouteContext({
+    from: "/festivals/$festivalSlug/editions/$editionSlug/schedule/list",
+  });
   const { canShowTime } = useScheduleReveal();
   const { data: editionSets = [], isLoading: setsLoading } =
-    useEditionSetsQuery(edition?.id);
-  const stagesQuery = useStagesByEditionQuery(edition?.id);
+    useEditionSetsQuery(edition.id);
+  const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
   const { scheduleDays, loading, error } = useScheduleData({
     sets: editionSets,
-    stages: stagesQuery.data,
+    stages,
     timezone: festival.timezone,
   });
   const {
@@ -89,7 +94,7 @@ export function ListSchedule() {
         }
 
         // Find the stage data to get color information
-        const stageData = stagesQuery.data?.find((s) => s.id === stage.id);
+        const stageData = stages.find((s) => s.id === stage.id);
 
         stage.sets.forEach((set) => {
           if (set.startTime && matchesDay(set) && matchesTime(set)) {
@@ -133,7 +138,7 @@ export function ListSchedule() {
     selectedDay,
     selectedTime,
     selectedStages,
-    stagesQuery.data,
+    stages,
     festival.timezone,
   ]);
 

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import EditionLayout from "@/pages/EditionView/EditionLayout";
 import { editionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
+import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 
 export const Route = createFileRoute(
   "/festivals/$festivalSlug/editions/$editionSlug",
@@ -23,5 +24,10 @@ export const Route = createFileRoute(
     );
 
     return { edition };
+  },
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(
+      stagesByEditionQuery(context.edition.id),
+    );
   },
 });


### PR DESCRIPTION
Prefetch stages in the edition route loader so the public schedule components read them via useSuspenseQuery from the router-guaranteed edition, dropping their per-component stage loading branches.

## Verification
- Open a festival edition schedule (list view); stage filter buttons and the schedule render with no separate "loading stages" flash.
- Switch to the timeline view; stages render and stage filtering still works.
- Toggle a stage filter in both list and timeline views; sets filter accordingly.
- Open the Vote (artists) tab, expand filters on desktop and mobile widths; stage filter list still loads (kept on useQuery since editionId is a plain prop).
- Reload directly on a schedule URL; stages are prefetched by the loader before the view paints.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhcG4Y4YL7MCQg7CXjyMJb)_