### PR TITLE
feat(phases): add derived festival phase hook

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,10 @@ _Avoid_: Roster, bill
 The arrangement of an edition's **sets** across **stages** and time. Presented to users via the Timeline and List views on the Schedule tab. Not a stored entity — derived from sets + stages of an edition.
 _Avoid_: Lineup (lineup = who; schedule = when/where), program, timetable
 
+**Festival phase**:
+Which stage of its lifecycle an **edition** is in. An ordered, derived concept (parallel to how **Schedule** is derived) — not a stored entity and not a column. Computed from the edition's **schedule reveal level**, `start_date`/`end_date`, and the **festival timezone** at the current time. Four ordered values: **Pre-Schedule → Planning → Live → Post-Festival**. `draft` reveal level ⇒ Pre-Schedule; before the festival ⇒ Planning; during (with grace before/after) ⇒ Live; after ⇒ Post-Festival. See ADR-0003.
+_Avoid_: Status, state, stage (stage = a venue), stored phase
+
 **Set**:
 A single scheduled performance within an edition, with one or more artists, a stage, and a start/end time.
 _Avoid_: Show, gig, slot, performance

--- a/docs/adr/0003-festival-phase-derived.md
+++ b/docs/adr/0003-festival-phase-derived.md
@@ -1,0 +1,28 @@
+# Festival phase is derived, not stored
+
+An edition moves through four ordered phases — **Pre-Schedule → Planning → Live → Post-Festival** — that gate which features the app surfaces. We derive the current phase from signals the platform already has (`schedule_reveal_level`, `start_date`, `end_date`, festival `timezone`) via a pure `getFestivalPhase({ revealLevel, startDate, endDate, timezone, now })`, rather than storing a `phase` column and advancing it. `now` is injected so the rule is a pure function; a thin `useFestivalPhase` hook calls it with the current time from the edition context. This builds on ADR-0001 (`schedule_reveal_level`) and ADR-0002 (festival-timezone display).
+
+Derivation rules:
+
+- `draft` reveal level ⇒ **Pre-Schedule**, regardless of dates. The schedule doesn't exist yet, so date-driven phases don't apply.
+- Otherwise, `liveStart = start_date − 1 day @ 00:00` and `liveEnd = end_date + 1 day @ 06:00`, both evaluated **in the festival timezone**:
+  - `now < liveStart` ⇒ **Planning**
+  - `liveStart ≤ now ≤ liveEnd` ⇒ **Live** (boundaries inclusive)
+  - `now > liveEnd` ⇒ **Post-Festival**
+- The grace boundaries (`−1 day @ 00:00`, `+1 day @ 06:00`) keep an edition "Live" across arrival-day setup and the post-midnight tail of the final night, so a 02:00 closing set still reads as Live.
+- NULL-date degradation: NULL `start_date` ⇒ never past **Planning** (no anchor to enter Live); NULL `end_date` ⇒ Live never flips to **Post** (no anchor to leave Live).
+
+All calendar boundaries reuse the existing `fromZonedTime`-based helper (`convertLocalTimeToUTC`) in `src/lib/timeUtils.ts` — there is no second timezone approach. The seam mirrors the pure-lib + thin-hook split of ADR-0001's `scheduleReveal.ts` / `useScheduleReveal.ts`.
+
+## Considered Options
+
+- **Derive from existing signals (chosen).** No migration, no state machine to advance, no risk of a stored phase drifting out of sync with the dates/reveal level it should reflect. The phase is always a pure function of current facts + `now`.
+- **Stored `phase` column on `festival_editions`.** Rejected: requires a migration and a mechanism to advance it (cron, admin action, or a trigger on `now`), and introduces a class of "phase says Live but the festival ended last week" bugs. Nothing needs to *remember* a phase that the dates already imply.
+- **`schedule_release_date` column.** Rejected: adds a third date field that overlaps with `start_date`/`schedule_reveal_level` and must be kept consistent with them. Reveal level already models schedule readiness; a separate release date is redundant state.
+
+## Consequences
+
+- The phase updates purely with the passage of time and edits to the dates/reveal level — no write path, no backfill. Editing `start_date` or bumping the reveal level immediately re-derives the phase.
+- Because `now` is injected, the rule is unit-tested with no clock, DOM, or React mocking: tests assert only the phase output for a given `now`, not the internal boundary instants.
+- Every downstream festival-phase ticket reads this one seam (`getFestivalPhase` / `useFestivalPhase`) instead of re-deriving boundaries, so the grace rules live in exactly one place.
+- Consumers rendering across the exact boundary must pass a fresh `now` to re-derive; the hook reads `new Date()` per render and does not schedule a re-render at the boundary. A live-updating timer is out of scope for this slice.

