### PR TITLE
chore(agents): ignore worktree dirs used by background agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ dump.sql
 
 # Sync script credentials (DB connection strings — never commit)
 scripts/.env.sync
+
+# Isolated worktrees for background agents
+.claude/worktrees/


### PR DESCRIPTION
Ignores `.claude/worktrees/`, the isolated git worktrees created when running multiple background agents in parallel, so they don't show up as untracked files.

## Verification
- Launch a background agent with worktree isolation; `git status` on the main checkout no longer flags the worktree directory as untracked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCbsLsv1a5jNZQhw3GnD8h)_