### PR TITLE
feat(schedule): add timeline nav prototype

### DIFF
--- a/src/components/prototype/PrototypeSwitcher.tsx
+++ b/src/components/prototype/PrototypeSwitcher.tsx
@@ -1,0 +1,85 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with
+// src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/.
+//
+// Floating variant switcher: arrows (and ←/→ keys) cycle the `?variant=`
+// search param. Only rendered in dev builds, and only when a variant is
+// already active (the prototype path never renders for normal users).
+import { useEffect } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+const ROUTE =
+  "/festivals/$festivalSlug/editions/$editionSlug/schedule/timeline" as const;
+
+const VARIANTS = [
+  { key: "a", name: "Slim jump bar" },
+  { key: "b", name: "Segmented rail" },
+  { key: "c", name: "Mini-map" },
+] as const;
+
+export function PrototypeSwitcher() {
+  const { variant } = useSearch({ from: ROUTE });
+  const navigate = useNavigate({ from: ROUTE });
+
+  const index = Math.max(
+    0,
+    VARIANTS.findIndex((v) => v.key === variant),
+  );
+  const current = VARIANTS[index];
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === "ArrowLeft") cycle(-1);
+      if (e.key === "ArrowRight") cycle(1);
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  });
+
+  if (!import.meta.env.DEV) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
+      <div className="flex items-center gap-2 rounded-full border border-white/20 bg-gray-950 px-3 py-1.5 shadow-xl">
+        <button
+          type="button"
+          onClick={() => cycle(-1)}
+          className="text-white/70 hover:text-white"
+          aria-label="Previous variant"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <span className="whitespace-nowrap font-mono text-xs text-white">
+          {current.key.toUpperCase()} — {current.name}
+        </span>
+        <button
+          type="button"
+          onClick={() => cycle(1)}
+          className="text-white/70 hover:text-white"
+          aria-label="Next variant"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+
+  function cycle(delta: number) {
+    const next = VARIANTS[(index + delta + VARIANTS.length) % VARIANTS.length];
+    navigate({
+      to: ".",
+      search: (prev) => ({ ...prev, variant: next.key }),
+      replace: true,
+    });
+  }
+}

--- a/src/components/prototype/PrototypeSwitcher.tsx
+++ b/src/components/prototype/PrototypeSwitcher.tsx
@@ -2,8 +2,9 @@
 // src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/.
 //
 // Floating variant switcher: arrows (and ←/→ keys) cycle the `?variant=`
-// search param. Only rendered in dev builds, and only when a variant is
-// already active (the prototype path never renders for normal users).
+// search param. Renders only when a variant is already active in the URL —
+// normal users never see it, and preview deploys (production builds) can
+// still flip variants when sharing the prototype.
 import { useEffect } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -46,7 +47,7 @@ export function PrototypeSwitcher() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   });
 