--- a/src/hooks/useFestivalPhase.ts
+++ b/src/hooks/useFestivalPhase.ts
@@ -1,0 +1,19 @@
+import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
+import {
+  type FestivalPhase,
+  getFestivalPhase,
+} from "@/lib/festivalPhase";
+
+export function useFestivalPhase(): { phase: FestivalPhase } {
+  const { festival, edition } = useFestivalEdition();
+
+  const phase = getFestivalPhase({
+    revealLevel: edition?.schedule_reveal_level ?? "draft",
+    startDate: edition?.start_date ?? null,
+    endDate: edition?.end_date ?? null,
+    timezone: festival.timezone,
+    now: new Date(),
+  });
+
+  return { phase };
+}

--- a/src/lib/festivalPhase.test.ts
+++ b/src/lib/festivalPhase.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getFestivalPhase, type FestivalPhaseInput } from "./festivalPhase";
+import {
+  getFestivalPhase,
+  type FestivalPhase,
+  type FestivalPhaseInput,
+} from "./festivalPhase";
 
 // Europe/Lisbon is UTC+1 (WEST) in August, so these calendar boundaries land
 // on the previous UTC day — the festival-tz evaluation is what makes the phase
@@ -11,7 +15,7 @@ const TZ = "Europe/Lisbon";
 const LIVE_START = "2025-07-30T23:00:00.000Z";
 const LIVE_END = "2025-08-04T05:00:00.000Z";
 
