### PR TITLE
refactor(festival-info): adopt route loader and suspense

### DIFF
--- a/src/api/festival-info/useFestivalInfo.ts
+++ b/src/api/festival-info/useFestivalInfo.ts
@@ -2,18 +2,16 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { FestivalInfo, festivalInfoKeys } from "./types";
 
-async function fetchFestivalInfo(festivalId: string): Promise<FestivalInfo> {
+async function fetchFestivalInfo(
+  festivalId: string,
+): Promise<FestivalInfo | null> {
   const { data, error } = await supabase
     .from("festival_info")
     .select("*")
     .eq("festival_id", festivalId)
-    .single();
+    .maybeSingle();
 
   if (error) {
-    if (error.code === "PGRST116") {
-      throw new Error("Festival info not found");
-    }
-
     console.error("Error fetching festival info:", error);
     throw new Error("Failed to fetch festival info");
   }

--- a/src/pages/EditionView/TabNavigation/TabNavigation.tsx
+++ b/src/pages/EditionView/TabNavigation/TabNavigation.tsx
@@ -1,12 +1,15 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
+import { festivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { DesktopTabButton } from "./DesktopTabButton";
 import { MobileTabButton } from "./MobileTabButton";
 import { config } from "./config";
 
 export function MainTabNavigation() {
   const { festival } = useFestivalEdition();
-  const { data: festivalInfo } = useFestivalInfoQuery(festival?.id);
+  const { data: festivalInfo } = useSuspenseQuery(
+    festivalInfoQuery(festival.id),
+  );
 
   const visibleTabs = config.filter((config) => {
     if (typeof config.enabled === "boolean") {

--- a/src/pages/EditionView/TabNavigation/types.ts
+++ b/src/pages/EditionView/TabNavigation/types.ts
@@ -15,7 +15,7 @@ export type TabConfig = {
   icon: LucideIcon;
   label: string;
   shortLabel: string;
-  enabled: boolean | ((festivalInfo?: FestivalInfo) => boolean);
+  enabled: boolean | ((festivalInfo?: FestivalInfo | null) => boolean);
   Indicator?: ComponentType;
 };
 

--- a/src/pages/EditionView/tabs/InfoTab.tsx
+++ b/src/pages/EditionView/tabs/InfoTab.tsx
@@ -1,22 +1,21 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
+import { festivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 import { EditionTitle } from "./InfoTab/EditionTitle";
 import { InfoText } from "./InfoTab/InfoText";
 import { CustomLinks } from "./InfoTab/CustomLinks";
 import { NoInfo } from "./InfoTab/NoInfo";
-import { LoadingInfo } from "./InfoTab/LoadingInfo";
 import { SocialLinkItem } from "./InfoTab/SocialLinkItem";
 import { useCustomLinksQuery } from "@/api/custom-links/useCustomLinks";
 
 export function InfoTab() {
   const { edition, festival } = useFestivalEdition();
-  const { data: festivalInfo, isLoading } = useFestivalInfoQuery(festival?.id);
+  const { data: festivalInfo } = useSuspenseQuery(
+    festivalInfoQuery(festival.id),
+  );
 
   const customLinksQuery = useCustomLinksQuery(festival?.id || "");
-  if (isLoading) {
-    return <LoadingInfo />;
-  }
 
   const customLinks = customLinksQuery.data || [];
   const noInfoAvailable =

--- a/src/pages/EditionView/tabs/MapTab.tsx
+++ b/src/pages/EditionView/tabs/MapTab.tsx
@@ -1,21 +1,13 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
+import { festivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 
 export function MapTab() {
   const { festival } = useFestivalEdition();
-  const { data: festivalInfo, isLoading } = useFestivalInfoQuery(festival?.id);
-
-  if (isLoading) {
-    return (
-      <>
-        <PageTitle title="Map" prefix={festival?.name} />
-        <div className="text-center text-purple-300 py-12">
-          <p>Loading map...</p>
-        </div>
-      </>
-    );
-  }
+  const { data: festivalInfo } = useSuspenseQuery(
+    festivalInfoQuery(festival.id),
+  );
 
   if (!festivalInfo?.map_image_url) {
     return (

--- a/src/pages/EditionView/tabs/SocialTab.tsx
+++ b/src/pages/EditionView/tabs/SocialTab.tsx
@@ -1,24 +1,17 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
-import { useFestivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
+import { festivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 import { ExternalLinkIcon } from "lucide-react";
 
 export function SocialTab() {
   const { festival } = useFestivalEdition();
-  const { data: festivalInfo, isLoading } = useFestivalInfoQuery(festival?.id);
+  const { data: festivalInfo } = useSuspenseQuery(
+    festivalInfoQuery(festival.id),
+  );
 
-  if (isLoading || !festivalInfo) {
-    return (
-      <>
-        <PageTitle title="Social" prefix={festival?.name} />
-        <div className="text-center text-purple-300 py-12">
-          <p>Loading social feeds...</p>
-        </div>
-      </>
-    );
-  }
-
-  const { facebook_url, instagram_url } = festivalInfo;
+  const facebook_url = festivalInfo?.facebook_url;
+  const instagram_url = festivalInfo?.instagram_url;
   if (!facebook_url && !instagram_url) {
     return (
       <>
@@ -40,12 +33,12 @@ export function SocialTab() {
 
         <div className="grid gap-8 lg:grid-cols-2">
           {/* Facebook Embed */}
-          {festivalInfo.facebook_url && (
+          {facebook_url && (
             <div className="bg-white/5 rounded-lg p-6">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-lg font-semibold text-white">Facebook</h3>
                 <a
-                  href={festivalInfo.facebook_url}
+                  href={facebook_url}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center gap-2 text-purple-300 hover:text-white transition-colors"
@@ -57,7 +50,7 @@ export function SocialTab() {
 
               <div className="relative">
                 <iframe
-                  src={`https://www.facebook.com/plugins/page.php?href=${encodeURIComponent(festivalInfo.facebook_url)}&tabs=timeline&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId=1064955115428877`}
+                  src={`https://www.facebook.com/plugins/page.php?href=${encodeURIComponent(facebook_url)}&tabs=timeline&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId=1064955115428877`}
                   width="100%"
                   height="500"
                   style={{ border: "none", overflow: "hidden" }}

--- a/src/routes/festivals/$festivalSlug.tsx
+++ b/src/routes/festivals/$festivalSlug.tsx
@@ -2,12 +2,14 @@ import { createFileRoute, Outlet, useParams } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionProvider } from "@/contexts/FestivalEditionContext";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
+import { festivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
 
 export const Route = createFileRoute("/festivals/$festivalSlug")({
   loader: async ({ params, context }) => {
-    await context.queryClient.ensureQueryData(
+    const festival = await context.queryClient.ensureQueryData(
       festivalBySlugQuery(params.festivalSlug),
     );
+    await context.queryClient.ensureQueryData(festivalInfoQuery(festival.id));
   },
   component: FestivalLayout,
 });


### PR DESCRIPTION
Prefetch festival info in the festival layout loader and read it via useSuspenseQuery in the public Info/Map/Social tabs and tab navigation.
Made the fetch genuinely optional (maybeSingle → null) so a festival with no info row no longer throws into the route error boundary.

## Verification
- Open a festival edition with a festival_info row; Info/Map/Social tabs and tab bar render as before.
- Open a festival edition whose festival has NO festival_info row; the page loads normally (no RouteErrorFallback), Map/Social/Info show their "not available" states, Map/Info/Social tabs stay hidden.
- Open admin festival info for a festival with no info row; the "No festival information has been added yet" state still shows.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhcG4Y4YL7MCQg7CXjyMJb)_