### PR TITLE
refactor(editions): remove unreachable error ui

### DIFF
--- a/src/contexts/FestivalEditionContext.tsx
+++ b/src/contexts/FestivalEditionContext.tsx
@@ -1,10 +1,7 @@
-import { createContext, PropsWithChildren, useContext, useEffect } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { createContext, PropsWithChildren, useContext } from "react";
 import { Festival } from "@/api/festivals/types";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { FestivalEdition } from "@/api/editions/types";
-import { TopBar } from "@/components/layout/TopBar";
-import { useToast } from "@/hooks/use-toast";
 
 interface FestivalEditionContextType {
   festival: Festival;
@@ -35,9 +32,6 @@ export function FestivalEditionProvider({
   festival,
   editionSlug = "",
 }: PropsWithChildren<FestivalEditionProviderProps>) {
-  const navigate = useNavigate();
-  const { toast } = useToast();
-
   const editionQuery = useFestivalEditionBySlugQuery({
     festivalSlug: festival.slug,
     editionSlug,
@@ -49,32 +43,6 @@ export function FestivalEditionProvider({
     festival,
     edition,
   };
-
-  useEffect(() => {
-    if (editionQuery.error) {
-      toast({
-        title: "Festival edition not found",
-        description: `Festival edition with slug ${editionSlug} not found`,
-        variant: "destructive",
-      });
-      navigate({ to: "/" });
-    }
-  }, [editionQuery.error, toast, editionSlug, navigate]);
-
-  if (editionQuery.error) {
-    return (
-      <FestivalEditionContext.Provider value={contextValue}>
-        <div className="min-h-screen bg-app-gradient">
-          <div className="container mx-auto px-4 py-8">
-            <TopBar backLabel="Back to Festivals" />
-            <h1 className="text-4xl font-bold text-white text-center mb-8">
-              No valid festival edition found
-            </h1>
-          </div>
-        </div>
-      </FestivalEditionContext.Provider>
-    );
-  }
 
   return (
     <FestivalEditionContext.Provider value={contextValue}>


### PR DESCRIPTION
Removes the unreachable error useEffect/redirect and error UI from FestivalEditionProvider, since the route's beforeLoad already throws on a failed edition load before the provider renders.
Eliminates a redirect flash; route-level error boundaries now handle real load failures.

## Verification
- Visit a valid festival edition URL; the page loads normally as before.
- `pnpm run lint` and `pnpm test` pass.

Closes #83

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCbsLsv1a5jNZQhw3GnD8h)_