-function phase(overrides: Partial<FestivalPhaseInput>): string {
+function phase(overrides: Partial<FestivalPhaseInput>): FestivalPhase {
   return getFestivalPhase({
     revealLevel: "full",
     startDate: "2025-08-01",
@@ -69,6 +73,18 @@ describe("getFestivalPhase", () => {
   it("NULL end_date keeps Live and never flips to Post", () => {
     expect(
       phase({ endDate: null, now: new Date("2030-01-01T00:00:00Z") }),
+    ).toBe("live");
+  });
+
+  it("degrades an unparseable start_date to Planning instead of throwing", () => {
+    expect(
+      phase({ startDate: "not-a-date", now: new Date("2030-01-01T00:00:00Z") }),
+    ).toBe("planning");
+  });
+
+  it("degrades an unparseable end_date to Live (never Post)", () => {
+    expect(
+      phase({ endDate: "not-a-date", now: new Date("2030-01-01T00:00:00Z") }),
     ).toBe("live");
   });
 });

--- a/src/lib/festivalPhase.test.ts
+++ b/src/lib/festivalPhase.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { getFestivalPhase, type FestivalPhaseInput } from "./festivalPhase";
+
+// Europe/Lisbon is UTC+1 (WEST) in August, so these calendar boundaries land
+// on the previous UTC day — the festival-tz evaluation is what makes the phase
+// correct for a viewer whose zone reads a different calendar day.
+//   start_date 2025-08-01, end_date 2025-08-03
+//   liveStart = 2025-07-31 00:00 Lisbon = 2025-07-30T23:00:00Z
+//   liveEnd   = 2025-08-04 06:00 Lisbon = 2025-08-04T05:00:00Z
+const TZ = "Europe/Lisbon";
+const LIVE_START = "2025-07-30T23:00:00.000Z";
+const LIVE_END = "2025-08-04T05:00:00.000Z";
+
+function phase(overrides: Partial<FestivalPhaseInput>): string {
+  return getFestivalPhase({
+    revealLevel: "full",
+    startDate: "2025-08-01",
+    endDate: "2025-08-03",
+    timezone: TZ,
+    now: new Date(LIVE_START),
+    ...overrides,
+  });
+}
+
+describe("getFestivalPhase", () => {
+  it("draft is Pre-Schedule regardless of dates or now", () => {
+    expect(
+      phase({ revealLevel: "draft", now: new Date("2025-08-02T12:00:00Z") }),
+    ).toBe("pre-schedule");
+    expect(
+      phase({
+        revealLevel: "draft",
+        startDate: null,
+        endDate: null,
+        now: new Date("2030-01-01T00:00:00Z"),
+      }),
+    ).toBe("pre-schedule");
+  });
+
+  it("non-draft before liveStart is Planning", () => {
+    expect(phase({ now: new Date("2025-07-30T22:59:59Z") })).toBe("planning");
+  });
+
+  it("is Live at the exact liveStart boundary (inclusive)", () => {
+    // 2025-07-30T23:00:00Z is still July 30 in UTC but July 31 in Lisbon.
+    expect(phase({ now: new Date(LIVE_START) })).toBe("live");
+  });
+
+  it("is Live between the boundaries", () => {
+    expect(phase({ now: new Date("2025-08-02T12:00:00Z") })).toBe("live");
+  });
+
+  it("is Live at the exact liveEnd boundary (inclusive)", () => {
+    expect(phase({ now: new Date(LIVE_END) })).toBe("live");
+  });
+
+  it("is Post-Festival just after liveEnd", () => {
+    expect(phase({ now: new Date("2025-08-04T05:00:00.001Z") })).toBe(
+      "post-festival",
+    );
+  });
+
+  it("NULL start_date never reaches Live/Post (stays Planning)", () => {
+    expect(
+      phase({ startDate: null, now: new Date("2030-01-01T00:00:00Z") }),
+    ).toBe("planning");
+  });
+
+  it("NULL end_date keeps Live and never flips to Post", () => {
+    expect(
+      phase({ endDate: null, now: new Date("2030-01-01T00:00:00Z") }),
+    ).toBe("live");
+  });
+});

--- a/src/lib/festivalPhase.ts
+++ b/src/lib/festivalPhase.ts
@@ -1,0 +1,55 @@
+import { addDays, format, parseISO } from "date-fns";
+import { convertLocalTimeToUTC } from "@/lib/timeUtils";
+import type { RevealLevel } from "@/lib/scheduleReveal";
+
+export type FestivalPhase =
+  | "pre-schedule"
+  | "planning"
+  | "live"
+  | "post-festival";
+
+export type FestivalPhaseInput = {
+  revealLevel: RevealLevel;
+  startDate: string | null;
+  endDate: string | null;
+  timezone: string;
+  now: Date;
+};
+
+export function getFestivalPhase({
+  revealLevel,
+  startDate,
+  endDate,
+  timezone,
+  now,
+}: FestivalPhaseInput): FestivalPhase {
+  if (revealLevel === "draft") return "pre-schedule";
+
+  const liveStart = startDate
+    ? zonedInstant(shiftDayKey(startDate, -1), "00:00:00", timezone)
+    : null;
+  if (!liveStart || now.getTime() < liveStart.getTime()) return "planning";
+
+  const liveEnd = endDate
+    ? zonedInstant(shiftDayKey(endDate, 1), "06:00:00", timezone)
+    : null;
+  if (!liveEnd || now.getTime() <= liveEnd.getTime()) return "live";
+
+  return "post-festival";
+}
+
+// Shift a yyyy-MM-dd calendar day by whole days, staying a yyyy-MM-dd string.
+function shiftDayKey(dateKey: string, delta: number): string {
+  return format(addDays(parseISO(dateKey), delta), "yyyy-MM-dd");
+}
+
+// The UTC instant for a wall-clock day + time read in the festival timezone,
+// via the same fromZonedTime-based helper the display path uses.
+function zonedInstant(
+  dateKey: string,
+  time: string,
+  timezone: string,
+): Date | null {
+  const iso = convertLocalTimeToUTC(`${dateKey} ${time}`, timezone);
+  return iso ? new Date(iso) : null;
+}

--- a/src/lib/festivalPhase.ts
+++ b/src/lib/festivalPhase.ts
@@ -1,4 +1,4 @@
-import { addDays, format, parseISO } from "date-fns";
+import { addDays, format, isValid, parseISO } from "date-fns";
 import { convertLocalTimeToUTC } from "@/lib/timeUtils";
 import type { RevealLevel } from "@/lib/scheduleReveal";
 
@@ -39,17 +39,21 @@ export function getFestivalPhase({
 }
 
 // Shift a yyyy-MM-dd calendar day by whole days, staying a yyyy-MM-dd string.
-function shiftDayKey(dateKey: string, delta: number): string {
-  return format(addDays(parseISO(dateKey), delta), "yyyy-MM-dd");
+// Returns null for an unparseable date so callers degrade instead of throwing.
+function shiftDayKey(dateKey: string, delta: number): string | null {
+  const date = parseISO(dateKey);
+  if (!isValid(date)) return null;
+  return format(addDays(date, delta), "yyyy-MM-dd");
 }
 
 // The UTC instant for a wall-clock day + time read in the festival timezone,
 // via the same fromZonedTime-based helper the display path uses.
 function zonedInstant(
-  dateKey: string,
+  dateKey: string | null,
   time: string,
   timezone: string,
 ): Date | null {
+  if (!dateKey) return null;
   const iso = convertLocalTimeToUTC(`${dateKey} ${time}`, timezone);
   return iso ? new Date(iso) : null;
 }


### PR DESCRIPTION
Derives the festival phase (Pre-Schedule → Planning → Live → Post-Festival) from reveal level, start/end dates and festival timezone — no stored phase, no migration. Closes #136.

This slice adds the derivation seam only; consumers land in later festival-phase tickets, so behavior is verified by unit tests (with `now` injected) rather than a running screen.

## Verification
- `pnpm test src/lib/festivalPhase.test.ts` — 10 cases pass. They assert only phase output for an injected `now`, no clock/DOM/React mocking:
  - `draft` reveal level ⇒ `pre-schedule` regardless of dates.
  - Non-draft: before `start_date − 1 day @ 00:00` (festival tz) ⇒ `planning`; inclusive on `liveStart`/`liveEnd`; after `end_date + 1 day @ 06:00` ⇒ `post-festival`. Boundaries exercised in `Europe/Lisbon`, including an instant on a different UTC calendar day than the festival's.
  - NULL `start_date` stays `planning`; NULL `end_date` stays `live`; unparseable dates degrade the same way instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)