### PR TITLE
fix(nav): keep tab active on nested routes

### DIFF
--- a/src/pages/EditionView/TabNavigation/MobileTabButton.tsx
+++ b/src/pages/EditionView/TabNavigation/MobileTabButton.tsx
@@ -15,7 +15,7 @@ export function MobileTabButton({ config }: TabButtonProps) {
     from: "/festivals/$festivalSlug/editions/$editionSlug",
   });
   const matchRoute = useMatchRoute();
-  const isActive = !!matchRoute({ to: tabRoutes[config.key] });
+  const isActive = !!matchRoute({ to: tabRoutes[config.key], fuzzy: true });
 
   return (
     <Link


### PR DESCRIPTION
Fixes #26

Mobile tab active-state used exact route matching, so tabs lost their highlight on descendant routes. Adds `fuzzy: true` to `useMatchRoute` so parent tabs stay highlighted on nested routes, matching the desktop `Link`'s existing behavior.

## Verification
- Navigate to a set detail page (`.../sets/$setSlug`) on mobile; the Sets tab stays highlighted.
- Navigate to `.../schedule/timeline` or `.../schedule/list` on mobile; the Schedule tab stays highlighted.
- Switch between tabs (Sets, Schedule, Map, Info, Social, Explore); exactly one tab is highlighted at a time, no cross-activation.
- Desktop tab bar behavior is unchanged (still uses `Link activeProps`).

---
_Generated by [Claude Code](https://claude.ai/code/session_014iiisPt8nyYMGcYfh9p5yo)_