### PR TITLE
refactor(groups): unify group creator role check

### DIFF
--- a/src/lib/groupPermissions.test.ts
+++ b/src/lib/groupPermissions.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isGroupCreator } from "./groupPermissions";
+
+describe("isGroupCreator", () => {
+  it("is true when the user id matches created_by", () => {
+    expect(isGroupCreator("user-1", "user-1")).toBe(true);
+  });
+
+  it("is false for a different member's user id", () => {
+    expect(isGroupCreator("user-1", "user-2")).toBe(false);
+  });
+});

--- a/src/lib/groupPermissions.ts
+++ b/src/lib/groupPermissions.ts
@@ -1,0 +1,3 @@
+export function isGroupCreator(createdBy: string, userId: string): boolean {
+  return createdBy === userId;
+}

--- a/src/pages/groups/GroupDetail.tsx
+++ b/src/pages/groups/GroupDetail.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { groupBySlugQuery } from "@/api/groups/useGroupBySlug";
 import { groupMembersQuery } from "@/api/groups/useGroupMembers";
 import { useRemoveMemberMutation } from "@/api/groups/useRemoveMember";
+import { isGroupCreator } from "@/lib/groupPermissions";
 
 function GroupDetail() {
   const { user } = useRouteContext({ from: "/groups/$groupSlug" });
@@ -55,7 +56,7 @@ function GroupDetailContent({ user }: { user: User }) {
   const { data: members } = useSuspenseQuery(groupMembersQuery(group.id));
   const removeMemberMutation = useRemoveMemberMutation(group.id);
 
-  const isCreator = group.created_by === user.id;
+  const isCreator = isGroupCreator(group.created_by, user.id);
 
   return (
     <div className="min-h-screen bg-app-gradient">
@@ -118,7 +119,10 @@ function GroupDetailContent({ user }: { user: User }) {
                 <div className="space-y-3">
                   {members.map((member) => {
                     const isCurrentUser = member.user_id === user.id;
-                    const isMemberCreator = member.role === "creator";
+                    const isMemberCreator = isGroupCreator(
+                      group.created_by,
+                      member.user_id,
+                    );
                     const profile = member.profiles;
 
                     return (


### PR DESCRIPTION
Adds `isGroupCreator(createdBy, userId)` so `GroupDetail.tsx`'s page-level and per-member creator checks both derive from `group.created_by` — the same field the Postgres `is_group_creator()` RLS function treats as authoritative — instead of one of them reading the unenforced `group_members.role` column.

Closes #163

## Verification
- Open a group you created: crown badge shows next to your name, invite tab enabled, add-member form visible.
- Open a group you joined (not created): no crown badge on you, invite tab disabled, no remove button next to your own row.
- As creator, view the member list: crown badge appears only on your own row, remove button appears on every other member's row.
- `pnpm test` — full suite passes (353 tests, including new `groupPermissions.test.ts`).
- `pnpm run typecheck` and `pnpm run lint` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGYwJL71hVsgK93B3Li4Ya)_