-  if (!import.meta.env.DEV) return null;
+  if (!variant) return null;
 
   return (
     <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -40,6 +40,9 @@ export const timelineSearchSchema = z.object({
   day: z.string().catch("all"),
   time: z.enum(["all", "morning", "afternoon", "evening"]).catch("all"),
   stages: z.array(z.string()).catch([]),
+  // PROTOTYPE (timeline nav & filtering) — remove with src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/
+  variant: z.enum(["a", "b", "c"]).optional(),
+  scrollTo: z.string().optional(),
 });
 
 export type TimelineSearch = z.infer<typeof timelineSearchSchema>;

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
+import { useRouteContext, useSearch } from "@tanstack/react-router";
+import { TimelinePrototype } from "./prototype/TimelinePrototype";
 import { useScheduleData } from "@/hooks/useScheduleData";
 import { calculateTimelineData } from "@/lib/timelineCalculator";
 import { StageLabels } from "./StageLabels";
@@ -33,6 +34,10 @@ export function Timeline() {
     time: selectedTime,
     stages: selectedStages,
   } = useTimelineUrlState("timeline");
+  // PROTOTYPE (timeline nav & filtering) — remove with ./prototype/
+  const { variant: prototypeVariant } = useSearch({
+    from: "/festivals/$festivalSlug/editions/$editionSlug/schedule/timeline",
+  });
 
   const timelineData = useMemo(() => {
     if (!edition.start_date || !edition.end_date) {
@@ -125,6 +130,18 @@ export function Timeline() {
 
   if (!canShowTime) {
     return <ScheduleNotRevealedPlaceholder />;
+  }
+
+  if (prototypeVariant) {
+    return (
+      <TimelinePrototype
+        variant={prototypeVariant}
+        scheduleDays={scheduleDays}
+        stages={stages}
+        edition={edition}
+        timezone={festival.timezone}
+      />
+    );
   }
 
   return (

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -128,10 +128,9 @@ export function Timeline() {
     );
   }
 
-  if (!canShowTime) {
-    return <ScheduleNotRevealedPlaceholder />;
-  }
-
+  // PROTOTYPE (timeline nav & filtering) — remove with ./prototype/. Bypasses
+  // the reveal-level gate below: testing nav/filtering shouldn't depend on
+  // whether the real schedule has been publicly announced yet.
   if (prototypeVariant) {
     return (
       <TimelinePrototype
@@ -142,6 +141,10 @@ export function Timeline() {
         timezone={festival.timezone}
       />
     );
+  }
+
+  if (!canShowTime) {
+    return <ScheduleNotRevealedPlaceholder />;
   }
 
   return (

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -128,9 +128,10 @@ export function Timeline() {
     );
   }
 
-  // PROTOTYPE (timeline nav & filtering) — remove with ./prototype/. Bypasses
-  // the reveal-level gate below: testing nav/filtering shouldn't depend on
-  // whether the real schedule has been publicly announced yet.
+  if (!canShowTime) {
+    return <ScheduleNotRevealedPlaceholder />;
+  }
+
   if (prototypeVariant) {
     return (
       <TimelinePrototype
@@ -141,10 +142,6 @@ export function Timeline() {
         timezone={festival.timezone}
       />
     );
-  }
-
-  if (!canShowTime) {
-    return <ScheduleNotRevealedPlaceholder />;
   }
 
   return (

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
@@ -1,0 +1,74 @@
+# PROTOTYPE — timeline navigation, filtering & my-vote chips
+
+**Throwaway code.** Three variants of timeline navigation + my-vote filtering,
+switchable via `?variant=`, on the existing
+`/festivals/$festivalSlug/editions/$editionSlug/schedule/timeline` route.
+Delete this folder (plus `src/components/prototype/` and the two
+PROTOTYPE-marked blocks in `src/lib/searchSchemas.ts` and
+`../Timeline.tsx`) once the verdicts below are captured.
+
+## How to run
+
+```
+pnpm run dev
+```
+
+Open any edition's timeline with a variant param, e.g.:
+
+```
+/festivals/<festival>/editions/<edition>/schedule/timeline?variant=a
+```
+
+Flip variants with the floating bottom bar or the ←/→ keys. Without
+`?variant=`, the production timeline renders untouched. The switcher is
+dev-build only.
+
+Demo affordances (prototype-only, the real implementation drops both):
+
+- "Now" is **faked** to ~60% into the edition window (still ticks every 60s)
+  so the Now button + current-time indicator are always demoable.
+- Logged out, "my votes" are **fake** (deterministic per set); logged in, your
+  real votes are used. The real implementation hides the chips when logged out.
+
+## The variants
+
+| | Navigation | Scroll on jump | My-vote chips | Now indicator |
+|---|---|---|---|---|
+| **a — Slim jump bar** | sticky ghost day buttons + Now pill (agreed design, literal) | smooth | inside collapsed filter panel | thin fuchsia line + dot |
+| **b — Segmented rail** | segmented control highlighting the day at viewport center | instant | inline row above strip, with counts | gradient line + "now HH:mm" bubble |
+| **c — Mini-map** | proportional overview strip, draggable viewport window, click to jump | smooth | compact icon chips in map header | dashed white line |
+
+All variants share the agreed `scrollTo` URL mechanics (`useScrollToUrl.ts`):
+debounced ~300ms scroll-idle write, 5-minute rounding, history replace,
+one-way ownership, mount precedence `scrollTo` → day filter → now−1h →
+festival start. Back-from-a-set-page restores position in every variant.
+
+## Questions to answer (fill in verdicts, then delete the folder)
+
+1. **Does URL-driven jumping feel right?** Smooth (a, c) vs instant (b) on
+   day/Now clicks; jank while swiping from the debounced `scrollTo` writes;
+   does back-restoration land where you expect?
+   - VERDICT:
+2. **Does the nav-vs-filter split read?** Do test users reach for the jump bar
+   to move and the Filters panel to narrow, or do they tap "Fri" expecting a
+   filter? (b's active-day highlight may make it read *more* like a filter —
+   that's deliberate, to probe the confusion.)
+   - VERDICT:
+3. **Vote-chip placement and form.** In-panel (a) vs inline with counts (b) vs
+   compact-in-minimap (c)? Does "my schedule" (Must Go + Interested) feel like
+   a two-tap primary use case?
+   - VERDICT:
+4. **Current-time indicator + jump bar visual treatment.** Which of the three
+   treatments has enough contrast without shouting?
+   - VERDICT:
+
+Open sub-question surfaced while building: when the day *filter* is active,
+the jump bar only shows the filtered day's button (nav operates on what's
+rendered). Right call, or should all days stay and clear the filter on jump?
+   - VERDICT:
+
+## After verdicts
+
+Fold amendments into the drafted PRD, publish it to GitHub Issues with
+`ready-for-agent`, and delete the prototype code (see the deletion list at
+the top).

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
@@ -35,14 +35,33 @@ Demo affordances (prototype-only, the real implementation drops both):
 
 | | Navigation | Scroll on jump | My-vote chips | Now indicator |
 |---|---|---|---|---|
-| **a — Slim jump bar** | sticky ghost day buttons + Now pill (agreed design, literal) | smooth | inside collapsed filter panel | thin fuchsia line + dot |
+| **a — Slim jump bar** | sticky ghost day buttons + Now pill (agreed design, literal) | smooth | inside filters drawer | thin fuchsia line + dot |
 | **b — Segmented rail** | segmented control highlighting the day at viewport center | instant | inline row above strip, with counts | gradient line + "now HH:mm" bubble |
-| **c — Mini-map** | proportional overview strip, draggable viewport window, click to jump | smooth | compact icon chips in map header | dashed white line |
+| **c — Mini-map** | collapsed by default to a slim day-button strip (same as a); an optional "Show overview" toggle reveals the draggable density map | smooth | compact icon chips in map header | dashed white line |
 
 All variants share the agreed `scrollTo` URL mechanics (`useScrollToUrl.ts`):
 debounced ~300ms scroll-idle write, 5-minute rounding, history replace,
 one-way ownership, mount precedence `scrollTo` → day filter → now−1h →
 festival start. Back-from-a-set-page restores position in every variant.
+
+### Round 2 changes, from first-round feedback
+
+Two users tried round 1: one preferred **a**, the other loved **c**'s mini-map
+for being visual — but flagged the always-visible 3-variant switcher as
+intimidating without a label. Fed back in:
+
+- **Filters moved into a bottom sheet** (`PrototypeFilters.tsx`, via shadcn
+  `Sheet`) instead of an inline expanding panel, in all three variants — the
+  schedule stays the visual focus instead of competing with an expanded
+  filter block for space.
+- **Mini-map (c) now collapses to a's slim day-strip by default**, with a
+  "Show overview" toggle to reveal the full colored density map. What the
+  tester actually valued was one control doing "jump to a day" + "filter by
+  my votes" together — not the density map being visually loud all the time.
+- **Day labels now include the date** (`"Thu 13"`, not bare `"Thu"`) — a real
+  bug, not a preference: multi-weekend festivals (Tomorrowland's two
+  long weekends) repeat weekday names, and the bare-weekday jump bar/segmented
+  rail/mini-map ticks had no way to tell the two Thursdays apart.
 
 ## Questions to answer (fill in verdicts, then delete the folder)
 

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
@@ -63,32 +63,68 @@ intimidating without a label. Fed back in:
   long weekends) repeat weekday names, and the bare-weekday jump bar/segmented
   rail/mini-map ticks had no way to tell the two Thursdays apart.
 
-## Questions to answer (fill in verdicts, then delete the folder)
+## Questions to answer — VERDICTS (tested with 2 real users, round 1 + round 2)
 
 1. **Does URL-driven jumping feel right?** Smooth (a, c) vs instant (b) on
    day/Now clicks; jank while swiping from the debounced `scrollTo` writes;
    does back-restoration land where you expect?
-   - VERDICT:
+   - **VERDICT: yes.** No jank reported from the debounced writes; a tester
+     called the smooth transition a "wow." Reload and back-navigation both
+     restored position correctly. **Smooth wins over instant** (b's approach
+     dropped).
 2. **Does the nav-vs-filter split read?** Do test users reach for the jump bar
    to move and the Filters panel to narrow, or do they tap "Fri" expecting a
    filter? (b's active-day highlight may make it read *more* like a filter —
    that's deliberate, to probe the confusion.)
-   - VERDICT:
+   - **VERDICT: reads fine.** At least one tester found it "fairly clear" —
+     no one reached for a day button expecting it to filter.
 3. **Vote-chip placement and form.** In-panel (a) vs inline with counts (b) vs
    compact-in-minimap (c)? Does "my schedule" (Must Go + Interested) feel like
    a two-tap primary use case?
-   - VERDICT:
+   - **VERDICT: the standout feature.** A tester specifically called out that
+     it "does something amazing, filters just by my markers, exactly what's
+     needed." Confirms the two-tap "my schedule" hypothesis. **Winning form:
+     compact chips paired with the map/nav control** (c), not a separate
+     inline row (b) or panel-only (a) — one control doing "jump to a day" +
+     "filter by my votes" together is what landed, not the chips alone.
 4. **Current-time indicator + jump bar visual treatment.** Which of the three
    treatments has enough contrast without shouting?
-   - VERDICT:
+   - **VERDICT: no complaints either way**, weak signal. Shipping with c's
+     dashed-line treatment since c is the overall winner — nothing in
+     testing argues for switching it.
 
 Open sub-question surfaced while building: when the day *filter* is active,
 the jump bar only shows the filtered day's button (nav operates on what's
 rendered). Right call, or should all days stay and clear the filter on jump?
-   - VERDICT:
+   - **VERDICT: keep current behavior** (only show the filtered day's
+     button) — decided directly with the product owner, **not** tested with
+     real users. Flag as lower-confidence than the others if revisited.
+
+## Winning direction: synthesized "c", not literally round 1's mini-map
+
+Round 1: one tester preferred **a**; the other loved **c**'s mini-map for
+being visual, but flagged the noise (always-visible density map, plain
+switcher) and general clutter. Round 2 folded that into a synthesis, and
+**that synthesis is the final winner**:
+
+- Collapsed by default to **a**'s slim day-strip + Now pill; an optional
+  "Show overview" toggle reveals the full draggable density map. What
+  testers valued was the control doing "jump to a day" + "filter by my
+  votes" together, not the map being loud all the time.
+- Filters live in a bottom sheet (`Sheet`, `side="bottom"`) instead of an
+  inline expanding panel, uniform on mobile and desktop (not tested against
+  a responsive desktop-side-sheet alternative — decided to keep one
+  interaction pattern rather than validate two).
+- The Filters trigger sits inline in the same toolbar row as the nav
+  controls (round 1 feedback: it sat alone on its own line, wasting space).
+- Day labels always carry the date (`"Thu 13"`) — see Round 2 note above,
+  a correctness fix for multi-weekend festivals, not a preference.
 
 ## After verdicts
 
-Fold amendments into the drafted PRD, publish it to GitHub Issues with
-`ready-for-agent`, and delete the prototype code (see the deletion list at
-the top).
+Handed off via `/handoff` to a fresh session to run `/to-prd` and publish to
+GitHub Issues with `ready-for-agent`. Two pre-existing related issues found
+mid-prototype that the PRD session should reconcile: **#105** ("Jump to
+current time in the Schedule timeline") and **#154** (orphaned
+`TimelineControls.tsx`/`TimelineNavigation.tsx` stubs). Delete this prototype
+folder (see the deletion list at the top) once the PRD is published.

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NOTES.md
@@ -20,8 +20,9 @@ Open any edition's timeline with a variant param, e.g.:
 ```
 
 Flip variants with the floating bottom bar or the ←/→ keys. Without
-`?variant=`, the production timeline renders untouched. The switcher is
-dev-build only.
+`?variant=`, the production timeline renders untouched (switcher included —
+it only mounts when a variant is active in the URL), so preview deploys can
+be shared safely.
 
 Demo affordances (prototype-only, the real implementation drops both):
 

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NowIndicator.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/NowIndicator.tsx
@@ -1,0 +1,55 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// Three visual treatments for the current-time line, one per variant, to
+// answer "enough contrast against the purple/white-on-dark styling without
+// shouting?"
+import { formatInTimeZone } from "date-fns-tz";
+
+interface NowIndicatorProps {
+  left: number;
+  now: Date;
+  timezone: string;
+  treatment: "line" | "bubble" | "dashed";
+}
+
+export function NowIndicator({
+  left,
+  now,
+  timezone,
+  treatment,
+}: NowIndicatorProps) {
+  if (treatment === "bubble") {
+    return (
+      <div
+        className="absolute inset-y-0 z-20 pointer-events-none"
+        style={{ left: `${left}px` }}
+      >
+        <div className="absolute inset-y-0 w-0.5 bg-gradient-to-b from-fuchsia-400 via-fuchsia-400/60 to-transparent" />
+        <div className="absolute top-0 -translate-x-1/2 rounded-full bg-fuchsia-500 px-2 py-0.5 text-[10px] font-semibold text-white whitespace-nowrap shadow-lg">
+          now {formatInTimeZone(now, timezone, "HH:mm")}
+        </div>
+      </div>
+    );
+  }
+
+  if (treatment === "dashed") {
+    return (
+      <div
+        className="absolute inset-y-0 z-20 pointer-events-none border-l-2 border-dashed border-white/50"
+        style={{ left: `${left}px` }}
+      >
+        <div className="absolute top-0 h-2 w-2 -translate-x-[5px] rounded-full bg-white/80" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="absolute inset-y-0 z-20 pointer-events-none"
+      style={{ left: `${left}px` }}
+    >
+      <div className="absolute inset-y-0 w-0.5 bg-fuchsia-400/90" />
+      <div className="absolute top-0 h-2 w-2 -translate-x-[3px] rounded-full bg-fuchsia-400" />
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/PrototypeCanvas.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/PrototypeCanvas.tsx
@@ -1,0 +1,78 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// The timeline scroll surface: production TimeScale + StageRows, but with the
+// scroll container ref owned by the variant (for scrollTo/jump control) and a
+// current-time indicator overlaid on the strip.
+import type { RefObject } from "react";
+import { TimeScale } from "../TimeScale";
+import { StageRow } from "../StageRow";
+import { StageLabels } from "../StageLabels";
+import { NowIndicator } from "./NowIndicator";
+import { PX_PER_MINUTE, CONTENT_OFFSET_PX } from "./useScrollToUrl";
+import type { TimelineData } from "@/lib/timelineCalculator";
+
+interface PrototypeCanvasProps {
+  timelineData: TimelineData;
+  timezone: string;
+  scrollRef: RefObject<HTMLDivElement>;
+  now: Date | null;
+  nowTreatment: "line" | "bubble" | "dashed";
+}
+
+export function PrototypeCanvas({
+  timelineData,
+  timezone,
+  scrollRef,
+  now,
+  nowTreatment,
+}: PrototypeCanvasProps) {
+  const showNow =
+    now !== null &&
+    now >= timelineData.festivalStart &&
+    now <= timelineData.festivalEnd;
+  const nowLeft = now
+    ? ((now.getTime() - timelineData.festivalStart.getTime()) / 60_000) *
+        PX_PER_MINUTE +
+      CONTENT_OFFSET_PX
+    : 0;
+
+  return (
+    <div className="relative bg-white/5 rounded-lg p-4">
+      <StageLabels stages={timelineData.stages} />
+      <div
+        ref={scrollRef}
+        className="overflow-x-auto overflow-y-hidden pb-20"
+      >
+        <div
+          className="relative"
+          style={{ minWidth: timelineData.totalWidth }}
+        >
+          <TimeScale
+            timeSlots={timelineData.timeSlots}
+            totalWidth={timelineData.totalWidth}
+            scrollContainerRef={scrollRef}
+            timezone={timezone}
+          />
+          <div className="space-y-12 mt-28">
+            {timelineData.stages.map((stage) => (
+              <StageRow
+                key={stage.name}
+                stage={stage}
+                totalWidth={timelineData.totalWidth}
+                timezone={timezone}
+              />
+            ))}
+          </div>
+          {showNow && (
+            <NowIndicator
+              left={nowLeft}
+              now={now}
+              timezone={timezone}
+              treatment={nowTreatment}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/PrototypeFilters.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/PrototypeFilters.tsx
@@ -1,18 +1,28 @@
 // PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
 //
-// The shared collapsed filter panel ("filtering narrows, it never scrolls"):
-// day / time-of-day / stage, plus an optional my-vote chips slot (variant A
-// places the chips here; B and C surface them elsewhere). Vote selections
-// count toward the filter badge either way.
+// The shared filter drawer ("filtering narrows, it never scrolls"): day /
+// time-of-day / stage in a bottom sheet, not an always-inline panel — so the
+// schedule stays the visual focus instead of competing with an expanded
+// filter block. Optional my-vote chips slot (variant a places chips here; b
+// keeps its own always-visible inline row). Vote selections still count
+// toward the badge either way.
 import { useState, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { Vote } from "lucide-react";
+import { Filter, Vote, X } from "lucide-react";
 import { DayFilterSelect } from "../../DayFilterSelect";
 import { TimeFilterSelect } from "../../TimeFilterSelect";
 import { StageFilterButtons } from "../../StageFilterButtons";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
-import { FilterToggle } from "@/components/filters/FilterToggle";
-import { FilterContainer } from "@/components/filters/FilterContainer";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 
 interface PrototypeFiltersProps {
@@ -26,7 +36,7 @@ export function PrototypeFilters({
   voteFilterCount,
   onClearVotes,
 }: PrototypeFiltersProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const { day, time, stages, updateDay, updateTime, updateStages } =
     useTimelineUrlState("timeline");
   const navigate = useNavigate({
@@ -41,26 +51,56 @@ export function PrototypeFilters({
   const hasActiveFilters = activeFilterCount > 0;
 
   return (
-    <FilterContainer>
-      <div className="flex items-center gap-2 flex-wrap">
-        <h3 className="text-purple-100 font-medium">Filters</h3>
-        <div className="ml-auto" />
+    <div className="flex items-center gap-2">
+      {hasActiveFilters && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={clearAll}
+          className="text-red-400 hover:text-red-300 hover:bg-red-400/10"
+        >
+          <X className="h-3 w-3 mr-1" />
+          <span className="hidden sm:inline">Clear</span>
+        </Button>
+      )}
 
-        <FilterToggle
-          isExpanded={isExpanded}
-          onToggle={() => setIsExpanded(!isExpanded)}
-          hasActiveFilters={hasActiveFilters}
-          activeFilterCount={activeFilterCount}
-          label="Filters"
-          onClearFilters={hasActiveFilters ? clearAll : undefined}
-        />
-      </div>
-
-      {isExpanded && (
-        <div className="mt-4">
+      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+        <SheetTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "flex items-center gap-2",
+              hasActiveFilters
+                ? "bg-purple-600/50 text-purple-100 hover:bg-purple-600/60"
+                : "text-purple-300 hover:text-purple-100",
+            )}
+          >
+            {hasActiveFilters && (
+              <Badge
+                variant="secondary"
+                className="bg-purple-800/50 text-purple-100"
+              >
+                {activeFilterCount}
+              </Badge>
+            )}
+            <Filter className="h-4 w-4" />
+            <span className="hidden md:inline">Filters</span>
+          </Button>
+        </SheetTrigger>
+        <SheetContent
+          side="bottom"
+          className="bg-gray-900 border-purple-400/30 text-purple-100"
+        >
+          <SheetHeader>
+            <SheetTitle className="text-purple-100">Filters</SheetTitle>
+            <SheetDescription className="text-purple-300">
+              Narrow the schedule by day, time, stage, or your own votes.
+            </SheetDescription>
+          </SheetHeader>
           <div
             className={cn(
-              "grid grid-cols-1 gap-3 md:gap-4",
+              "grid grid-cols-1 gap-4 mt-4",
               voteChips ? "md:grid-cols-4" : "md:grid-cols-3",
             )}
           >
@@ -82,9 +122,9 @@ export function PrototypeFilters({
               </div>
             )}
           </div>
-        </div>
-      )}
-    </FilterContainer>
+        </SheetContent>
+      </Sheet>
+    </div>
   );
 
   function handleStageToggle(stageId: string) {

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/PrototypeFilters.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/PrototypeFilters.tsx
@@ -1,0 +1,109 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// The shared collapsed filter panel ("filtering narrows, it never scrolls"):
+// day / time-of-day / stage, plus an optional my-vote chips slot (variant A
+// places the chips here; B and C surface them elsewhere). Vote selections
+// count toward the filter badge either way.
+import { useState, type ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Vote } from "lucide-react";
+import { DayFilterSelect } from "../../DayFilterSelect";
+import { TimeFilterSelect } from "../../TimeFilterSelect";
+import { StageFilterButtons } from "../../StageFilterButtons";
+import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
+import { FilterToggle } from "@/components/filters/FilterToggle";
+import { FilterContainer } from "@/components/filters/FilterContainer";
+import { cn } from "@/lib/utils";
+
+interface PrototypeFiltersProps {
+  voteChips?: ReactNode;
+  voteFilterCount: number;
+  onClearVotes: () => void;
+}
+
+export function PrototypeFilters({
+  voteChips,
+  voteFilterCount,
+  onClearVotes,
+}: PrototypeFiltersProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { day, time, stages, updateDay, updateTime, updateStages } =
+    useTimelineUrlState("timeline");
+  const navigate = useNavigate({
+    from: "/festivals/$festivalSlug/editions/$editionSlug/schedule/timeline",
+  });
+
+  const activeFilterCount =
+    (day !== "all" ? 1 : 0) +
+    (time !== "all" ? 1 : 0) +
+    stages.length +
+    voteFilterCount;
+  const hasActiveFilters = activeFilterCount > 0;
+
+  return (
+    <FilterContainer>
+      <div className="flex items-center gap-2 flex-wrap">
+        <h3 className="text-purple-100 font-medium">Filters</h3>
+        <div className="ml-auto" />
+
+        <FilterToggle
+          isExpanded={isExpanded}
+          onToggle={() => setIsExpanded(!isExpanded)}
+          hasActiveFilters={hasActiveFilters}
+          activeFilterCount={activeFilterCount}
+          label="Filters"
+          onClearFilters={hasActiveFilters ? clearAll : undefined}
+        />
+      </div>
+
+      {isExpanded && (
+        <div className="mt-4">
+          <div
+            className={cn(
+              "grid grid-cols-1 gap-3 md:gap-4",
+              voteChips ? "md:grid-cols-4" : "md:grid-cols-3",
+            )}
+          >
+            <DayFilterSelect selectedDay={day} onDayChange={updateDay} />
+            <TimeFilterSelect selectedTime={time} onTimeChange={updateTime} />
+            <StageFilterButtons
+              selectedStages={stages}
+              onStageToggle={handleStageToggle}
+            />
+            {voteChips && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Vote className="h-3 w-3 text-purple-300" />
+                  <label className="text-sm font-medium text-purple-200">
+                    My votes
+                  </label>
+                </div>
+                {voteChips}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </FilterContainer>
+  );
+
+  function handleStageToggle(stageId: string) {
+    const newStages = stages.includes(stageId)
+      ? stages.filter((id) => id !== stageId)
+      : [...stages, stageId];
+    updateStages(newStages);
+  }
+
+  function clearAll() {
+    onClearVotes();
+    navigate({
+      to: ".",
+      search: (prev) => ({
+        view: prev.view,
+        variant: prev.variant,
+        scrollTo: prev.scrollTo,
+      }),
+      replace: true,
+    });
+  }
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/TimelinePrototype.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/TimelinePrototype.tsx
@@ -134,8 +134,10 @@ export function TimelinePrototype({
       if (!earliest) return [];
       return [
         {
+          // "EEE d" (not just "EEE"): multi-weekend festivals repeat weekday
+          // names (Tomorrowland's two Thursdays), so the date disambiguates.
           key: day.date,
-          label: format(parseISO(day.date), "EEE"),
+          label: format(parseISO(day.date), "EEE d"),
           start: earliest,
         },
       ];

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/TimelinePrototype.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/TimelinePrototype.tsx
@@ -1,0 +1,227 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete this folder when
+// the verdicts are captured (see NOTES.md).
+//
+// Three variants of timeline navigation + my-vote filtering, switchable via
+// `?variant=` on the existing schedule/timeline route:
+//   a — Slim jump bar (agreed design: ghost day buttons + Now pill, smooth)
+//   b — Segmented rail (active-day highlight, instant jumps, inline chips)
+//   c — Mini-map (draggable overview strip, compact chips)
+import { useMemo, useState } from "react";
+import { format, parseISO } from "date-fns";
+import { calculateTimelineData } from "@/lib/timelineCalculator";
+import { getFestivalHour } from "@/lib/timeUtils";
+import { getVoteConfig, getVoteValue, type VoteType } from "@/lib/voteConfig";
+import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
+import type { ScheduleDay, ScheduleSet } from "@/hooks/useScheduleData";
+import type { Stage } from "@/api/stages/types";
+import { useFakeNow } from "./useFakeNow";
+import { usePrototypeVotes } from "./usePrototypeVotes";
+import { VariantSlimBar } from "./VariantSlimBar";
+import { VariantSegmented } from "./VariantSegmented";
+import { VariantMinimap } from "./VariantMinimap";
+import type { DayJump } from "./types";
+import { PrototypeSwitcher } from "@/components/prototype/PrototypeSwitcher";
+
+interface TimelinePrototypeProps {
+  variant: "a" | "b" | "c";
+  scheduleDays: ScheduleDay[];
+  stages: Stage[];
+  edition: { start_date: string | null; end_date: string | null };
+  timezone: string;
+}
+
+export function TimelinePrototype({
+  variant,
+  scheduleDays,
+  stages,
+  edition,
+  timezone,
+}: TimelinePrototypeProps) {
+  const {
+    day: selectedDay,
+    time: selectedTime,
+    stages: selectedStages,
+  } = useTimelineUrlState("timeline");
+  const { getVote, isFake } = usePrototypeVotes();
+  const [voteFilter, setVoteFilter] = useState<VoteType[]>([]);
+
+  const now = useFakeNow(
+    edition.start_date ? new Date(edition.start_date) : null,
+    edition.end_date ? new Date(edition.end_date) : null,
+  );
+
+  const timelineData = useMemo(() => {
+    if (!edition.start_date || !edition.end_date) return null;
+
+    const selectedVoteValues: number[] = voteFilter.map(getVoteValue);
+
+    function matchesVotes(set: ScheduleSet) {
+      if (selectedVoteValues.length === 0) return true;
+      const vote = getVote(set.id);
+      return vote !== undefined && selectedVoteValues.includes(vote);
+    }
+
+    // Same day/time/stage filtering as the production Timeline, plus votes.
+    const filteredScheduleDays = scheduleDays.map((day) => {
+      if (selectedDay !== "all" && day.date !== selectedDay) {
+        return { ...day, stages: [] };
+      }
+
+      const filteredStages = day.stages
+        .filter(
+          (stage) =>
+            selectedStages.length === 0 || selectedStages.includes(stage.id),
+        )
+        .map((stage) => ({
+          ...stage,
+          sets: stage.sets.filter((set) => {
+            if (!matchesVotes(set)) return false;
+            if (selectedTime !== "all" && set.startTime) {
+              const hour = getFestivalHour(
+                set.startTime.toISOString(),
+                timezone,
+              );
+              if (hour === null) return false;
+              switch (selectedTime) {
+                case "morning":
+                  return hour >= 6 && hour < 12;
+                case "afternoon":
+                  return hour >= 12 && hour < 18;
+                case "evening":
+                  return hour >= 18 && hour < 24;
+                default:
+                  return true;
+              }
+            }
+            return true;
+          }),
+        }));
+
+      return { ...day, stages: filteredStages };
+    });
+
+    return calculateTimelineData(
+      new Date(edition.start_date),
+      new Date(edition.end_date),
+      filteredScheduleDays,
+      stages,
+    );
+  }, [
+    edition,
+    scheduleDays,
+    selectedDay,
+    selectedTime,
+    selectedStages,
+    stages,
+    timezone,
+    voteFilter,
+    getVote,
+  ]);
+
+  // Jump-bar days derive from the *filtered* strip: nav operates on what is
+  // rendered (open sub-question — see NOTES.md).
+  const days = useMemo<DayJump[]>(() => {
+    return scheduleDays.flatMap((day) => {
+      if (selectedDay !== "all" && day.date !== selectedDay) return [];
+      let earliest: Date | null = null;
+      day.stages.forEach((stage) => {
+        stage.sets.forEach((set) => {
+          if (set.startTime && (!earliest || set.startTime < earliest)) {
+            earliest = set.startTime;
+          }
+        });
+      });
+      if (!earliest) return [];
+      return [
+        {
+          key: day.date,
+          label: format(parseISO(day.date), "EEE"),
+          start: earliest,
+        },
+      ];
+    });
+  }, [scheduleDays, selectedDay]);
+
+  const voteCounts = useMemo(() => {
+    const counts: Partial<Record<VoteType, number>> = {};
+    scheduleDays.forEach((day) => {
+      day.stages.forEach((stage) => {
+        stage.sets.forEach((set) => {
+          const vote = getVote(set.id);
+          if (vote === undefined) return;
+          const voteType = getVoteConfig(vote);
+          if (!voteType) return;
+          counts[voteType] = (counts[voteType] ?? 0) + 1;
+        });
+      });
+    });
+    return counts;
+  }, [scheduleDays, getVote]);
+
+  // Mount precedence after scrollTo (handled in useScrollToUrl): day filter
+  // start, else now - 1h context, else festival start.
+  const mountFallback = useMemo(() => {
+    if (selectedDay !== "all") {
+      const day = days.find((d) => d.key === selectedDay);
+      if (day) return day.start;
+    }
+    if (
+      timelineData &&
+      now &&
+      now >= timelineData.festivalStart &&
+      now <= timelineData.festivalEnd
+    ) {
+      return new Date(now.getTime() - 60 * 60_000);
+    }
+    return null;
+  }, [selectedDay, days, timelineData, now]);
+
+  const variantProps = timelineData && {
+    timelineData,
+    timezone,
+    days,
+    now,
+    mountFallback,
+    voteFilter,
+    voteCounts,
+    onToggleVote: handleToggleVote,
+    onClearVotes: handleClearVotes,
+  };
+
+  return (
+    <>
+      {variantProps ? (
+        <>
+          {variant === "a" && <VariantSlimBar {...variantProps} />}
+          {variant === "b" && <VariantSegmented {...variantProps} />}
+          {variant === "c" && (
+            <VariantMinimap {...variantProps} getVote={getVote} />
+          )}
+        </>
+      ) : (
+        <div className="text-center text-purple-300 py-12">
+          <p>No sets match the current filters.</p>
+        </div>
+      )}
+      {isFake && (
+        <p className="mt-3 text-center text-xs text-purple-400/70">
+          Prototype: not logged in, showing fake “my votes” so the chips are
+          demoable.
+        </p>
+      )}
+      <PrototypeSwitcher />
+    </>
+  );
+
+  function handleToggleVote(voteType: VoteType) {
+    setVoteFilter((prev) =>
+      prev.includes(voteType)
+        ? prev.filter((v) => v !== voteType)
+        : [...prev, voteType],
+    );
+  }
+
+  function handleClearVotes() {
+    setVoteFilter([]);
+  }
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantMinimap.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantMinimap.tsx
@@ -1,0 +1,233 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// Variant C — "Mini-map":
+// a proportional overview strip of the whole festival (day boundaries, set
+// density per stage, voted sets in vote colors) with a draggable viewport
+// window; click anywhere on the map to jump (smooth). Compact icon-only vote
+// chips live in the mini-map header.
+import { useEffect, useRef, useState } from "react";
+import { Clock } from "lucide-react";
+import { PrototypeCanvas } from "./PrototypeCanvas";
+import { PrototypeFilters } from "./PrototypeFilters";
+import { VoteChips } from "./VoteChips";
+import {
+  useScrollToUrl,
+  PX_PER_MINUTE,
+  CONTENT_OFFSET_PX,
+} from "./useScrollToUrl";
+import { isNowInWindow, type VariantProps } from "./types";
+import { DEFAULT_STAGE_COLOR } from "@/lib/constants/stages";
+
+const MAP_HEIGHT_PX = 64;
+const MAP_LABEL_SPACE_PX = 16;
+
+const VOTE_HEX: Record<number, string> = {
+  2: "#ea580c", // orange-600, Must Go
+  1: "#2563eb", // blue-600, Interested
+  [-1]: "#4b5563", // gray-600, Won't Go
+};
+
+interface VariantMinimapProps extends VariantProps {
+  getVote: (setId: string) => number | undefined;
+}
+
+export function VariantMinimap({
+  timelineData,
+  timezone,
+  days,
+  now,
+  mountFallback,
+  voteFilter,
+  onToggleVote,
+  onClearVotes,
+  getVote,
+}: VariantMinimapProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [viewport, setViewport] = useState({ left: 0, width: 0 });
+  const [mapWidth, setMapWidth] = useState(0);
+
+  const { jumpToCenter } = useScrollToUrl({
+    scrollRef,
+    festivalStart: timelineData.festivalStart,
+    timezone,
+    smooth: true,
+    mountFallbackLeftEdge: mountFallback,
+  });
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    function update() {
+      setViewport({ left: el!.scrollLeft, width: el!.clientWidth });
+      setMapWidth(mapRef.current?.clientWidth ?? 0);
+    }
+
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      el.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  const scale = mapWidth > 0 ? mapWidth / timelineData.totalWidth : 0;
+  const showNow = isNowInWindow(now, timelineData);
+  const nowX = showNow
+    ? (((now.getTime() - timelineData.festivalStart.getTime()) / 60_000) *
+        PX_PER_MINUTE +
+        CONTENT_OFFSET_PX) *
+      scale
+    : 0;
+  const stageCount = timelineData.stages.length;
+  const rowHeight =
+    stageCount > 0
+      ? Math.max(
+          3,
+          Math.floor((MAP_HEIGHT_PX - MAP_LABEL_SPACE_PX - 4) / stageCount),
+        )
+      : 4;
+
+  return (
+    <div className="space-y-4">
+      <PrototypeFilters
+        voteFilterCount={voteFilter.length}
+        onClearVotes={onClearVotes}
+      />
+
+      <div className="space-y-1.5">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs uppercase tracking-wide text-purple-400">
+            Overview — click or drag to move
+          </span>
+          <div className="flex items-center gap-2">
+            <VoteChips compact selected={voteFilter} onToggle={onToggleVote} />
+            {showNow && (
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded-full bg-fuchsia-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-fuchsia-500"
+                onClick={() => jumpToCenter(now)}
+              >
+                <Clock className="h-3 w-3" />
+                Now
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div
+          ref={mapRef}
+          className="relative w-full cursor-pointer touch-none select-none overflow-hidden rounded-lg border border-purple-400/30 bg-purple-950/60"
+          style={{ height: MAP_HEIGHT_PX }}
+          onPointerDown={handleMapPointerDown}
+        >
+          {days.map((day) => (
+            <div
+              key={day.key}
+              className="absolute inset-y-0 border-l border-white/15"
+              style={{ left: `${timeToMapX(day.start)}px` }}
+            >
+              <span className="absolute left-1 top-0.5 text-[9px] uppercase text-purple-300">
+                {day.label}
+              </span>
+            </div>
+          ))}
+
+          {timelineData.stages.map((stage, row) =>
+            stage.sets.map((set) => {
+              if (!set.horizontalPosition) return null;
+              const vote = getVote(set.id);
+              const voteColor = vote !== undefined ? VOTE_HEX[vote] : undefined;
+              return (
+                <div
+                  key={set.id}
+                  className="absolute rounded-[1px]"
+                  style={{
+                    left: `${
+                      (set.horizontalPosition.left + CONTENT_OFFSET_PX) * scale
+                    }px`,
+                    width: `${Math.max(
+                      2,
+                      set.horizontalPosition.width * scale,
+                    )}px`,
+                    top: MAP_LABEL_SPACE_PX + row * rowHeight,
+                    height: rowHeight - 1,
+                    backgroundColor:
+                      voteColor ?? stage.color ?? DEFAULT_STAGE_COLOR,
+                    opacity: voteColor ? 1 : 0.4,
+                  }}
+                />
+              );
+            }),
+          )}
+
+          {showNow && (
+            <div
+              className="absolute inset-y-0 w-0.5 bg-fuchsia-400"
+              style={{ left: `${nowX}px` }}
+            />
+          )}
+
+          <div
+            className="absolute inset-y-0 cursor-grab rounded border-2 border-white/80 bg-white/10 active:cursor-grabbing"
+            style={{
+              left: `${viewport.left * scale}px`,
+              width: `${Math.max(8, viewport.width * scale)}px`,
+            }}
+            onPointerDown={handleWindowPointerDown}
+          />
+        </div>
+      </div>
+
+      <PrototypeCanvas
+        timelineData={timelineData}
+        timezone={timezone}
+        scrollRef={scrollRef}
+        now={now}
+        nowTreatment="dashed"
+      />
+    </div>
+  );
+
+  function timeToMapX(t: Date) {
+    return (
+      (((t.getTime() - timelineData.festivalStart.getTime()) / 60_000) *
+        PX_PER_MINUTE +
+        CONTENT_OFFSET_PX) *
+      scale
+    );
+  }
+
+  function handleMapPointerDown(e: React.PointerEvent<HTMLDivElement>) {
+    if (!mapRef.current || scale === 0) return;
+    const rect = mapRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const minutes = (x / scale - CONTENT_OFFSET_PX) / PX_PER_MINUTE;
+    jumpToCenter(
+      new Date(timelineData.festivalStart.getTime() + minutes * 60_000),
+    );
+  }
+
+  function handleWindowPointerDown(e: React.PointerEvent<HTMLDivElement>) {
+    e.stopPropagation();
+    const el = scrollRef.current;
+    if (!el || scale === 0) return;
+    const windowEl = e.currentTarget;
+    windowEl.setPointerCapture(e.pointerId);
+    const startX = e.clientX;
+    const startScrollLeft = el.scrollLeft;
+
+    function onMove(ev: PointerEvent) {
+      el!.scrollLeft = startScrollLeft + (ev.clientX - startX) / scale;
+    }
+    function onUp() {
+      windowEl.removeEventListener("pointermove", onMove);
+      windowEl.removeEventListener("pointerup", onUp);
+    }
+
+    windowEl.addEventListener("pointermove", onMove);
+    windowEl.addEventListener("pointerup", onUp);
+  }
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantMinimap.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantMinimap.tsx
@@ -98,21 +98,22 @@ export function VariantMinimap({
 
   return (
     <div className="space-y-4">
-      <PrototypeFilters
-        voteFilterCount={voteFilter.length}
-        onClearVotes={onClearVotes}
-      />
-
       <div className="space-y-1.5">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <button
-            type="button"
-            onClick={() => setShowMap((v) => !v)}
-            className="inline-flex items-center gap-1.5 text-xs uppercase tracking-wide text-purple-400 hover:text-purple-200"
-          >
-            <Map className="h-3.5 w-3.5" />
-            {showMap ? "Hide overview" : "Show overview"}
-          </button>
+          <div className="flex items-center gap-3">
+            <PrototypeFilters
+              voteFilterCount={voteFilter.length}
+              onClearVotes={onClearVotes}
+            />
+            <button
+              type="button"
+              onClick={() => setShowMap((v) => !v)}
+              className="inline-flex items-center gap-1.5 text-xs uppercase tracking-wide text-purple-400 hover:text-purple-200"
+            >
+              <Map className="h-3.5 w-3.5" />
+              {showMap ? "Hide overview" : "Show overview"}
+            </button>
+          </div>
           <div className="flex items-center gap-2">
             <VoteChips compact selected={voteFilter} onToggle={onToggleVote} />
             {showNow && (

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantMinimap.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantMinimap.tsx
@@ -4,9 +4,13 @@
 // a proportional overview strip of the whole festival (day boundaries, set
 // density per stage, voted sets in vote colors) with a draggable viewport
 // window; click anywhere on the map to jump (smooth). Compact icon-only vote
-// chips live in the mini-map header.
+// chips live in the mini-map header. Collapsed by default — what testers
+// actually valued was one control doing both "jump to a day" and "filter by
+// my votes," not the density map being visually loud all the time — so the
+// default view is a slim day-button strip (like variant a) with a toggle to
+// reveal the full map for people who want the richer overview.
 import { useEffect, useRef, useState } from "react";
-import { Clock } from "lucide-react";
+import { Clock, Map } from "lucide-react";
 import { PrototypeCanvas } from "./PrototypeCanvas";
 import { PrototypeFilters } from "./PrototypeFilters";
 import { VoteChips } from "./VoteChips";
@@ -46,8 +50,9 @@ export function VariantMinimap({
   const mapRef = useRef<HTMLDivElement>(null);
   const [viewport, setViewport] = useState({ left: 0, width: 0 });
   const [mapWidth, setMapWidth] = useState(0);
+  const [showMap, setShowMap] = useState(false);
 
-  const { jumpToCenter } = useScrollToUrl({
+  const { jumpToCenter, jumpToLeftEdge } = useScrollToUrl({
     scrollRef,
     festivalStart: timelineData.festivalStart,
     timezone,
@@ -71,7 +76,8 @@ export function VariantMinimap({
       el.removeEventListener("scroll", update);
       window.removeEventListener("resize", update);
     };
-  }, []);
+    // re-measure mapRef once it mounts (showMap flips true -> element exists)
+  }, [showMap]);
 
   const scale = mapWidth > 0 ? mapWidth / timelineData.totalWidth : 0;
   const showNow = isNowInWindow(now, timelineData);
@@ -99,9 +105,14 @@ export function VariantMinimap({
 
       <div className="space-y-1.5">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs uppercase tracking-wide text-purple-400">
-            Overview — click or drag to move
-          </span>
+          <button
+            type="button"
+            onClick={() => setShowMap((v) => !v)}
+            className="inline-flex items-center gap-1.5 text-xs uppercase tracking-wide text-purple-400 hover:text-purple-200"
+          >
+            <Map className="h-3.5 w-3.5" />
+            {showMap ? "Hide overview" : "Show overview"}
+          </button>
           <div className="flex items-center gap-2">
             <VoteChips compact selected={voteFilter} onToggle={onToggleVote} />
             {showNow && (
@@ -117,68 +128,85 @@ export function VariantMinimap({
           </div>
         </div>
 
-        <div
-          ref={mapRef}
-          className="relative w-full cursor-pointer touch-none select-none overflow-hidden rounded-lg border border-purple-400/30 bg-purple-950/60"
-          style={{ height: MAP_HEIGHT_PX }}
-          onPointerDown={handleMapPointerDown}
-        >
-          {days.map((day) => (
-            <div
-              key={day.key}
-              className="absolute inset-y-0 border-l border-white/15"
-              style={{ left: `${timeToMapX(day.start)}px` }}
-            >
-              <span className="absolute left-1 top-0.5 text-[9px] uppercase text-purple-300">
-                {day.label}
-              </span>
-            </div>
-          ))}
-
-          {timelineData.stages.map((stage, row) =>
-            stage.sets.map((set) => {
-              if (!set.horizontalPosition) return null;
-              const vote = getVote(set.id);
-              const voteColor = vote !== undefined ? VOTE_HEX[vote] : undefined;
-              return (
-                <div
-                  key={set.id}
-                  className="absolute rounded-[1px]"
-                  style={{
-                    left: `${
-                      (set.horizontalPosition.left + CONTENT_OFFSET_PX) * scale
-                    }px`,
-                    width: `${Math.max(
-                      2,
-                      set.horizontalPosition.width * scale,
-                    )}px`,
-                    top: MAP_LABEL_SPACE_PX + row * rowHeight,
-                    height: rowHeight - 1,
-                    backgroundColor:
-                      voteColor ?? stage.color ?? DEFAULT_STAGE_COLOR,
-                    opacity: voteColor ? 1 : 0.4,
-                  }}
-                />
-              );
-            }),
-          )}
-
-          {showNow && (
-            <div
-              className="absolute inset-y-0 w-0.5 bg-fuchsia-400"
-              style={{ left: `${nowX}px` }}
-            />
-          )}
-
+        {showMap ? (
           <div
-            className="absolute inset-y-0 cursor-grab rounded border-2 border-white/80 bg-white/10 active:cursor-grabbing"
-            style={{
-              left: `${viewport.left * scale}px`,
-              width: `${Math.max(8, viewport.width * scale)}px`,
-            }}
-            onPointerDown={handleWindowPointerDown}
-          />
-        </div>
+            ref={mapRef}
+            className="relative w-full cursor-pointer touch-none select-none overflow-hidden rounded-lg border border-purple-400/30 bg-purple-950/60"
+            style={{ height: MAP_HEIGHT_PX }}
+            onPointerDown={handleMapPointerDown}
+          >
+            {days.map((day) => (
+              <div
+                key={day.key}
+                className="absolute inset-y-0 border-l border-white/15"
+                style={{ left: `${timeToMapX(day.start)}px` }}
+              >
+                <span className="absolute left-1 top-0.5 text-[9px] uppercase text-purple-300">
+                  {day.label}
+                </span>
+              </div>
+            ))}
+
+            {timelineData.stages.map((stage, row) =>
+              stage.sets.map((set) => {
+                if (!set.horizontalPosition) return null;
+                const vote = getVote(set.id);
+                const voteColor =
+                  vote !== undefined ? VOTE_HEX[vote] : undefined;
+                return (
+                  <div
+                    key={set.id}
+                    className="absolute rounded-[1px]"
+                    style={{
+                      left: `${
+                        (set.horizontalPosition.left + CONTENT_OFFSET_PX) *
+                        scale
+                      }px`,
+                      width: `${Math.max(
+                        2,
+                        set.horizontalPosition.width * scale,
+                      )}px`,
+                      top: MAP_LABEL_SPACE_PX + row * rowHeight,
+                      height: rowHeight - 1,
+                      backgroundColor:
+                        voteColor ?? stage.color ?? DEFAULT_STAGE_COLOR,
+                      opacity: voteColor ? 1 : 0.4,
+                    }}
+                  />
+                );
+              }),
+            )}
+
+            {showNow && (
+              <div
+                className="absolute inset-y-0 w-0.5 bg-fuchsia-400"
+                style={{ left: `${nowX}px` }}
+              />
+            )}
+
+            <div
+              className="absolute inset-y-0 cursor-grab rounded border-2 border-white/80 bg-white/10 active:cursor-grabbing"
+              style={{
+                left: `${viewport.left * scale}px`,
+                width: `${Math.max(8, viewport.width * scale)}px`,
+              }}
+              onPointerDown={handleWindowPointerDown}
+            />
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-center gap-1 rounded-lg border border-purple-400/20 bg-purple-950/80 px-2 py-1.5">
+            {days.map((day) => (
+              <button
+                key={day.key}
+                type="button"
+                className="rounded-md px-2.5 py-1 text-xs text-purple-200 hover:bg-purple-600/40 hover:text-white"
+                onClick={() => jumpToLeftEdge(day.start)}
+              >
+                {day.label}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       <PrototypeCanvas

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSegmented.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSegmented.tsx
@@ -1,0 +1,108 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// Variant B — "Segmented rail + inline chips":
+// a segmented day control that highlights the day currently at the viewport
+// center (nav shows where you ARE), instant jumps, and my-vote chips with
+// per-vote counts always visible in a row above the strip — testing whether
+// "my schedule" (Must Go + Interested) works as a two-tap primary use case.
+import { useCallback, useRef, useState } from "react";
+import { formatInTimeZone } from "date-fns-tz";
+import { PrototypeCanvas } from "./PrototypeCanvas";
+import { PrototypeFilters } from "./PrototypeFilters";
+import { VoteChips } from "./VoteChips";
+import { useScrollToUrl } from "./useScrollToUrl";
+import { isNowInWindow, type VariantProps } from "./types";
+import { cn } from "@/lib/utils";
+
+export function VariantSegmented({
+  timelineData,
+  timezone,
+  days,
+  now,
+  mountFallback,
+  voteFilter,
+  voteCounts,
+  onToggleVote,
+  onClearVotes,
+}: VariantProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [activeDayKey, setActiveDayKey] = useState<string | null>(null);
+
+  const handleCenterChange = useCallback(
+    (center: Date) => {
+      setActiveDayKey(formatInTimeZone(center, timezone, "yyyy-MM-dd"));
+    },
+    [timezone],
+  );
+
+  const { jumpToCenter, jumpToLeftEdge } = useScrollToUrl({
+    scrollRef,
+    festivalStart: timelineData.festivalStart,
+    timezone,
+    smooth: false,
+    mountFallbackLeftEdge: mountFallback,
+    onCenterChange: handleCenterChange,
+  });
+
+  const showNow = isNowInWindow(now, timelineData);
+
+  return (
+    <div className="space-y-4">
+      <PrototypeFilters
+        voteFilterCount={voteFilter.length}
+        onClearVotes={onClearVotes}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="inline-flex items-center rounded-lg bg-white/10 p-1">
+          {days.map((day) => (
+            <button
+              key={day.key}
+              type="button"
+              className={cn(
+                "rounded-md px-4 py-1.5 text-sm transition-colors",
+                activeDayKey === day.key
+                  ? "bg-purple-600 text-white shadow"
+                  : "text-purple-300 hover:text-white",
+              )}
+              onClick={() => jumpToLeftEdge(day.start)}
+            >
+              {day.label}
+            </button>
+          ))}
+          {showNow && (
+            <>
+              <div className="mx-1 h-5 w-px bg-white/20" />
+              <button
+                type="button"
+                className="rounded-md bg-fuchsia-600/90 px-4 py-1.5 text-sm text-white hover:bg-fuchsia-500"
+                onClick={() => jumpToCenter(now)}
+              >
+                Now
+              </button>
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-purple-400">
+            My votes
+          </span>
+          <VoteChips
+            selected={voteFilter}
+            onToggle={onToggleVote}
+            counts={voteCounts}
+          />
+        </div>
+      </div>
+
+      <PrototypeCanvas
+        timelineData={timelineData}
+        timezone={timezone}
+        scrollRef={scrollRef}
+        now={now}
+        nowTreatment="bubble"
+      />
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSegmented.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSegmented.tsx
@@ -48,11 +48,6 @@ export function VariantSegmented({
 
   return (
     <div className="space-y-4">
-      <PrototypeFilters
-        voteFilterCount={voteFilter.length}
-        onClearVotes={onClearVotes}
-      />
-
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="inline-flex items-center rounded-lg bg-white/10 p-1">
           {days.map((day) => (
@@ -84,15 +79,21 @@ export function VariantSegmented({
           )}
         </div>
 
-        <div className="flex items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-purple-400">
-            My votes
-          </span>
-          <VoteChips
-            selected={voteFilter}
-            onToggle={onToggleVote}
-            counts={voteCounts}
+        <div className="flex items-center gap-3">
+          <PrototypeFilters
+            voteFilterCount={voteFilter.length}
+            onClearVotes={onClearVotes}
           />
+          <div className="flex items-center gap-2">
+            <span className="text-xs uppercase tracking-wide text-purple-400">
+              My votes
+            </span>
+            <VoteChips
+              selected={voteFilter}
+              onToggle={onToggleVote}
+              counts={voteCounts}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSlimBar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSlimBar.tsx
@@ -35,14 +35,15 @@ export function VariantSlimBar({
 
   return (
     <div className="space-y-4">
-      <PrototypeFilters
-        voteChips={<VoteChips selected={voteFilter} onToggle={onToggleVote} />}
-        voteFilterCount={voteFilter.length}
-        onClearVotes={onClearVotes}
-      />
-
       <div className="sticky top-2 z-30">
         <div className="flex flex-wrap items-center gap-1 rounded-lg border border-purple-400/20 bg-purple-950/80 px-2 py-1.5 backdrop-blur">
+          <PrototypeFilters
+            voteChips={
+              <VoteChips selected={voteFilter} onToggle={onToggleVote} />
+            }
+            voteFilterCount={voteFilter.length}
+            onClearVotes={onClearVotes}
+          />
           <span className="mr-1 text-xs uppercase tracking-wide text-purple-400">
             Jump to
           </span>

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSlimBar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VariantSlimBar.tsx
@@ -1,0 +1,82 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// Variant A — "Slim jump bar" (the agreed design, literal):
+// sticky slim bar of ghost day buttons + a Now pill above the strip, smooth
+// scrolling on jumps, my-vote chips inside the collapsed filter panel.
+import { useRef } from "react";
+import { Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PrototypeCanvas } from "./PrototypeCanvas";
+import { PrototypeFilters } from "./PrototypeFilters";
+import { VoteChips } from "./VoteChips";
+import { useScrollToUrl } from "./useScrollToUrl";
+import { isNowInWindow, type VariantProps } from "./types";
+
+export function VariantSlimBar({
+  timelineData,
+  timezone,
+  days,
+  now,
+  mountFallback,
+  voteFilter,
+  onToggleVote,
+  onClearVotes,
+}: VariantProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { jumpToCenter, jumpToLeftEdge } = useScrollToUrl({
+    scrollRef,
+    festivalStart: timelineData.festivalStart,
+    timezone,
+    smooth: true,
+    mountFallbackLeftEdge: mountFallback,
+  });
+
+  const showNow = isNowInWindow(now, timelineData);
+
+  return (
+    <div className="space-y-4">
+      <PrototypeFilters
+        voteChips={<VoteChips selected={voteFilter} onToggle={onToggleVote} />}
+        voteFilterCount={voteFilter.length}
+        onClearVotes={onClearVotes}
+      />
+
+      <div className="sticky top-2 z-30">
+        <div className="flex flex-wrap items-center gap-1 rounded-lg border border-purple-400/20 bg-purple-950/80 px-2 py-1.5 backdrop-blur">
+          <span className="mr-1 text-xs uppercase tracking-wide text-purple-400">
+            Jump to
+          </span>
+          {days.map((day) => (
+            <Button
+              key={day.key}
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2.5 text-purple-200 hover:bg-purple-600/40 hover:text-white"
+              onClick={() => jumpToLeftEdge(day.start)}
+            >
+              {day.label}
+            </Button>
+          ))}
+          {showNow && (
+            <Button
+              size="sm"
+              className="ml-auto h-7 bg-fuchsia-600 px-3 text-white hover:bg-fuchsia-500"
+              onClick={() => jumpToCenter(now)}
+            >
+              <Clock className="mr-1 h-3.5 w-3.5" />
+              Now
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <PrototypeCanvas
+        timelineData={timelineData}
+        timezone={timezone}
+        scrollRef={scrollRef}
+        now={now}
+        nowTreatment="line"
+      />
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VoteChips.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/VoteChips.tsx
@@ -1,0 +1,56 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+import { VOTE_CONFIG, VOTES_TYPES, type VoteType } from "@/lib/voteConfig";
+import { cn } from "@/lib/utils";
+
+interface VoteChipsProps {
+  selected: VoteType[];
+  onToggle: (voteType: VoteType) => void;
+  compact?: boolean;
+  counts?: Partial<Record<VoteType, number>>;
+}
+
+export function VoteChips({
+  selected,
+  onToggle,
+  compact,
+  counts,
+}: VoteChipsProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {VOTES_TYPES.map((voteType) => {
+        const config = VOTE_CONFIG[voteType];
+        const Icon = config.icon;
+        const isSelected = selected.includes(voteType);
+        return (
+          <button
+            key={voteType}
+            type="button"
+            onClick={() => onToggle(voteType)}
+            aria-pressed={isSelected}
+            title={config.label}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full border text-xs font-medium transition-colors",
+              compact ? "px-2 py-1" : "px-3 py-1.5",
+              isSelected
+                ? cn("border-transparent text-white", config.buttonSelected)
+                : cn("bg-transparent", config.buttonUnselected),
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {!compact && <span>{config.label}</span>}
+            {!compact && counts?.[voteType] !== undefined && (
+              <span
+                className={cn(
+                  "rounded-full px-1.5",
+                  isSelected ? "bg-white/25" : "bg-white/10",
+                )}
+              >
+                {counts[voteType]}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/types.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/types.ts
@@ -1,0 +1,32 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+import type { TimelineData } from "@/lib/timelineCalculator";
+import type { VoteType } from "@/lib/voteConfig";
+
+export interface DayJump {
+  key: string;
+  label: string;
+  start: Date;
+}
+
+export interface VariantProps {
+  timelineData: TimelineData;
+  timezone: string;
+  days: DayJump[];
+  now: Date | null;
+  mountFallback: Date | null;
+  voteFilter: VoteType[];
+  voteCounts: Partial<Record<VoteType, number>>;
+  onToggleVote: (voteType: VoteType) => void;
+  onClearVotes: () => void;
+}
+
+export function isNowInWindow(
+  now: Date | null,
+  timelineData: TimelineData,
+): now is Date {
+  return (
+    now !== null &&
+    now >= timelineData.festivalStart &&
+    now <= timelineData.festivalEnd
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/useFakeNow.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/useFakeNow.ts
@@ -1,0 +1,29 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// Fakes "now" to ~60% into the edition window (evening prime time) so the Now button and the
+// current-time indicator are demoable regardless of the real date. Advances
+// in real time and ticks every 60s, like the real indicator would.
+// The real implementation uses the actual clock and hides both when the
+// current time is outside the festival window.
+import { useEffect, useRef, useState } from "react";
+
+export function useFakeNow(
+  windowStart: Date | null,
+  windowEnd: Date | null,
+): Date | null {
+  const [, setTick] = useState(0);
+  const anchorRef = useRef(Date.now());
+
+  useEffect(() => {
+    const id = window.setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  if (!windowStart || !windowEnd || windowEnd <= windowStart) return null;
+
+  const base =
+    windowStart.getTime() +
+    (windowEnd.getTime() - windowStart.getTime()) * 0.6;
+  const now = base + (Date.now() - anchorRef.current);
+  return new Date(Math.floor(now / 60_000) * 60_000);
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/usePrototypeVotes.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/usePrototypeVotes.ts
@@ -1,0 +1,36 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// Real votes when logged in; deterministic fake votes when logged out so the
+// my-vote chips are demoable anonymously. The real implementation hides the
+// chips entirely when logged out.
+import { useCallback } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useUserVotes } from "@/api/voting/useUserVotes";
+
+function fakeVote(setId: string): number | undefined {
+  let hash = 0;
+  for (let i = 0; i < setId.length; i++) {
+    hash = (hash * 31 + setId.charCodeAt(i)) >>> 0;
+  }
+  const bucket = hash % 10;
+  if (bucket < 2) return 2;
+  if (bucket < 5) return 1;
+  if (bucket === 5) return -1;
+  return undefined;
+}
+
+export function usePrototypeVotes() {
+  const { user } = useAuth();
+  const { data: userVotes } = useUserVotes(user?.id);
+  const isFake = !user;
+
+  const getVote = useCallback(
+    (setId: string): number | undefined => {
+      if (user) return userVotes?.[setId];
+      return fakeVote(setId);
+    },
+    [user, userVotes],
+  );
+
+  return { getVote, isFake };
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/useScrollToUrl.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/prototype/useScrollToUrl.ts
@@ -1,0 +1,215 @@
+// PROTOTYPE (timeline nav & filtering) — throwaway, delete with this folder.
+//
+// The agreed `scrollTo` URL mechanics, shared by all variants:
+// - `scrollTo=<yyyy-MM-dd'T'HH:mm>` (festival-timezone wall clock) = the moment
+//   at the viewport center. Absent by default.
+// - User scroll writes it debounced (~300ms scroll-idle), rounded to 5 minutes,
+//   via history replace.
+// - One-way ownership: URL -> scroll only on mount and on jump-control clicks;
+//   user scroll -> URL only.
+import { useCallback, useEffect, useRef } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
+
+export const PX_PER_MINUTE = 2;
+export const CONTENT_OFFSET_PX = 20;
+
+const ROUTE =
+  "/festivals/$festivalSlug/editions/$editionSlug/schedule/timeline" as const;
+
+const SCROLL_IDLE_MS = 300;
+const PROGRAMMATIC_SETTLE_MS = 300;
+const FIVE_MINUTES_MS = 5 * 60_000;
+
+interface UseScrollToUrlOptions {
+  scrollRef: React.RefObject<HTMLDivElement>;
+  festivalStart: Date;
+  timezone: string;
+  smooth: boolean;
+  // Mount precedence when no scrollTo param: this moment lands at the left
+  // edge (day-filter start, or fake-now minus 1h); null = stay at festival start.
+  mountFallbackLeftEdge: Date | null;
+  onCenterChange?: (center: Date) => void;
+}
+
+function parseScrollTo(
+  value: string | undefined,
+  timezone: string,
+): Date | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) return null;
+  const date = fromZonedTime(value, timezone);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function useScrollToUrl({
+  scrollRef,
+  festivalStart,
+  timezone,
+  smooth,
+  mountFallbackLeftEdge,
+  onCenterChange,
+}: UseScrollToUrlOptions) {
+  const { scrollTo } = useSearch({ from: ROUTE });
+  const navigate = useNavigate({ from: ROUTE });
+
+  // Axis bounds change when filters change; callbacks read the latest values.
+  const latest = useRef({
+    festivalStart,
+    timezone,
+    smooth,
+    scrollTo,
+    mountFallbackLeftEdge,
+    onCenterChange,
+  });
+  latest.current = {
+    festivalStart,
+    timezone,
+    smooth,
+    scrollTo,
+    mountFallbackLeftEdge,
+    onCenterChange,
+  };
+
+  const isProgrammatic = useRef(false);
+  const programmaticTimer = useRef<number>();
+  const writeTimer = useRef<number>();
+
+  const timeToPx = useCallback((t: Date) => {
+    return (
+      ((t.getTime() - latest.current.festivalStart.getTime()) / 60_000) *
+        PX_PER_MINUTE +
+      CONTENT_OFFSET_PX
+    );
+  }, []);
+
+  const centerTimeAt = useCallback((scrollLeft: number) => {
+    const el = scrollRef.current;
+    if (!el) return null;
+    const centerPx = scrollLeft + el.clientWidth / 2 - CONTENT_OFFSET_PX;
+    return new Date(
+      latest.current.festivalStart.getTime() +
+        (centerPx / PX_PER_MINUTE) * 60_000,
+    );
+  }, [scrollRef]);
+
+  const writeScrollTo = useCallback(
+    (center: Date) => {
+      const rounded = new Date(
+        Math.round(center.getTime() / FIVE_MINUTES_MS) * FIVE_MINUTES_MS,
+      );
+      const value = formatInTimeZone(
+        rounded,
+        latest.current.timezone,
+        "yyyy-MM-dd'T'HH:mm",
+      );
+      navigate({
+        to: ".",
+        search: (prev) => ({ ...prev, scrollTo: value }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
+  const markProgrammatic = useCallback(() => {
+    isProgrammatic.current = true;
+    window.clearTimeout(programmaticTimer.current);
+    programmaticTimer.current = window.setTimeout(() => {
+      isProgrammatic.current = false;
+    }, PROGRAMMATIC_SETTLE_MS);
+  }, []);
+
+  const scrollToPx = useCallback(
+    (left: number) => {
+      const el = scrollRef.current;
+      if (!el) return;
+      markProgrammatic();
+      el.scrollTo({
+        left: Math.max(0, left),
+        behavior: latest.current.smooth ? "smooth" : "auto",
+      });
+    },
+    [scrollRef, markProgrammatic],
+  );
+
+  // Jump controls: write scrollTo + scroll. One code path for day/Now buttons.
+  const jumpToCenter = useCallback(
+    (t: Date) => {
+      const el = scrollRef.current;
+      if (!el) return;
+      writeScrollTo(t);
+      scrollToPx(timeToPx(t) - el.clientWidth / 2);
+    },
+    [scrollRef, writeScrollTo, scrollToPx, timeToPx],
+  );
+
+  const jumpToLeftEdge = useCallback(
+    (t: Date) => {
+      const el = scrollRef.current;
+      if (!el) return;
+      const left = timeToPx(t) - 12;
+      const center = centerTimeAt(Math.max(0, left));
+      if (center) writeScrollTo(center);
+      scrollToPx(left);
+    },
+    [scrollRef, timeToPx, centerTimeAt, writeScrollTo, scrollToPx],
+  );
+
+  // User scroll -> URL (debounced); programmatic scrolls only reset the flag.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    function handleScroll() {
+      const center = centerTimeAt(el!.scrollLeft);
+      if (center) latest.current.onCenterChange?.(center);
+
+      if (isProgrammatic.current) {
+        window.clearTimeout(programmaticTimer.current);
+        programmaticTimer.current = window.setTimeout(() => {
+          isProgrammatic.current = false;
+        }, PROGRAMMATIC_SETTLE_MS);
+        return;
+      }
+      window.clearTimeout(writeTimer.current);
+      writeTimer.current = window.setTimeout(() => {
+        const idleCenter = centerTimeAt(el!.scrollLeft);
+        if (idleCenter) writeScrollTo(idleCenter);
+      }, SCROLL_IDLE_MS);
+    }
+
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", handleScroll);
+      window.clearTimeout(writeTimer.current);
+      window.clearTimeout(programmaticTimer.current);
+    };
+  }, [scrollRef, centerTimeAt, writeScrollTo]);
+
+  // URL -> scroll, once on mount only. Precedence:
+  // scrollTo param -> centered; else fallback (day start / now-1h) -> left edge.
+  const didPosition = useRef(false);
+  useEffect(() => {
+    if (didPosition.current) return;
+    didPosition.current = true;
+    const el = scrollRef.current;
+    if (!el) return;
+    const { scrollTo: param, timezone: tz, mountFallbackLeftEdge: fallback } =
+      latest.current;
+    const target = parseScrollTo(param, tz);
+    let left: number | null = null;
+    if (target) {
+      left = timeToPx(target) - el.clientWidth / 2;
+    } else if (fallback) {
+      left = timeToPx(fallback) - 12;
+    }
+    if (left !== null) {
+      markProgrammatic();
+      el.scrollLeft = Math.max(0, left);
+    }
+    const center = centerTimeAt(el.scrollLeft);
+    if (center) latest.current.onCenterChange?.(center);
+  }, [scrollRef, timeToPx, centerTimeAt, markProgrammatic]);
+
+  return { jumpToCenter, jumpToLeftEdge };
+}


### PR DESCRIPTION
Throwaway prototype: three timeline navigation + my-vote filtering variants on the timeline route behind `?variant=` (a: slim jump bar, b: segmented rail, c: mini-map), to validate the agreed scrollTo/jump-bar design before the PRD is published.
Without `?variant=` the production timeline renders untouched; verdict placeholders and the deletion list live in `prototype/NOTES.md`.

## Verification
- Open an edition's timeline with `?variant=a`; jump bar with day buttons + Now pill renders, clicking a day smooth-scrolls the strip and writes `scrollTo` to the URL.
- Swipe/scroll the strip, wait a moment, reload; position is restored from `scrollTo` (also when returning from a set page via back).
- Cycle variants with the floating bottom bar or ←/→ keys; scroll position carries over.
- In variant a, expand Filters and select Must Go + Interested; strip narrows to those sets and the badge counts them.
- In variant c, drag the mini-map viewport window and click elsewhere on the map; the strip follows.
- Open the timeline without `?variant=`; the existing production timeline renders with no switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeDJWUoheP7zyhpchNa3DW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeDJWUoheP7zyhpchNa3DW)_