### PR TITLE
fix(editions): move redirect to beforeLoad

### DIFF
--- a/src/pages/EditionSelection.tsx
+++ b/src/pages/EditionSelection.tsx
@@ -10,37 +10,14 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { AppHeader } from "@/components/layout/AppHeader";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { useFestivalEditionsForFestivalQuery } from "@/api/editions/useFestivalEditionsForFestival";
 import { FestivalEdition } from "@/api/editions/types";
-import { useEffect } from "react";
 import { TopBar } from "@/components/layout/TopBar";
 
 export default function EditionSelection() {
   const { festival } = useFestivalEdition();
   const editionListQuery = useFestivalEditionsForFestivalQuery(festival?.id);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (
-      festival?.slug &&
-      !editionListQuery.isLoading &&
-      editionListQuery.data?.length === 1
-    ) {
-      navigate({
-        to: "/festivals/$festivalSlug/editions/$editionSlug",
-        params: {
-          festivalSlug: festival.slug,
-          editionSlug: editionListQuery.data[0].slug,
-        },
-      });
-    }
-  }, [
-    editionListQuery.data,
-    editionListQuery.isLoading,
-    festival?.slug,
-    navigate,
-  ]);
 
   if (!festival) {
     return (
@@ -54,20 +31,6 @@ export default function EditionSelection() {
     return (
       <div className="min-h-screen bg-app-gradient flex items-center justify-center">
         <div className="text-white text-xl">Loading editions...</div>
-      </div>
-    );
-  }
-
-  if (
-    festival?.slug &&
-    !editionListQuery.isLoading &&
-    editionListQuery.data?.length === 1
-  ) {
-    return (
-      <div className="min-h-screen bg-app-gradient flex items-center justify-center">
-        <div className="text-white text-xl">
-          Redirecting to current edition...
-        </div>
       </div>
     );
   }

--- a/src/routes/festivals/$festivalSlug/index.tsx
+++ b/src/routes/festivals/$festivalSlug/index.tsx
@@ -1,6 +1,26 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import EditionSelection from "@/pages/EditionSelection";
+import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
+import { editionsForFestivalQuery } from "@/api/editions/useFestivalEditionsForFestival";
 
 export const Route = createFileRoute("/festivals/$festivalSlug/")({
   component: EditionSelection,
+  beforeLoad: async ({ params, context }) => {
+    const festival = await context.queryClient.ensureQueryData(
+      festivalBySlugQuery(params.festivalSlug),
+    );
+    const editions = await context.queryClient.ensureQueryData(
+      editionsForFestivalQuery(festival.id),
+    );
+
+    if (editions.length === 1) {
+      throw redirect({
+        to: "/festivals/$festivalSlug/editions/$editionSlug",
+        params: {
+          festivalSlug: params.festivalSlug,
+          editionSlug: editions[0].slug,
+        },
+      });
+    }
+  },
 });


### PR DESCRIPTION
Moves the single-edition auto-redirect from a useEffect in EditionSelection into the route's beforeLoad, so it never flashes before redirecting.
Festivals with exactly one edition now redirect with no visible "Redirecting..." state.

## Verification
- Visit a festival with exactly one edition; it redirects straight to that edition with no "Redirecting..." flash.
- Visit a festival with zero editions; the "No Editions Available" card still renders.
- Visit a festival with two or more editions; the edition list still renders unchanged.

Closes #84

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCbsLsv1a5jNZQhw3GnD8h)_