### PR TITLE
refactor(groups): prefetch groups and invites in loaders

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { PostHogProvider } from "posthog-js/react";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { supabase } from "./integrations/supabase/client";
 import { routeTree } from "./routeTree.gen";
 import NotFound from "./pages/NotFound";
 import { RouteLoadingFallback } from "./components/layout/RouteLoadingFallback";
@@ -25,6 +26,7 @@ const router = createRouter({
   routeTree,
   context: {
     queryClient,
+    user: null,
   },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
@@ -62,6 +64,10 @@ declare module "@tanstack/react-router" {
     router: typeof router;
   }
 }
+
+supabase.auth.onAuthStateChange(() => {
+  router.invalidate();
+});
 
 createRoot(document.getElementById("root")!).render(
   <PostHogProvider

--- a/src/pages/groups/GroupDetail.tsx
+++ b/src/pages/groups/GroupDetail.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from "react";
-import { useParams, useNavigate, Link } from "@tanstack/react-router";
+import { useState } from "react";
+import { useParams, useRouteContext, Link } from "@tanstack/react-router";
+import type { User } from "@supabase/supabase-js";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { TopBar } from "@/components/layout/TopBar";
 import {
   Card,
@@ -10,66 +12,15 @@ import {
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Users, UserMinus, Crown } from "lucide-react";
-import { useAuth } from "@/contexts/AuthContext";
-import { useToast } from "@/components/ui/use-toast";
 import { InviteManagement } from "./GroupDetail/InviteManagement";
 import { AddMemberForm } from "./GroupDetail/AddMemberForm";
 import { Button } from "@/components/ui/button";
-import { useGroupBySlugQuery } from "@/api/groups/useGroupBySlug";
-import { useGroupMembersQuery } from "@/api/groups/useGroupMembers";
+import { groupBySlugQuery } from "@/api/groups/useGroupBySlug";
+import { groupMembersQuery } from "@/api/groups/useGroupMembers";
 import { useRemoveMemberMutation } from "@/api/groups/useRemoveMember";
 
 function GroupDetail() {
-  const { groupSlug } = useParams({ from: "/groups/$groupSlug" });
-  const navigate = useNavigate();
-  const { user, loading: authLoading } = useAuth();
-  const { toast } = useToast();
-  const [removingMember, setRemovingMember] = useState<string | null>(null);
-
-  // React Query hooks
-  const {
-    data: group,
-    isLoading: groupLoading,
-    error: groupError,
-  } = useGroupBySlugQuery({ slug: groupSlug, userId: user?.id });
-  const { data: members = [], isLoading: membersLoading } =
-    useGroupMembersQuery(group?.id || "");
-  const removeMemberMutation = useRemoveMemberMutation(group?.id || "");
-
-  const loading = groupLoading || membersLoading;
-
-  useEffect(() => {
-    if (authLoading) return; // Wait for auth to load
-
-    if (!groupSlug) {
-      navigate({ to: "/groups" });
-      return;
-    }
-
-    if (!user) {
-      navigate({ to: "/" }); // Redirect to home to sign in
-      return;
-    }
-
-    // Handle group fetch errors
-    if (groupError) {
-      toast({
-        title: "Error",
-        description: "Failed to fetch group details",
-        variant: "destructive",
-      });
-      navigate({ to: "/groups" });
-    }
-  }, [groupSlug, user, authLoading, groupError, navigate, toast]);
-
-  // Show loading while checking authentication
-  if (authLoading) {
-    return (
-      <div className="min-h-screen bg-app-gradient flex items-center justify-center">
-        <div className="text-white text-xl">Loading...</div>
-      </div>
-    );
-  }
+  const { user } = useRouteContext({ from: "/groups/$groupSlug" });
 
   if (!user) {
     return (
@@ -91,34 +42,18 @@ function GroupDetail() {
     );
   }
 
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-app-gradient flex items-center justify-center">
-        <div className="text-white text-xl">Loading group details...</div>
-      </div>
-    );
-  }
+  return <GroupDetailContent user={user} />;
+}
 
-  if (!group) {
-    return (
-      <div className="min-h-screen bg-app-gradient flex items-center justify-center">
-        <Card className="w-full max-w-md">
-          <CardHeader>
-            <CardTitle>Group not found</CardTitle>
-            <CardDescription>
-              The group you're looking for doesn't exist or you don't have
-              access to it
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button asChild className="w-full">
-              <Link to="/groups">Back to Groups</Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
+function GroupDetailContent({ user }: { user: User }) {
+  const { groupSlug } = useParams({ from: "/groups/$groupSlug" });
+  const [removingMember, setRemovingMember] = useState<string | null>(null);
+
+  const { data: group } = useSuspenseQuery(
+    groupBySlugQuery(groupSlug, user.id),
+  );
+  const { data: members } = useSuspenseQuery(groupMembersQuery(group.id));
+  const removeMemberMutation = useRemoveMemberMutation(group.id);
 
   const isCreator = group.created_by === user.id;
 
@@ -256,8 +191,6 @@ function GroupDetail() {
   );
 
   async function handleRemoveMember(memberId: string, memberUserId: string) {
-    if (!group?.id || !user) return;
-
     if (
       window.confirm(
         "Are you sure you want to remove this member from the group?",

--- a/src/pages/groups/GroupDetail/InviteManagement.tsx
+++ b/src/pages/groups/GroupDetail/InviteManagement.tsx
@@ -12,7 +12,8 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Link, Copy, Trash2, Calendar, Users } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
-import { useGroupInvitesQuery } from "@/api/invites/useGroupInvites";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { groupInvitesQuery } from "@/api/invites/useGroupInvites";
 import { useGenerateInviteMutation } from "@/api/invites/useGenerateInviteMutation";
 import { useDeleteInviteMutation } from "@/api/invites/useDeleteInviteMutation";
 import { GroupInvite } from "@/api/invites/types";
@@ -32,7 +33,7 @@ export function InviteManagement({
   const { toast } = useToast();
 
   // React Query hooks
-  const { data: invites = [] } = useGroupInvitesQuery(groupId);
+  const { data: invites } = useSuspenseQuery(groupInvitesQuery(groupId));
   const generateInviteMutation = useGenerateInviteMutation(groupId);
   const deleteInviteMutation = useDeleteInviteMutation(groupId);
 

--- a/src/pages/groups/Groups.tsx
+++ b/src/pages/groups/Groups.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
-import { useAuth } from "@/contexts/AuthContext";
-import { useUserGroupsQuery } from "@/api/groups/useUserGroups";
+import { Suspense, useState } from "react";
+import { useNavigate, useRouteContext } from "@tanstack/react-router";
+import type { User } from "@supabase/supabase-js";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { userGroupsQuery } from "@/api/groups/useUserGroups";
 import { useUserPermissionsQuery } from "@/api/auth/useUserPermissions";
 import { useDeleteGroupMutation } from "@/api/groups/useDeleteGroup";
 import { DeleteGroupDialog } from "./Groups/DeleteGroupDialog";
@@ -12,20 +13,24 @@ import { MyGroupsList } from "./Groups/MyGroupsList";
 import { Button } from "@/components/ui/button";
 
 function Groups() {
+  const { user } = useRouteContext({ from: "/groups/" });
+
+  if (!user) {
+    return <SignInRequired />;
+  }
+
+  return <GroupsContent user={user} />;
+}
+
+function GroupsContent({ user }: { user: User }) {
   const navigate = useNavigate();
-  const { user, loading: authLoading } = useAuth();
   const [showAllGroups, setShowAllGroups] = useState(false);
 
   const { data: isAdmin = false } = useUserPermissionsQuery(
-    user?.id,
+    user.id,
     "is_admin",
   );
-  const { data: groups = [], isLoading: groupsLoading } = useUserGroupsQuery(
-    user?.id,
-    { all: showAllGroups },
-  );
   const deleteGroupMutation = useDeleteGroupMutation();
-  const loading = authLoading || groupsLoading;
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -40,7 +45,7 @@ function Groups() {
   }
 
   function confirmDeleteGroup() {
-    if (!groupToDelete || !user) return;
+    if (!groupToDelete) return;
 
     deleteGroupMutation.mutate(
       {
@@ -55,10 +60,6 @@ function Groups() {
       },
     );
     // The mutation automatically handles success/error toasts
-  }
-
-  if (!user) {
-    return <SignInRequired />;
   }
 
   return (
@@ -85,12 +86,17 @@ function Groups() {
           </div>
         )}
 
-        <MyGroupsList
-          groups={groups}
-          loading={loading}
-          onDelete={handleDeleteGroup}
-          showMembershipBadges={showAllGroups}
-        />
+        <Suspense
+          fallback={
+            <div className="text-center text-white">Loading groups...</div>
+          }
+        >
+          <GroupsList
+            userId={user.id}
+            showAllGroups={showAllGroups}
+            onDelete={handleDeleteGroup}
+          />
+        </Suspense>
 
         <CreateGroupDialog
           isOpen={createDialogOpen}
@@ -112,6 +118,29 @@ function Groups() {
         />
       </div>
     </div>
+  );
+}
+
+function GroupsList({
+  userId,
+  showAllGroups,
+  onDelete,
+}: {
+  userId: string;
+  showAllGroups: boolean;
+  onDelete: (id: string, name: string) => void;
+}) {
+  const { data: groups } = useSuspenseQuery(
+    userGroupsQuery(userId, { all: showAllGroups }),
+  );
+
+  return (
+    <MyGroupsList
+      groups={groups}
+      loading={false}
+      onDelete={onDelete}
+      showMembershipBadges={showAllGroups}
+    />
   );
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -22,6 +22,8 @@ import { useMemo, useEffect } from "react";
 import { shouldRedirectFromWww, getNonWwwRedirectUrl } from "@/lib/subdomain";
 import { z } from "zod";
 import type { QueryClient } from "@tanstack/react-query";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "@/integrations/supabase/client";
 
 const rootSearchSchema = z.object({
   invite: z.string().optional(),
@@ -29,11 +31,18 @@ const rootSearchSchema = z.object({
 
 interface RouterContext {
   queryClient: QueryClient;
+  user: User | null;
 }
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
   validateSearch: rootSearchSchema,
+  beforeLoad: async () => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    return { user: session?.user ?? null };
+  },
 });
 
 function RootComponent() {

--- a/src/routes/groups/$groupSlug.tsx
+++ b/src/routes/groups/$groupSlug.tsx
@@ -1,6 +1,21 @@
 import { createFileRoute } from "@tanstack/react-router";
 import GroupDetail from "@/pages/groups/GroupDetail";
+import { groupBySlugQuery } from "@/api/groups/useGroupBySlug";
+import { groupMembersQuery } from "@/api/groups/useGroupMembers";
+import { groupInvitesQuery } from "@/api/invites/useGroupInvites";
 
 export const Route = createFileRoute("/groups/$groupSlug")({
   component: GroupDetail,
+  loader: async ({ params, context }) => {
+    if (!context.user) return;
+
+    const group = await context.queryClient.ensureQueryData(
+      groupBySlugQuery(params.groupSlug, context.user.id),
+    );
+    await context.queryClient.ensureQueryData(groupMembersQuery(group.id));
+
+    if (group.created_by === context.user.id) {
+      await context.queryClient.ensureQueryData(groupInvitesQuery(group.id));
+    }
+  },
 });

--- a/src/routes/groups/index.tsx
+++ b/src/routes/groups/index.tsx
@@ -1,6 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import Groups from "@/pages/groups/Groups";
+import { userGroupsQuery } from "@/api/groups/useUserGroups";
 
 export const Route = createFileRoute("/groups/")({
   component: Groups,
+  loader: async ({ context }) => {
+    if (context.user) {
+      await context.queryClient.ensureQueryData(
+        userGroupsQuery(context.user.id, { all: false }),
+      );
+    }
+  },
 });


### PR DESCRIPTION
Adopts the loader + `useSuspenseQuery` pattern (same as #90) for `/groups` and `/groups/$groupSlug`, now possible because #50 hoists the auth session into router context. Loaders prefetch `userGroups`, `groupBySlug`, `groupMembers`, and `groupInvites` (creators only); pages guard the signed-out case before suspending. Public group widgets stay `useQuery`.

Stacked on #102 (#50) — base retargets to `main` once that merges. Part of #53.

## Verification
- Signed out, open `/groups` and `/groups/{slug}`; the sign-in prompt shows, no crash.
- Sign in, open `/groups`; your groups render without a loading flash (prefetched).
- As an admin, toggle "All Groups"; the list swaps (brief inline "Loading groups...").
- Open a group you created; Members tab lists members, Invites tab loads existing invites, generating/deleting an invite updates the list.
- Open a group you're a member of but didn't create; Invites tab is disabled, members show.
- Open a non-existent/no-access group slug; the route error fallback shows the access message.
- `pnpm run build && pnpm run lint && pnpm test` — build, 0 lint errors, 311 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJgBP1QJc3GnLCyss7qY3H)_