### PR TITLE
feat(auth): hoist supabase session into router context

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { PostHogProvider } from "posthog-js/react";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { supabase } from "./integrations/supabase/client";
 import { routeTree } from "./routeTree.gen";
 import NotFound from "./pages/NotFound";
 import { RouteLoadingFallback } from "./components/layout/RouteLoadingFallback";
@@ -25,6 +26,7 @@ const router = createRouter({
   routeTree,
   context: {
     queryClient,
+    user: null,
   },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
@@ -62,6 +64,10 @@ declare module "@tanstack/react-router" {
     router: typeof router;
   }
 }
+
+supabase.auth.onAuthStateChange(() => {
+  router.invalidate();
+});
 
 createRoot(document.getElementById("root")!).render(
   <PostHogProvider

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -22,6 +22,8 @@ import { useMemo, useEffect } from "react";
 import { shouldRedirectFromWww, getNonWwwRedirectUrl } from "@/lib/subdomain";
 import { z } from "zod";
 import type { QueryClient } from "@tanstack/react-query";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
 
 const rootSearchSchema = z.object({
   invite: z.string().optional(),
@@ -29,11 +31,18 @@ const rootSearchSchema = z.object({
 
 interface RouterContext {
   queryClient: QueryClient;
+  user: User | null;
 }
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
   validateSearch: rootSearchSchema,
+  beforeLoad: async () => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    return { user: session?.user ?? null };
+  },
 });
 
 function RootComponent() {


### PR DESCRIPTION
Resolves the supabase session in a root `beforeLoad` into `context.user` so route loaders can prefetch auth-dependent queries (#50), unblocking the remaining Effort 2 slices. `AuthProvider` and its ~23 `useAuth` consumers are untouched; reactivity comes from a router-side `onAuthStateChange` → `router.invalidate()`.

Closes #50.

## Verification
- Load the app signed out; navigate between routes — pages render as before, no errors.
- Sign in; confirm the router re-runs loaders (auth-gated data appears) without a manual refresh.
- Sign out; confirm loaders re-run and auth-gated UI clears.
- `pnpm run build && pnpm run lint && pnpm test` — build, 0 lint errors, 311 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJgBP1QJc3GnLCyss7qY3H)_