### PR TITLE
docs(skills): add low-hanging-fruits skill

### DIFF
--- a/.claude/skills/low-hanging-fruits/SKILL.md
+++ b/.claude/skills/low-hanging-fruits/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: low-hanging-fruits
 description: Find ready-for-agent GitHub issues that are simple and unblocked, and hand off a ready-to-use prompt for implementing the confirmed batch in parallel. Use when the user asks to "do a batch of low hanging fruit", "pick up ready-for-agent tickets", or similar.
+disable-model-invocation: true
 ---
 
 # Low hanging fruits

--- a/.claude/skills/low-hanging-fruits/SKILL.md
+++ b/.claude/skills/low-hanging-fruits/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: low-hanging-fruits
-description: Find ready-for-agent GitHub issues that are safe to implement right now, and implement them in parallel via isolated worktree agents. Use when the user asks to "do a batch of low hanging fruit", "pick up ready-for-agent tickets", or similar.
+description: Find ready-for-agent GitHub issues that are simple and unblocked, and hand off a ready-to-use prompt for implementing the confirmed batch in parallel. Use when the user asks to "do a batch of low hanging fruit", "pick up ready-for-agent tickets", or similar.
 ---
 
 # Low hanging fruits
 
-Select a batch of standalone, unblocked `ready-for-agent` issues and implement
-them in parallel, each in its own isolated worktree, each ending in a
-self-reviewed PR.
+Find a batch of standalone, unblocked, **simple** `ready-for-agent` issues,
+confirm the batch with the user, then hand off a ready-to-use prompt for
+implementing them. This skill only discovers and filters — it does not call
+`Agent`/`Task` itself, and it does not implement anything. It stops at the
+handoff prompt.
 
 ## 1. List candidates
 
@@ -16,14 +18,14 @@ self-reviewed PR.
 
 ## 2. Filter
 
-Apply all three checks below before treating an issue as pickable. Do this
-for every candidate, not just the ones that look busy.
+Apply every check below before treating an issue as pickable. Do this for
+every candidate, not just the ones that look busy.
 
 **Skip WIP.** For each candidate issue `#n`, check `list_pull_requests` /
 `search_pull_requests` (open, this repo) for a PR whose title or body
 references `Closes #n` or `#n`. If one exists — even from a different
