### PR TITLE
fix(routing): move single-festival redirect to beforeLoad

### DIFF
--- a/src/pages/FestivalSelection.tsx
+++ b/src/pages/FestivalSelection.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/components/ui/card";
 import { useFestivalsQuery } from "@/api/festivals/useFestivals";
 import { Festival } from "@/api/festivals/types";
-import { useEffect } from "react";
 import {
   createFestivalSubdomainUrl,
   isMainGetuplineDomain,
@@ -27,26 +26,9 @@ export default function FestivalSelection() {
     refetch,
   } = useFestivalsQuery();
 
-  function handleFestivalClick(festival: Festival) {
-    const subdomainUrl = createFestivalSubdomainUrl(festival.slug);
-    const isMain = isMainGetuplineDomain();
-
-    if (isMain) {
-      window.location.href = subdomainUrl;
-    } else {
-      window.location.href = `/festivals/${festival.slug}`;
-    }
-  }
-
   function handleRetry() {
     refetch();
   }
-
-  useEffect(() => {
-    if (!festivalsLoading && availableFestivals.length === 1) {
-      handleFestivalClick(availableFestivals[0]);
-    }
-  }, [availableFestivals, festivalsLoading]);
 
   if (festivalsLoading) {
     return (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,29 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import FestivalSelection from "@/pages/FestivalSelection";
+import { festivalsQuery } from "@/api/festivals/useFestivals";
+import {
+  createFestivalSubdomainUrl,
+  isMainGetuplineDomain,
+} from "@/lib/subdomain";
 
 export const Route = createFileRoute("/")({
   component: FestivalSelection,
+  beforeLoad: async ({ context }) => {
+    const festivals =
+      await context.queryClient.ensureQueryData(festivalsQuery());
+
+    if (festivals.length === 1) {
+      const festival = festivals[0];
+
+      if (isMainGetuplineDomain()) {
+        window.location.href = createFestivalSubdomainUrl(festival.slug);
+        return;
+      }
+
+      throw redirect({
+        to: "/festivals/$festivalSlug",
+        params: { festivalSlug: festival.slug },
+      });
+    }
+  },
 });


### PR DESCRIPTION
Moves the single-festival auto-redirect out of a post-render `useEffect` in `FestivalSelection` into the index route's `beforeLoad`, so there's no flash of the selection grid before redirecting. Duplicated subdomain-redirect logic is gone; `FestivalCard.handleClick` still handles user-initiated clicks.

## Verification
- Visit `/` with exactly one published festival; redirect happens with no visible flash of the selection grid.
- On the main domain, confirm the redirect lands on the festival's subdomain URL.
- Off the main domain, confirm the redirect navigates in-app to `/festivals/$festivalSlug`.
- With zero or two-plus festivals, the selection grid still renders as before.

Closes #85

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnMoytqBEnK3TCeRZvW2yE)_