### PR TITLE
fix(festivals): add timeout and error state to festival queries

### DIFF
--- a/src/api/editions/useFestivalEditionBySlug.ts
+++ b/src/api/editions/useFestivalEditionBySlug.ts
@@ -2,28 +2,28 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { FestivalEdition, editionsKeys } from "./types";
 import { fetchFestivalBySlug } from "@/api/festivals/useFestivalBySlug";
-import { withTimeout } from "@/lib/timeout";
+import { timeoutSignal } from "@/lib/timeout";
 
 export async function fetchFestivalEditionBySlug({
   editionSlug,
   festivalSlug,
+  signal,
 }: {
   festivalSlug: string;
   editionSlug: string;
+  signal?: AbortSignal;
 }): Promise<FestivalEdition> {
-  const festival = await fetchFestivalBySlug(festivalSlug);
+  const festival = await fetchFestivalBySlug(festivalSlug, signal);
 
   try {
-    const { data, error } = await withTimeout(
-      supabase
-        .from("festival_editions")
-        .select("*")
-        .eq("archived", false)
-        .eq("festival_id", festival.id)
-        .eq("slug", editionSlug)
-        .single(),
-      10000,
-    );
+    const { data, error } = await supabase
+      .from("festival_editions")
+      .select("*")
+      .eq("archived", false)
+      .eq("festival_id", festival.id)
+      .eq("slug", editionSlug)
+      .abortSignal(timeoutSignal(signal))
+      .single();
 
     if (error) {
       throw new Error("Failed to load festival edition");
@@ -31,7 +31,7 @@ export async function fetchFestivalEditionBySlug({
 
     return data;
   } catch (err) {
-    if (err instanceof Error && err.message === "Request timeout") {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
       throw new Error("Failed to load festival edition - request timed out");
     }
     throw err;
@@ -47,10 +47,11 @@ export function editionBySlugQuery({
 }) {
   return queryOptions({
     queryKey: editionsKeys.bySlug(festivalSlug, editionSlug),
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       fetchFestivalEditionBySlug({
         festivalSlug,
         editionSlug,
+        signal,
       }),
   });
 }

--- a/src/api/editions/useFestivalEditionBySlug.ts
+++ b/src/api/editions/useFestivalEditionBySlug.ts
@@ -2,7 +2,7 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { FestivalEdition, editionsKeys } from "./types";
 import { fetchFestivalBySlug } from "@/api/festivals/useFestivalBySlug";
-import { timeoutSignal } from "@/lib/timeout";
+import { isTimeoutError, withTimeout } from "@/lib/timeout";
 
 export async function fetchFestivalEditionBySlug({
   editionSlug,
@@ -15,35 +15,33 @@ export async function fetchFestivalEditionBySlug({
 }): Promise<FestivalEdition> {
   const festival = await fetchFestivalBySlug(festivalSlug, signal);
 
-  try {
-    const { data, error } = await supabase
-      .from("festival_editions")
-      .select("*")
-      .eq("archived", false)
-      .eq("festival_id", festival.id)
-      .eq("slug", editionSlug)
-      .abortSignal(timeoutSignal(signal))
-      .single();
+  const { data, error } = await supabase
+    .from("festival_editions")
+    .select("*")
+    .eq("archived", false)
+    .eq("festival_id", festival.id)
+    .eq("slug", editionSlug)
+    .abortSignal(signal!)
+    .single();
 
-    if (error) {
-      throw new Error("Failed to load festival edition");
-    }
-
-    return data;
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
+  if (error) {
+    if (isTimeoutError(signal)) {
       throw new Error("Failed to load festival edition - request timed out");
     }
-    throw err;
+    throw new Error("Failed to load festival edition");
   }
+
+  return data;
 }
 
 export function editionBySlugQuery({
   editionSlug,
   festivalSlug,
+  timeoutMs = 10000,
 }: {
   festivalSlug: string;
   editionSlug: string;
+  timeoutMs?: number;
 }) {
   return queryOptions({
     queryKey: editionsKeys.bySlug(festivalSlug, editionSlug),
@@ -51,7 +49,7 @@ export function editionBySlugQuery({
       fetchFestivalEditionBySlug({
         festivalSlug,
         editionSlug,
-        signal,
+        signal: withTimeout(signal, timeoutMs),
       }),
   });
 }

--- a/src/api/editions/useFestivalEditionBySlug.ts
+++ b/src/api/editions/useFestivalEditionBySlug.ts
@@ -2,6 +2,7 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { FestivalEdition, editionsKeys } from "./types";
 import { fetchFestivalBySlug } from "@/api/festivals/useFestivalBySlug";
+import { withTimeout } from "@/lib/timeout";
 
 export async function fetchFestivalEditionBySlug({
   editionSlug,
@@ -12,21 +13,29 @@ export async function fetchFestivalEditionBySlug({
 }): Promise<FestivalEdition> {
   const festival = await fetchFestivalBySlug(festivalSlug);
 
-  const query = supabase
-    .from("festival_editions")
-    .select("*")
-    .eq("archived", false)
-    .eq("festival_id", festival.id)
-    .eq("slug", editionSlug)
-    .single();
+  try {
+    const { data, error } = await withTimeout(
+      supabase
+        .from("festival_editions")
+        .select("*")
+        .eq("archived", false)
+        .eq("festival_id", festival.id)
+        .eq("slug", editionSlug)
+        .single(),
+      10000,
+    );
 
-  const { data, error } = await query;
+    if (error) {
+      throw new Error("Failed to load festival edition");
+    }
 
-  if (error) {
-    throw new Error("Failed to load festival edition");
+    return data;
+  } catch (err) {
+    if (err instanceof Error && err.message === "Request timeout") {
+      throw new Error("Failed to load festival edition - request timed out");
+    }
+    throw err;
   }
-
-  return data;
 }
 
 export function editionBySlugQuery({

--- a/src/api/festivals/useFestivalBySlug.ts
+++ b/src/api/festivals/useFestivalBySlug.ts
@@ -1,21 +1,20 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
-import { withTimeout } from "@/lib/timeout";
+import { timeoutSignal } from "@/lib/timeout";
 
 export async function fetchFestivalBySlug(
   festivalSlug: string,
+  signal?: AbortSignal,
 ): Promise<Festival> {
   try {
-    const { data, error } = await withTimeout(
-      supabase
-        .from("festivals")
-        .select("*")
-        .eq("archived", false)
-        .eq("slug", festivalSlug)
-        .single(),
-      10000,
-    );
+    const { data, error } = await supabase
+      .from("festivals")
+      .select("*")
+      .eq("archived", false)
+      .eq("slug", festivalSlug)
+      .abortSignal(timeoutSignal(signal))
+      .single();
 
     if (error) {
       throw new Error("Failed to load festival");
@@ -23,7 +22,7 @@ export async function fetchFestivalBySlug(
 
     return data;
   } catch (err) {
-    if (err instanceof Error && err.message === "Request timeout") {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
       throw new Error("Failed to load festival - request timed out");
     }
     throw err;
@@ -33,7 +32,7 @@ export async function fetchFestivalBySlug(
 export function festivalBySlugQuery(festivalSlug: string) {
   return queryOptions({
     queryKey: festivalsKeys.bySlug(festivalSlug),
-    queryFn: () => fetchFestivalBySlug(festivalSlug),
+    queryFn: ({ signal }) => fetchFestivalBySlug(festivalSlug, signal),
   });
 }
 

--- a/src/api/festivals/useFestivalBySlug.ts
+++ b/src/api/festivals/useFestivalBySlug.ts
@@ -1,22 +1,33 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
+import { withTimeout } from "@/lib/timeout";
 
 export async function fetchFestivalBySlug(
   festivalSlug: string,
 ): Promise<Festival> {
-  const { data, error } = await supabase
-    .from("festivals")
-    .select("*")
-    .eq("archived", false)
-    .eq("slug", festivalSlug)
-    .single();
+  try {
+    const { data, error } = await withTimeout(
+      supabase
+        .from("festivals")
+        .select("*")
+        .eq("archived", false)
+        .eq("slug", festivalSlug)
+        .single(),
+      10000,
+    );
 
-  if (error) {
-    throw new Error("Failed to load festival");
+    if (error) {
+      throw new Error("Failed to load festival");
+    }
+
+    return data;
+  } catch (err) {
+    if (err instanceof Error && err.message === "Request timeout") {
+      throw new Error("Failed to load festival - request timed out");
+    }
+    throw err;
   }
-
-  return data;
 }
 
 export function festivalBySlugQuery(festivalSlug: string) {

--- a/src/api/festivals/useFestivalBySlug.ts
+++ b/src/api/festivals/useFestivalBySlug.ts
@@ -1,38 +1,38 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
-import { timeoutSignal } from "@/lib/timeout";
+import { isTimeoutError, withTimeout } from "@/lib/timeout";
 
 export async function fetchFestivalBySlug(
   festivalSlug: string,
   signal?: AbortSignal,
 ): Promise<Festival> {
-  try {
-    const { data, error } = await supabase
-      .from("festivals")
-      .select("*")
-      .eq("archived", false)
-      .eq("slug", festivalSlug)
-      .abortSignal(timeoutSignal(signal))
-      .single();
+  const { data, error } = await supabase
+    .from("festivals")
+    .select("*")
+    .eq("archived", false)
+    .eq("slug", festivalSlug)
+    .abortSignal(signal!)
+    .single();
 
-    if (error) {
-      throw new Error("Failed to load festival");
-    }
-
-    return data;
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
+  if (error) {
+    if (isTimeoutError(signal)) {
       throw new Error("Failed to load festival - request timed out");
     }
-    throw err;
+    throw new Error("Failed to load festival");
   }
+
+  return data;
 }
 
-export function festivalBySlugQuery(festivalSlug: string) {
+export function festivalBySlugQuery(
+  festivalSlug: string,
+  { timeoutMs = 10000 }: { timeoutMs?: number } = {},
+) {
   return queryOptions({
     queryKey: festivalsKeys.bySlug(festivalSlug),
-    queryFn: ({ signal }) => fetchFestivalBySlug(festivalSlug, signal),
+    queryFn: ({ signal }) =>
+      fetchFestivalBySlug(festivalSlug, withTimeout(signal, timeoutMs)),
   });
 }
 

--- a/src/api/festivals/useFestivals.ts
+++ b/src/api/festivals/useFestivals.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
+import { withTimeout } from "@/lib/timeout";
 
 async function fetchFestivals({ all }: { all?: boolean } = {}): Promise<
   Festival[]
@@ -15,13 +16,20 @@ async function fetchFestivals({ all }: { all?: boolean } = {}): Promise<
     query = query.eq("published", true);
   }
 
-  const { data, error } = await query;
+  try {
+    const { data, error } = await withTimeout(query, 10000);
 
-  if (error) {
-    throw new Error("Failed to load festivals");
+    if (error) {
+      throw new Error("Failed to load festivals");
+    }
+
+    return data || [];
+  } catch (err) {
+    if (err instanceof Error && err.message === "Request timeout") {
+      throw new Error("Failed to load festivals - request timed out");
+    }
+    throw err;
   }
-
-  return data || [];
 }
 
 export function festivalsQuery({ all }: { all?: boolean } = {}) {

--- a/src/api/festivals/useFestivals.ts
+++ b/src/api/festivals/useFestivals.ts
@@ -1,7 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
-import { timeoutSignal } from "@/lib/timeout";
+import { isTimeoutError, withTimeout } from "@/lib/timeout";
 
 async function fetchFestivals({
   all,
@@ -17,26 +17,26 @@ async function fetchFestivals({
     query = query.eq("published", true);
   }
 
-  try {
-    const { data, error } = await query.abortSignal(timeoutSignal(signal));
+  const { data, error } = await query.abortSignal(signal!);
 
-    if (error) {
-      throw new Error("Failed to load festivals");
-    }
-
-    return data || [];
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
+  if (error) {
+    if (isTimeoutError(signal)) {
       throw new Error("Failed to load festivals - request timed out");
     }
-    throw err;
+    throw new Error("Failed to load festivals");
   }
+
+  return data || [];
 }
 
-export function festivalsQuery({ all }: { all?: boolean } = {}) {
+export function festivalsQuery({
+  all,
+  timeoutMs = 10000,
+}: { all?: boolean; timeoutMs?: number } = {}) {
   return queryOptions({
     queryKey: festivalsKeys.all(),
-    queryFn: ({ signal }) => fetchFestivals({ all, signal }),
+    queryFn: ({ signal }) =>
+      fetchFestivals({ all, signal: withTimeout(signal, timeoutMs) }),
   });
 }
 

--- a/src/api/festivals/useFestivals.ts
+++ b/src/api/festivals/useFestivals.ts
@@ -1,11 +1,12 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
-import { withTimeout } from "@/lib/timeout";
+import { timeoutSignal } from "@/lib/timeout";
 
-async function fetchFestivals({ all }: { all?: boolean } = {}): Promise<
-  Festival[]
-> {
+async function fetchFestivals({
+  all,
+  signal,
+}: { all?: boolean; signal?: AbortSignal } = {}): Promise<Festival[]> {
   let query = supabase
     .from("festivals")
     .select("*")
@@ -17,7 +18,7 @@ async function fetchFestivals({ all }: { all?: boolean } = {}): Promise<
   }
 
   try {
-    const { data, error } = await withTimeout(query, 10000);
+    const { data, error } = await query.abortSignal(timeoutSignal(signal));
 
     if (error) {
       throw new Error("Failed to load festivals");
@@ -25,7 +26,7 @@ async function fetchFestivals({ all }: { all?: boolean } = {}): Promise<
 
     return data || [];
   } catch (err) {
-    if (err instanceof Error && err.message === "Request timeout") {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
       throw new Error("Failed to load festivals - request timed out");
     }
     throw err;
@@ -35,7 +36,7 @@ async function fetchFestivals({ all }: { all?: boolean } = {}): Promise<
 export function festivalsQuery({ all }: { all?: boolean } = {}) {
   return queryOptions({
     queryKey: festivalsKeys.all(),
-    queryFn: () => fetchFestivals({ all }),
+    queryFn: ({ signal }) => fetchFestivals({ all, signal }),
   });
 }
 

--- a/src/lib/timeout.ts
+++ b/src/lib/timeout.ts
@@ -1,18 +1,7 @@
-export async function withTimeout<T>(
-  promise: PromiseLike<T>,
+export function timeoutSignal(
+  signal: AbortSignal | undefined,
   timeoutMs: number = 10000,
-): Promise<T> {
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-
-  const timeoutPromise = new Promise<T>((_, reject) => {
-    timeoutHandle = setTimeout(() => {
-      reject(new Error("Request timeout"));
-    }, timeoutMs);
-  });
-
-  try {
-    return await Promise.race([Promise.resolve(promise), timeoutPromise]);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
+): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }

--- a/src/lib/timeout.ts
+++ b/src/lib/timeout.ts
@@ -1,8 +1,8 @@
 export async function withTimeout<T>(
-  promise: Promise<T>,
+  promise: PromiseLike<T>,
   timeoutMs: number = 10000,
 ): Promise<T> {
-  let timeoutHandle: NodeJS.Timeout;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
   const timeoutPromise = new Promise<T>((_, reject) => {
     timeoutHandle = setTimeout(() => {
@@ -11,7 +11,7 @@ export async function withTimeout<T>(
   });
 
   try {
-    return await Promise.race([promise, timeoutPromise]);
+    return await Promise.race([Promise.resolve(promise), timeoutPromise]);
   } finally {
     clearTimeout(timeoutHandle);
   }

--- a/src/lib/timeout.ts
+++ b/src/lib/timeout.ts
@@ -1,7 +1,15 @@
-export function timeoutSignal(
+export function withTimeout(
   signal: AbortSignal | undefined,
-  timeoutMs: number = 10000,
+  timeoutMs: number,
 ): AbortSignal {
   const timeout = AbortSignal.timeout(timeoutMs);
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+export function isTimeoutError(signal: AbortSignal | undefined): boolean {
+  return (
+    signal?.aborted === true &&
+    signal.reason instanceof DOMException &&
+    signal.reason.name === "TimeoutError"
+  );
 }

--- a/src/lib/timeout.ts
+++ b/src/lib/timeout.ts
@@ -1,0 +1,18 @@
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number = 10000,
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout;
+
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new Error("Request timeout"));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}

--- a/src/pages/FestivalSelection.tsx
+++ b/src/pages/FestivalSelection.tsx
@@ -20,8 +20,12 @@ import { TopBar } from "@/components/layout/TopBar";
 import { AppHeader } from "@/components/layout/AppHeader";
 
 export default function FestivalSelection() {
-  const { data: availableFestivals = [], isLoading: festivalsLoading } =
-    useFestivalsQuery();
+  const {
+    data: availableFestivals = [],
+    isLoading: festivalsLoading,
+    isError: festivalsError,
+    refetch,
+  } = useFestivalsQuery();
 
   function handleFestivalClick(festival: Festival) {
     const subdomainUrl = createFestivalSubdomainUrl(festival.slug);
@@ -34,6 +38,10 @@ export default function FestivalSelection() {
     }
   }
 
+  function handleRetry() {
+    refetch();
+  }
+
   useEffect(() => {
     if (!festivalsLoading && availableFestivals.length === 1) {
       handleFestivalClick(availableFestivals[0]);
@@ -44,6 +52,40 @@ export default function FestivalSelection() {
     return (
       <div className="min-h-screen bg-app-gradient flex items-center justify-center">
         <div className="text-white text-xl">Loading festivals...</div>
+      </div>
+    );
+  }
+
+  if (festivalsError) {
+    return (
+      <div className="min-h-screen bg-app-gradient">
+        <div className="container mx-auto px-4 py-8">
+          <PageTitle title="Select Festival" />
+          <TopBar />
+
+          <div className="flex items-center justify-center mt-16">
+            <Card className="w-full max-w-md bg-white/10 border-purple-400/30">
+              <CardHeader className="text-center">
+                <Music className="h-16 w-16 mx-auto text-red-400 mb-4" />
+                <CardTitle className="text-white">
+                  Couldn't Load Festivals
+                </CardTitle>
+                <CardDescription className="text-purple-200">
+                  There was an error loading the festivals. Please check your
+                  connection and try again.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex justify-center">
+                <button
+                  onClick={handleRetry}
+                  className="px-6 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
+                >
+                  Retry
+                </button>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/pages/admin/festivals/FestivalManagementTable.tsx
+++ b/src/pages/admin/festivals/FestivalManagementTable.tsx
@@ -25,7 +25,12 @@ export function FestivalManagementTable({
   onSelect: (festival: Festival) => void;
   selected: string;
 }) {
-  const { data: festivals = [], isLoading } = useFestivalsQuery({ all: true });
+  const {
+    data: festivals = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useFestivalsQuery({ all: true });
   const deleteFestivalMutation = useDeleteFestivalMutation();
 
   const [logoDialogOpen, setLogoDialogOpen] = useState(false);
@@ -55,6 +60,27 @@ export function FestivalManagementTable({
         <CardContent className="flex items-center justify-center p-8">
           <Loader2 className="h-6 w-6 animate-spin mr-2" />
           <span>Loading festivals...</span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center p-8 gap-4">
+          <div className="text-center">
+            <p className="text-red-600 font-medium mb-2">
+              Error Loading Festivals
+            </p>
+            <p className="text-sm text-gray-600">
+              There was an error loading the festivals. Please check your
+              connection and try again.
+            </p>
+          </div>
+          <Button onClick={() => refetch()} variant="outline">
+            Retry
+          </Button>
         </CardContent>
       </Card>
     );


### PR DESCRIPTION
Adds a 10s timeout to festival/edition Supabase queries and an error state with retry, so an unreachable backend shows an actionable error instead of an infinite "Loading festivals…" spinner. Closes #56.

## Verification
- Load the festivals page normally; list renders as before.
- Simulate a hung/unreachable backend; after ~10s an error message with a retry button appears instead of spinning forever.
- Click retry; the query refetches.
- Load with zero festivals; "No Festivals Available" state is unchanged.
- Same check in admin `FestivalManagementTable`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018t8iK1xLANQNMTzmp6MdnU)_