### PR TITLE
refactor(api): standardize query-key id normalization

### DIFF
--- a/src/api/custom-links/useCustomLinks.ts
+++ b/src/api/custom-links/useCustomLinks.ts
@@ -27,7 +27,7 @@ export function customLinksQuery(festivalId: string) {
 
 export function useCustomLinksQuery(festivalId: string | undefined) {
   return useQuery({
-    ...customLinksQuery(festivalId ?? ""),
+    ...customLinksQuery(festivalId!),
     enabled: !!festivalId,
   });
 }

--- a/src/api/editions/types.ts
+++ b/src/api/editions/types.ts
@@ -9,7 +9,7 @@ export const editionsKeys = {
   root: (festivalId: string) =>
     [...festivalsKeys.root(), festivalId, "editions"] as const,
   all: (festivalId: string, { all }: { all?: boolean } = {}) =>
-    [...editionsKeys.root(festivalId), { all }] as const,
+    [...editionsKeys.root(festivalId), { all: !!all }] as const,
   item: ({
     editionId,
     festivalId,

--- a/src/api/editions/types.ts
+++ b/src/api/editions/types.ts
@@ -9,7 +9,7 @@ export const editionsKeys = {
   root: (festivalId: string) =>
     [...festivalsKeys.root(), festivalId, "editions"] as const,
   all: (festivalId: string, { all }: { all?: boolean } = {}) =>
-    [...editionsKeys.root(festivalId), { all: !!all }] as const,
+    [...editionsKeys.root(festivalId), { all }] as const,
   item: ({
     editionId,
     festivalId,

--- a/src/api/editions/useFestivalEditionsForFestival.ts
+++ b/src/api/editions/useFestivalEditionsForFestival.ts
@@ -44,7 +44,7 @@ export function useFestivalEditionsForFestivalQuery(
   { all }: { all?: boolean } = {},
 ) {
   return useQuery({
-    ...editionsForFestivalQuery(festivalId || "", { all }),
+    ...editionsForFestivalQuery(festivalId!, { all }),
     enabled: !!festivalId,
   });
 }

--- a/src/api/sets/useSetsByEdition.ts
+++ b/src/api/sets/useSetsByEdition.ts
@@ -55,7 +55,7 @@ export function setsByEditionQuery(editionId: string) {
 
 export function useSetsByEditionQuery(editionId: string | undefined) {
   return useQuery({
-    ...setsByEditionQuery(editionId || ""),
+    ...setsByEditionQuery(editionId!),
     enabled: !!editionId,
   });
 }

--- a/src/api/stages/useStageQuery.ts
+++ b/src/api/stages/useStageQuery.ts
@@ -30,7 +30,7 @@ export function stageQuery(stageId: string) {
 
 export function useStageQuery(stageId: string | undefined | null) {
   return useQuery({
-    ...stageQuery(stageId ?? ""),
+    ...stageQuery(stageId!),
     enabled: !!stageId,
   });
 }

--- a/src/api/stages/useStagesByEdition.ts
+++ b/src/api/stages/useStagesByEdition.ts
@@ -30,7 +30,7 @@ export function stagesByEditionQuery(editionId: string) {
 
 export function useStagesByEditionQuery(editionId: string | undefined) {
   return useQuery({
-    ...stagesByEditionQuery(editionId ?? ""),
+    ...stagesByEditionQuery(editionId!),
     enabled: !!editionId,
   });
 }


### PR DESCRIPTION
Converts the remaining useXQuery hooks from `id ?? ""` / `id || ""` empty-string normalization to the non-null-assertion form (`xQuery(id!)` with `enabled: !!id`), matching the pattern already used elsewhere in src/api.
No behavior change: disabled queries never execute the queryFn either way.

Closes #70

## Verification
- `pnpm run lint` passes with 0 warnings/errors.
- `pnpm test` — all 311 tests pass unchanged.
- `pnpm run typecheck` (`tsc --noEmit`) passes with no errors.
- Load pages backed by the converted hooks (custom links, sets by edition, stages by edition, stage detail, festival editions for festival) with and without an id present; behavior is unchanged since `enabled: !!id` still gates execution.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GCbsLsv1a5jNZQhw3GnD8h)_