-session — skip it. Don't open a second PR against an issue already in
-flight.
+session — skip it. Don't suggest a second implementation of an issue
+already in flight.
 
 **Skip epic subtasks by default.** An issue is a subtask if its body has a
 `## Parent` line linking to another issue (the convention used in this repo
@@ -35,58 +37,55 @@ Sibling subtasks of the same epic tend to touch overlapping surfaces
 parallel, so they need more coordination than a plain low-hanging-fruit
 batch.
 
-**Also check transitively.** Re-read each candidate's `## Blocked by`
+**Verify blockers transitively.** Re-read each candidate's `## Blocked by`
 section and verify every listed blocker issue is actually closed (don't
 trust that a ticket labeled `ready-for-agent` has had its blockers
 re-verified — labels go stale). An issue whose blocker just merged is fair
 game; one whose blocker is still open is not, regardless of its own label.
 
+**Skip complex work.** `ready-for-agent` + unblocked is necessary but not
+sufficient — low hanging fruit also means the resulting PR will be small,
+fast to review, and unlikely to need drawn-out back-and-forth. This can
+only be predicted from the issue body (there's no diff yet), so hard-skip
+an issue if its description matches any of the following categories, even
+if the prose reads as contained:
+
+1. Requires a new/changed migration beyond adding a single column or index
+   to an existing table. A plain `ALTER TABLE ... ADD COLUMN` (+ optional
+   index) is fine; a new table, new RLS policy, or new enum is not.
+2. Touches auth (login/session/magic-link/OTP flows).
+3. Requires new test infrastructure or seed-data changes.
+4. Introduces a new shared/cross-cutting primitive that other tickets are
+   expected to build on.
+5. Multi-view/multi-mode UI work — rendering N named states/levels/modes of
+   the same screen.
+
+These are one-line judgment calls, not keyword matches — apply them by
+reading the issue, not by scanning for literal phrases. There's no
+numeric backstop (e.g. acceptance-criteria bullet count) on top of this —
+the confirmation step below is the real safety net, so this filter doesn't
+need to be exhaustive.
+
 ## 3. Confirm the batch
 
-Show the user the filtered list before launching anything: which issues made
-the cut, which were skipped as WIP, which were skipped as epic subtasks, and
-why. This is a multi-PR, multi-branch action — surface it, don't just go.
+Show the user the filtered list before doing anything else:
 
-## 4. Implement in parallel
+- Which issues made the cut.
+- Which were skipped, and why — WIP, epic subtask, still blocked, or which
+  complexity category. Don't silently drop anything.
 
-One `Agent` tool call per issue, all in a single message so they run
-concurrently, each with `isolation: "worktree"`. Each agent's prompt should
-include:
+Wait for the user's approval (or edits) of the batch.
 
-- The full issue body (title, what-to-build, acceptance criteria) — don't
-  make the agent re-fetch it, paste it in.
-- A branch name: `claude/issue-<n>-<short-slug>`.
-- An instruction to read this repo's CLAUDE.md conventions before starting
-  (function declarations, query/mutation naming, no barrel exports, etc).
-- The full workflow: implement → commit → push → read
-  `.claude/skills/create-pr/SKILL.md` and follow it exactly to open the PR
-  (reference `Closes #<n>`) → invoke the `code-review` skill against the
-  diff → apply confirmed fixes → report back the PR URL and a summary.
+## 4. Hand off
 
-## 5. After launching
+Once the user approves the batch, output a single ready-to-use prompt for
+them to give to the next process — do not call `Agent`/`Task` yourself.
+Shape:
 
-Background agents notify on completion — don't poll. When a PR opens,
-webhook subscription (`subscribe_pr_activity`) picks up CI/review events
-automatically if the session is already watching, or subscribe explicitly.
+```
+/implement in parallel each of these issues on chiptus/UpLine: #xx, #xy, #xz.
+Each issue in its own worktree and branch. Once an issue's implementation
+finishes, run /create-pr and /code-review for it.
+```
 
-## Gotcha: don't work in the shared main directory while agents are running
-
-`isolation: "worktree"` should give each agent its own directory under
-`.claude/worktrees/agent-<id>`. In practice the shared main repo directory
-(the one this session's own `Bash` calls default to) can end up checked out
-onto an agent's branch too, with leftover staged changes from that
-transition. If a stop-hook or `git status` reports uncommitted changes in
-the shared directory that don't match what _you_ were doing there:
-
-1. **Don't commit or push reflexively.** Investigate first — run
-   `git worktree list` and check whether the same branch is checked out in
-   both the shared directory and an agent's isolated worktree.
-2. Check the isolated worktree's own `git status` — if it has real
-   in-progress work, leave it alone.
-3. If the shared directory's changes look like an accidental revert of
-   already-merged content (not something you or the user authored), stash
-   them with `git stash push -u -m "..."` (reversible, not a hard discard)
-   and `git checkout` back to the session's actual designated branch.
-4. Report what happened before doing anything else — this is exactly the
-   kind of unexpected repo state the top-level safety rules say to
-   investigate before touching.
+Substitute the approved issue numbers. This skill's job ends here.

--- a/.claude/skills/low-hanging-fruits/SKILL.md
+++ b/.claude/skills/low-hanging-fruits/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: low-hanging-fruits
+description: Find ready-for-agent GitHub issues that are safe to implement right now, and implement them in parallel via isolated worktree agents. Use when the user asks to "do a batch of low hanging fruit", "pick up ready-for-agent tickets", or similar.
+---
+
+# Low hanging fruits
+
+Select a batch of standalone, unblocked `ready-for-agent` issues and implement
+them in parallel, each in its own isolated worktree, each ending in a
+self-reviewed PR.
+
+## 1. List candidates
+
+`list_issues` (or `search_issues`) for `chiptus/UpLine`, state `OPEN`, label
+`ready-for-agent`.
+
+## 2. Filter
+
+Apply both filters before treating an issue as pickable. Do this for every
+candidate, not just the ones that look busy.
+
+**Skip WIP.** For each candidate issue `#n`, check `list_pull_requests` /
+`search_pull_requests` (open, this repo) for a PR whose title or body
+references `Closes #n` or `#n`. If one exists — even from a different
+session — skip it. Don't open a second PR against an issue already in
+flight.
+
+**Skip epic subtasks by default.** An issue is a subtask if its body has a
+`## Parent` line linking to another issue (the convention used in this repo
+— e.g. `## Parent: chiptus/UpLine#122` or `## Parent: Epic #126`). Treat
+these as _not_ standalone low-hanging fruit: surface them separately from
+the batch and only include them if the user explicitly asks for epic work.
+Sibling subtasks of the same epic tend to touch overlapping surfaces
+(shared migrations, shared CI targets) and can collide when run in
+parallel, so they need more coordination than a plain low-hanging-fruit
+batch.
+
+**Also check transitively.** Re-read each candidate's `## Blocked by`
+section and verify every listed blocker issue is actually closed (don't
+trust that a ticket labeled `ready-for-agent` has had its blockers
+re-verified — labels go stale). An issue whose blocker just merged is fair
+game; one whose blocker is still open is not, regardless of its own label.
+
+## 3. Confirm the batch
+
+Show the user the filtered list before launching anything: which issues made
+the cut, which were skipped as WIP, which were skipped as epic subtasks, and
+why. This is a multi-PR, multi-branch action — surface it, don't just go.
+
+## 4. Implement in parallel
+
+One `Agent` tool call per issue, all in a single message so they run
+concurrently, each with `isolation: "worktree"`. Each agent's prompt should
+include:
+
+- The full issue body (title, what-to-build, acceptance criteria) — don't
+  make the agent re-fetch it, paste it in.
+- A branch name: `claude/issue-<n>-<short-slug>`.
+- An instruction to read this repo's CLAUDE.md conventions before starting
+  (function declarations, query/mutation naming, no barrel exports, etc).
+- The full workflow: implement → commit → push → read
+  `.claude/skills/create-pr/SKILL.md` and follow it exactly to open the PR
+  (reference `Closes #<n>`) → invoke the `code-review` skill against the
+  diff → apply confirmed fixes → report back the PR URL and a summary.
+
+## 5. After launching
+
+Background agents notify on completion — don't poll. When a PR opens,
+webhook subscription (`subscribe_pr_activity`) picks up CI/review events
+automatically if the session is already watching, or subscribe explicitly.
+
+## Gotcha: don't work in the shared main directory while agents are running
+
+`isolation: "worktree"` should give each agent its own directory under
+`.claude/worktrees/agent-<id>`. In practice the shared main repo directory
+(the one this session's own `Bash` calls default to) can end up checked out
+onto an agent's branch too, with leftover staged changes from that
+transition. If a stop-hook or `git status` reports uncommitted changes in
+the shared directory that don't match what _you_ were doing there:
+
+1. **Don't commit or push reflexively.** Investigate first — run
+   `git worktree list` and check whether the same branch is checked out in
+   both the shared directory and an agent's isolated worktree.
+2. Check the isolated worktree's own `git status` — if it has real
+   in-progress work, leave it alone.
+3. If the shared directory's changes look like an accidental revert of
+   already-merged content (not something you or the user authored), `git
+stash push -u -m "..."` them (reversible, not a hard discard) and
+   `git checkout` back to the session's actual designated branch.
+4. Report what happened before doing anything else — this is exactly the
+   kind of unexpected repo state the top-level safety rules say to
+   investigate before touching.

--- a/.claude/skills/low-hanging-fruits/SKILL.md
+++ b/.claude/skills/low-hanging-fruits/SKILL.md
@@ -16,8 +16,8 @@ self-reviewed PR.
 
 ## 2. Filter
 
-Apply both filters before treating an issue as pickable. Do this for every
-candidate, not just the ones that look busy.
+Apply all three checks below before treating an issue as pickable. Do this
+for every candidate, not just the ones that look busy.
 
 **Skip WIP.** For each candidate issue `#n`, check `list_pull_requests` /
 `search_pull_requests` (open, this repo) for a PR whose title or body
@@ -84,9 +84,9 @@ the shared directory that don't match what _you_ were doing there:
 2. Check the isolated worktree's own `git status` — if it has real
    in-progress work, leave it alone.
 3. If the shared directory's changes look like an accidental revert of
-   already-merged content (not something you or the user authored), `git
-stash push -u -m "..."` them (reversible, not a hard discard) and
-   `git checkout` back to the session's actual designated branch.
+   already-merged content (not something you or the user authored), stash
+   them with `git stash push -u -m "..."` (reversible, not a hard discard)
+   and `git checkout` back to the session's actual designated branch.
 4. Report what happened before doing anything else — this is exactly the
    kind of unexpected repo state the top-level safety rules say to
    investigate before touching.


### PR DESCRIPTION
Codifies today's batch-selection process for `ready-for-agent` issues: skip issues with an open PR already targeting them, skip epic subtasks (`## Parent` reference) by default, and the parallel worktree-agent implement → create-pr → code-review flow.

No runtime behavior to verify — this is a new skill instructions file only (`.claude/skills/low-hanging-fruits/SKILL.md`), no application code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKMx3D6cDTnUEYacpy9Mn6)_