### PR TITLE
fix(sets): remove redundant slug update

### DIFF
--- a/src/api/sets/useCreateSet.ts
+++ b/src/api/sets/useCreateSet.ts
@@ -33,7 +33,6 @@ async function createSet(
     archived: false,
   };
 
-  // First, create the set without slug
   const { data, error } = await supabase
     .from("sets")
     .insert(insertData)
@@ -45,21 +44,8 @@ async function createSet(
     throw new Error("Failed to create set");
   }
 
-  // Generate and update the slug using the created ID
-  const slug = generateSlug(data.name);
-  const { error: slugError } = await supabase
-    .from("sets")
-    .update({ slug })
-    .eq("id", data.id);
-
-  if (slugError) {
-    console.error("Error updating set slug:", slugError);
-    throw new Error("Failed to generate set slug");
-  }
-
   return {
     ...data,
-    slug,
     artists: [],
     votes: [],
   };


### PR DESCRIPTION
Removes the redundant post-insert UPDATE in createSet — the initial insert already sets the correct slug, so the follow-up write was a wasted round-trip. Mirrors the single-insert pattern already used in createArtist.

Closes #39

## Verification
- Create a new set with a plain name; it saves successfully with the expected slug and only one write hits the `sets` table (network tab shows a single INSERT, no follow-up UPDATE).
- Create a set with special characters/spaces in the name; slug still generates correctly via `generateSlug`.
- `pnpm run lint` and `pnpm test` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCbsLsv1a5jNZQhw3GnD8h)_