### PR TITLE
feat(timeline): scroll position lives in url

### DIFF
--- a/src/hooks/useTimelineScrollSync.ts
+++ b/src/hooks/useTimelineScrollSync.ts
@@ -87,6 +87,12 @@ export function useTimelineScrollSync({
 
     let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+      if (debounceTimer) clearTimeout(debounceTimer);
+    };
+
     function handleScroll() {
       const programmaticLeft = programmaticScrollLeftRef.current;
       if (programmaticLeft !== null) {
@@ -116,11 +122,5 @@ export function useTimelineScrollSync({
         });
       }, SCROLL_DEBOUNCE_MS);
     }
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => {
-      container.removeEventListener("scroll", handleScroll);
-      if (debounceTimer) clearTimeout(debounceTimer);
-    };
   }, [scrollContainerRef, festivalStart, navigate]);
 }

--- a/src/hooks/useTimelineScrollSync.ts
+++ b/src/hooks/useTimelineScrollSync.ts
@@ -47,7 +47,10 @@ export function useTimelineScrollSync({
   const navigate = useNavigate({ from: route });
 
   const hasCenteredOnMountRef = useRef(false);
-  const suppressNextScrollEventRef = useRef(false);
+  // Position of the last programmatic scroll; scroll events reporting this
+  // position are ignored (a browser may fire more than one for a single
+  // scrollLeft write), so only genuine user scrolling reaches the URL.
+  const programmaticScrollLeftRef = useRef<number | null>(null);
 
   useLayoutEffect(() => {
     if (hasCenteredOnMountRef.current) return;
@@ -68,7 +71,7 @@ export function useTimelineScrollSync({
     );
 
     if (targetScrollLeft !== container.scrollLeft) {
-      suppressNextScrollEventRef.current = true;
+      programmaticScrollLeftRef.current = targetScrollLeft;
       container.scrollLeft = targetScrollLeft;
     }
     // Mount-only positioning: intentionally does not re-run when scrollTo/day
@@ -83,9 +86,13 @@ export function useTimelineScrollSync({
     let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
     function handleScroll() {
-      if (suppressNextScrollEventRef.current) {
-        suppressNextScrollEventRef.current = false;
-        return;
+      const programmaticLeft = programmaticScrollLeftRef.current;
+      if (programmaticLeft !== null) {
+        const el = scrollContainerRef.current;
+        if (el && Math.abs(el.scrollLeft - programmaticLeft) <= 1) {
+          return;
+        }
+        programmaticScrollLeftRef.current = null;
       }
 
       if (debounceTimer) clearTimeout(debounceTimer);

--- a/src/hooks/useTimelineScrollSync.ts
+++ b/src/hooks/useTimelineScrollSync.ts
@@ -42,7 +42,6 @@ export function useTimelineScrollSync({
   const { scrollTo, day } = useSearch({
     from: route,
     select: (search) => ({ scrollTo: search.scrollTo, day: search.day }),
-    structuralSharing: true,
   });
   const navigate = useNavigate({ from: route });
 

--- a/src/hooks/useTimelineScrollSync.ts
+++ b/src/hooks/useTimelineScrollSync.ts
@@ -1,0 +1,117 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import type { RefObject } from "react";
+import { offsetToTime, timeToOffset } from "@/lib/timelineCalculator";
+import {
+  resolveTimelineMountMoment,
+  roundToNearestMinutes,
+} from "@/lib/timelineMountMoment";
+
+const SCROLL_DEBOUNCE_MS = 300;
+const SCROLL_ROUND_MINUTES = 5;
+
+interface UseTimelineScrollSyncOptions {
+  scrollContainerRef: RefObject<HTMLDivElement>;
+  festivalStart: Date;
+  timezone: string;
+}
+
+/**
+ * Owns the one-way sync between the timeline's scroll position and the
+ * `scrollTo` URL param:
+ *
+ *   - On mount only: centers the viewport per `resolveTimelineMountMoment`'s
+ *     precedence (scrollTo -> day filter -> festival start).
+ *   - On user scroll: after the scroll settles (~300ms), writes the moment
+ *     now centered in the viewport back to the URL (history replace),
+ *     rounded to 5-minute granularity.
+ *
+ * These two directions never trigger each other: the mount effect runs once
+ * and the scroll listener only ever navigates, never touches `scrollLeft`.
+ */
+export function useTimelineScrollSync({
+  scrollContainerRef,
+  festivalStart,
+  timezone,
+}: UseTimelineScrollSyncOptions) {
+  const route =
+    "/festivals/$festivalSlug/editions/$editionSlug/schedule/timeline" as const;
+
+  // Narrow, structurally-shared selection: this hook only cares about
+  // scrollTo/day, so its own writes to scrollTo don't cascade elsewhere.
+  const { scrollTo, day } = useSearch({
+    from: route,
+    select: (search) => ({ scrollTo: search.scrollTo, day: search.day }),
+    structuralSharing: true,
+  });
+  const navigate = useNavigate({ from: route });
+
+  const hasCenteredOnMountRef = useRef(false);
+  const suppressNextScrollEventRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (hasCenteredOnMountRef.current) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    hasCenteredOnMountRef.current = true;
+
+    const moment = resolveTimelineMountMoment({
+      scrollTo,
+      day,
+      timezone,
+      festivalStart,
+    });
+
+    const targetScrollLeft = Math.max(
+      0,
+      timeToOffset(moment, festivalStart) - container.clientWidth / 2,
+    );
+
+    if (targetScrollLeft !== container.scrollLeft) {
+      suppressNextScrollEventRef.current = true;
+      container.scrollLeft = targetScrollLeft;
+    }
+    // Mount-only positioning: intentionally does not re-run when scrollTo/day
+    // change afterwards (one-way ownership, URL -> scroll only on mount).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollContainerRef]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function handleScroll() {
+      if (suppressNextScrollEventRef.current) {
+        suppressNextScrollEventRef.current = false;
+        return;
+      }
+
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        const el = scrollContainerRef.current;
+        if (!el) return;
+
+        const centerOffset = el.scrollLeft + el.clientWidth / 2;
+        const centerMoment = offsetToTime(centerOffset, festivalStart);
+        const rounded = roundToNearestMinutes(
+          centerMoment,
+          SCROLL_ROUND_MINUTES,
+        );
+
+        navigate({
+          to: ".",
+          search: (prev) => ({ ...prev, scrollTo: rounded.toISOString() }),
+          replace: true,
+        });
+      }, SCROLL_DEBOUNCE_MS);
+    }
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+      if (debounceTimer) clearTimeout(debounceTimer);
+    };
+  }, [scrollContainerRef, festivalStart, navigate]);
+}

--- a/src/hooks/useTimelineScrollSync.ts
+++ b/src/hooks/useTimelineScrollSync.ts
@@ -71,8 +71,10 @@ export function useTimelineScrollSync({
     );
 
     if (targetScrollLeft !== container.scrollLeft) {
-      programmaticScrollLeftRef.current = targetScrollLeft;
       container.scrollLeft = targetScrollLeft;
+      // Read back: the browser clamps to the scrollable range, and the
+      // suppression check must match the position events will report.
+      programmaticScrollLeftRef.current = container.scrollLeft;
     }
     // Mount-only positioning: intentionally does not re-run when scrollTo/day
     // change afterwards (one-way ownership, URL -> scroll only on mount).

--- a/src/hooks/useTimelineUrlState.ts
+++ b/src/hooks/useTimelineUrlState.ts
@@ -14,7 +14,6 @@ export function useTimelineUrlState(tab: "timeline" | "list" = "timeline") {
       time: search.time,
       stages: search.stages,
     }),
-    structuralSharing: true,
   });
   const navigate = useNavigate({ from: route });
 

--- a/src/hooks/useTimelineUrlState.ts
+++ b/src/hooks/useTimelineUrlState.ts
@@ -7,8 +7,18 @@ export type TimeFilter = TimelineSearch["time"];
 export function useTimelineUrlState(tab: "timeline" | "list" = "timeline") {
   const route =
     `/festivals/$festivalSlug/editions/$editionSlug/schedule/${tab}` as const;
+  // Select only the filter params this hook exposes, with structural sharing,
+  // so a `scrollTo` write (from scroll syncing) doesn't change this object's
+  // identity and trigger consumers to recompute the filtered schedule.
   const state = useSearch({
     from: route,
+    select: (search) => ({
+      view: search.view,
+      day: search.day,
+      time: search.time,
+      stages: search.stages,
+    }),
+    structuralSharing: true,
   });
   const navigate = useNavigate({ from: route });
 

--- a/src/hooks/useTimelineUrlState.ts
+++ b/src/hooks/useTimelineUrlState.ts
@@ -13,7 +13,6 @@ export function useTimelineUrlState(tab: "timeline" | "list" = "timeline") {
   const state = useSearch({
     from: route,
     select: (search) => ({
-      view: search.view,
       day: search.day,
       time: search.time,
       stages: search.stages,

--- a/src/hooks/useTimelineUrlState.ts
+++ b/src/hooks/useTimelineUrlState.ts
@@ -7,9 +7,6 @@ export type TimeFilter = TimelineSearch["time"];
 export function useTimelineUrlState(tab: "timeline" | "list" = "timeline") {
   const route =
     `/festivals/$festivalSlug/editions/$editionSlug/schedule/${tab}` as const;
-  // Select only the filter params this hook exposes, with structural sharing,
-  // so a `scrollTo` write (from scroll syncing) doesn't change this object's
-  // identity and trigger consumers to recompute the filtered schedule.
   const state = useSearch({
     from: route,
     select: (search) => ({

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -38,8 +38,6 @@ export const timelineSearchSchema = z.object({
   day: z.string().catch("all"),
   time: z.enum(["all", "morning", "afternoon", "evening"]).catch("all"),
   stages: z.array(z.string()).catch([]),
-  // The moment (ISO datetime) centered in the timeline viewport. Absent by
-  // default; only written once the user scrolls. See useTimelineScrollSync.
   scrollTo: z.string().optional().catch(undefined),
 });
 

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -38,6 +38,9 @@ export const timelineSearchSchema = z.object({
   day: z.string().catch("all"),
   time: z.enum(["all", "morning", "afternoon", "evening"]).catch("all"),
   stages: z.array(z.string()).catch([]),
+  // The moment (ISO datetime) centered in the timeline viewport. Absent by
+  // default; only written once the user scrolls. See useTimelineScrollSync.
+  scrollTo: z.string().optional().catch(undefined),
 });
 
 export type TimelineSearch = z.infer<typeof timelineSearchSchema>;

--- a/src/lib/timelineMountMoment.test.ts
+++ b/src/lib/timelineMountMoment.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveTimelineMountMoment,
+  roundToNearestMinutes,
+} from "./timelineMountMoment";
+
+const TIMEZONE = "Europe/Lisbon"; // UTC+1 in July (WEST)
+const FESTIVAL_START = new Date("2025-07-12T10:00:00Z");
+
+describe("resolveTimelineMountMoment", () => {
+  it("prefers scrollTo when present and valid", () => {
+    const moment = resolveTimelineMountMoment({
+      scrollTo: "2025-07-13T22:00:00.000Z",
+      day: "2025-07-12",
+      timezone: TIMEZONE,
+      festivalStart: FESTIVAL_START,
+    });
+
+    expect(moment.getTime()).toBe(
+      new Date("2025-07-13T22:00:00.000Z").getTime(),
+    );
+  });
+
+  it("falls back to the day filter's start when scrollTo is absent", () => {
+    const moment = resolveTimelineMountMoment({
+      scrollTo: undefined,
+      day: "2025-07-13",
+      timezone: TIMEZONE,
+      festivalStart: FESTIVAL_START,
+    });
+
+    // Midnight in Europe/Lisbon (UTC+1 in July) is 23:00 UTC the prior day.
+    expect(moment.getTime()).toBe(
+      new Date("2025-07-12T23:00:00.000Z").getTime(),
+    );
+  });
+
+  it("falls back to the day filter's start when scrollTo is an invalid date string", () => {
+    const moment = resolveTimelineMountMoment({
+      scrollTo: "not-a-date",
+      day: "2025-07-13",
+      timezone: TIMEZONE,
+      festivalStart: FESTIVAL_START,
+    });
+
+    expect(moment.getTime()).toBe(
+      new Date("2025-07-12T23:00:00.000Z").getTime(),
+    );
+  });
+
+  it("falls back to festivalStart when day filter is 'all' and scrollTo is absent", () => {
+    const moment = resolveTimelineMountMoment({
+      scrollTo: undefined,
+      day: "all",
+      timezone: TIMEZONE,
+      festivalStart: FESTIVAL_START,
+    });
+
+    expect(moment.getTime()).toBe(FESTIVAL_START.getTime());
+  });
+
+  it("falls back to festivalStart when scrollTo is invalid and day is 'all'", () => {
+    const moment = resolveTimelineMountMoment({
+      scrollTo: "garbage",
+      day: "all",
+      timezone: TIMEZONE,
+      festivalStart: FESTIVAL_START,
+    });
+
+    expect(moment.getTime()).toBe(FESTIVAL_START.getTime());
+  });
+
+  it("scrollTo takes precedence over an active day filter", () => {
+    const moment = resolveTimelineMountMoment({
+      scrollTo: "2025-07-14T12:00:00.000Z",
+      day: "2025-07-13",
+      timezone: TIMEZONE,
+      festivalStart: FESTIVAL_START,
+    });
+
+    expect(moment.getTime()).toBe(
+      new Date("2025-07-14T12:00:00.000Z").getTime(),
+    );
+  });
+});
+
+describe("roundToNearestMinutes", () => {
+  it("rounds down to the nearest 5 minutes", () => {
+    const date = new Date("2025-07-12T10:02:00.000Z");
+    expect(roundToNearestMinutes(date, 5).getTime()).toBe(
+      new Date("2025-07-12T10:00:00.000Z").getTime(),
+    );
+  });
+
+  it("rounds up to the nearest 5 minutes", () => {
+    const date = new Date("2025-07-12T10:03:00.000Z");
+    expect(roundToNearestMinutes(date, 5).getTime()).toBe(
+      new Date("2025-07-12T10:05:00.000Z").getTime(),
+    );
+  });
+
+  it("defaults to a 5-minute granularity", () => {
+    const date = new Date("2025-07-12T10:07:00.000Z");
+    expect(roundToNearestMinutes(date).getTime()).toBe(
+      new Date("2025-07-12T10:05:00.000Z").getTime(),
+    );
+  });
+
+  it("is a no-op for a moment already on the grid", () => {
+    const date = new Date("2025-07-12T10:15:00.000Z");
+    expect(roundToNearestMinutes(date, 5).getTime()).toBe(date.getTime());
+  });
+});

--- a/src/lib/timelineMountMoment.ts
+++ b/src/lib/timelineMountMoment.ts
@@ -1,0 +1,60 @@
+import { isValid, parseISO } from "date-fns";
+import { fromZonedTime } from "date-fns-tz";
+
+export interface TimelineMountMomentInput {
+  /** Raw `scrollTo` search param, if present in the URL. */
+  scrollTo?: string;
+  /** Active day filter: "all" or a "yyyy-MM-dd" festival calendar day. */
+  day: string;
+  /** Festival's IANA timezone, used to resolve the day filter's start. */
+  timezone: string;
+  /** Timeline geometry origin (earliest moment on the timeline). */
+  festivalStart: Date;
+}
+
+/**
+ * Decides which moment the timeline viewport should be centered on when the
+ * Timeline mounts. Pure and order-sensitive:
+ *
+ *   1. `scrollTo` from the URL, if present and parseable.
+ *   2. The start of the active `day` filter, if one is set.
+ *   3. The festival start (timeline origin).
+ *
+ * A future rule ("now, minus 1h, when now falls inside the festival window")
+ * slots in as an additional candidate between the day filter and the
+ * festival-start fallback (see issue #194).
+ */
+export function resolveTimelineMountMoment(
+  input: TimelineMountMomentInput,
+): Date {
+  return (
+    momentFromScrollTo(input.scrollTo) ??
+    momentFromDayFilter(input.day, input.timezone) ??
+    input.festivalStart
+  );
+}
+
+function momentFromScrollTo(scrollTo: string | undefined): Date | null {
+  if (!scrollTo) return null;
+  const parsed = parseISO(scrollTo);
+  return isValid(parsed) ? parsed : null;
+}
+
+function momentFromDayFilter(day: string, timezone: string): Date | null {
+  if (!day || day === "all") return null;
+  try {
+    const dayStart = fromZonedTime(`${day}T00:00:00`, timezone);
+    return isValid(dayStart) ? dayStart : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rounds a moment to the nearest multiple of `minutes` (default 5), used to
+ * keep `scrollTo` URL writes coarse-grained instead of pixel-precise.
+ */
+export function roundToNearestMinutes(date: Date, minutes = 5): Date {
+  const ms = minutes * 60 * 1000;
+  return new Date(Math.round(date.getTime() / ms) * ms);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,6 +30,7 @@ const router = createRouter({
   },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
+  defaultStructuralSharing: true,
   defaultNotFoundComponent: NotFound,
   defaultPendingComponent: RouteLoadingFallback,
   defaultErrorComponent: RouteErrorFallback,

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { TimeScale } from "./TimeScale";
 import { StageRow } from "./StageRow";
 import type { TimelineData } from "@/lib/timelineCalculator";
+import { useTimelineScrollSync } from "@/hooks/useTimelineScrollSync";
 
 interface TimelineContainerProps {
   timelineData: TimelineData;
@@ -14,9 +15,16 @@ export function TimelineContainer({
 }: TimelineContainerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
+  useTimelineScrollSync({
+    scrollContainerRef,
+    festivalStart: timelineData.festivalStart,
+    timezone,
+  });
+
   return (
     <div
       ref={scrollContainerRef}
+      data-testid="timeline-scroll-container"
       className="overflow-x-auto overflow-y-hidden pb-20"
     >
       {/* Time Scale */}

--- a/tests/e2e/timeline-scroll.spec.ts
+++ b/tests/e2e/timeline-scroll.spec.ts
@@ -2,10 +2,12 @@ import { test, expect } from "@playwright/test";
 
 // Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
-const SCROLL_DEBOUNCE_WAIT_MS = 600; // > the ~300ms debounce in useTimelineScrollSync
+// Fast-forwarded past the ~300ms debounce via Playwright's fake clock.
+const SCROLL_DEBOUNCE_WAIT_MS = 600;
 
 test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("untouched timeline has no scrollTo in the URL", async ({ page }) => {
+    await page.clock.install();
     await page.goto(TIMELINE_PATH);
 
     const scrollContainer = page.getByTestId("timeline-scroll-container");
@@ -19,6 +21,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("scrolling writes a debounced, rounded scrollTo via history replace", async ({
     page,
   }) => {
+    await page.clock.install();
     await page.goto(TIMELINE_PATH);
 
     const scrollContainer = page.getByTestId("timeline-scroll-container");
@@ -35,10 +38,10 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     });
 
     // No write yet: still inside the debounce window.
-    await page.waitForTimeout(100);
+    await page.clock.fastForward(100);
     expect(new URL(page.url()).searchParams.has("scrollTo")).toBe(false);
 
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await page.clock.fastForward(SCROLL_DEBOUNCE_WAIT_MS);
     await expect(page).toHaveURL(/scrollTo=/);
 
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
@@ -52,7 +55,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 200;
     });
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await page.clock.fastForward(SCROLL_DEBOUNCE_WAIT_MS);
 
     const historyLengthAfterScroll = await page.evaluate(
       () => window.history.length,
@@ -63,6 +66,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("opening a URL with scrollTo centers the viewport on that moment", async ({
     page,
   }) => {
+    await page.clock.install();
     await page.goto(TIMELINE_PATH);
 
     const scrollContainer = page.getByTestId("timeline-scroll-container");
@@ -74,7 +78,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 600;
     });
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await page.clock.fastForward(SCROLL_DEBOUNCE_WAIT_MS);
 
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
     expect(scrollTo).toBeTruthy();
@@ -101,6 +105,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("back from a set detail page and a full reload both restore the viewport position", async ({
     page,
   }) => {
+    await page.clock.install();
     await page.goto(TIMELINE_PATH);
 
     const scrollContainer = page.getByTestId("timeline-scroll-container");
@@ -111,7 +116,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 500;
     });
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await page.clock.fastForward(SCROLL_DEBOUNCE_WAIT_MS);
 
     const urlWithScroll = page.url();
     const scrollLeftBeforeNav = await scrollContainer.evaluate(

--- a/tests/e2e/timeline-scroll.spec.ts
+++ b/tests/e2e/timeline-scroll.spec.ts
@@ -119,20 +119,22 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     );
 
     const setLink = page.locator('a[href*="/sets/"]').first();
-    if (await setLink.isVisible().catch(() => false)) {
-      await setLink.click();
-      await page.goBack();
-      await expect(page).toHaveURL(urlWithScroll);
+    test.skip(
+      !(await setLink.isVisible().catch(() => false)),
+      "No set detail link rendered in this environment",
+    );
+    await setLink.click();
+    await page.goBack();
+    await expect(page).toHaveURL(urlWithScroll);
 
-      const restoredContainer = page.getByTestId("timeline-scroll-container");
-      await expect(restoredContainer).toBeVisible();
-      const scrollLeftAfterBack = await restoredContainer.evaluate(
-        (el) => el.scrollLeft,
-      );
-      expect(Math.abs(scrollLeftAfterBack - scrollLeftBeforeNav)).toBeLessThan(
-        10,
-      );
-    }
+    const restoredContainer = page.getByTestId("timeline-scroll-container");
+    await expect(restoredContainer).toBeVisible();
+    const scrollLeftAfterBack = await restoredContainer.evaluate(
+      (el) => el.scrollLeft,
+    );
+    expect(Math.abs(scrollLeftAfterBack - scrollLeftBeforeNav)).toBeLessThan(
+      10,
+    );
 
     // A full reload of the same URL should independently restore the
     // viewport position via mount-time centering on scrollTo.

--- a/tests/e2e/timeline-scroll.spec.ts
+++ b/tests/e2e/timeline-scroll.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+
+// Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
+const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
+const SCROLL_DEBOUNCE_WAIT_MS = 600; // > the ~300ms debounce in useTimelineScrollSync
+
+test.describe("Timeline scroll position (scrollTo URL state)", () => {
+  test("untouched timeline has no scrollTo in the URL", async ({ page }) => {
+    await page.goto(TIMELINE_PATH);
+
+    const scrollContainer = page.getByTestId("timeline-scroll-container");
+    if (!(await scrollContainer.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    expect(new URL(page.url()).searchParams.has("scrollTo")).toBe(false);
+  });
+
+  test("scrolling writes a debounced, rounded scrollTo via history replace", async ({
+    page,
+  }) => {
+    await page.goto(TIMELINE_PATH);
+
+    const scrollContainer = page.getByTestId("timeline-scroll-container");
+    if (!(await scrollContainer.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    const historyLengthBeforeScroll = await page.evaluate(
+      () => window.history.length,
+    );
+
+    await scrollContainer.evaluate((el) => {
+      el.scrollLeft = el.scrollLeft + 400;
+    });
+
+    // No write yet: still inside the debounce window.
+    await page.waitForTimeout(100);
+    expect(new URL(page.url()).searchParams.has("scrollTo")).toBe(false);
+
+    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await expect(page).toHaveURL(/scrollTo=/);
+
+    const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
+    expect(scrollTo).toBeTruthy();
+    expect(new Date(scrollTo as string).toString()).not.toBe("Invalid Date");
+    // Rounded to 5-minute granularity.
+    expect(new Date(scrollTo as string).getMinutes() % 5).toBe(0);
+
+    // History replace, not push: writing scrollTo must not grow the
+    // history stack, even across multiple debounced writes.
+    await scrollContainer.evaluate((el) => {
+      el.scrollLeft = el.scrollLeft + 200;
+    });
+    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+
+    const historyLengthAfterScroll = await page.evaluate(
+      () => window.history.length,
+    );
+    expect(historyLengthAfterScroll).toBe(historyLengthBeforeScroll);
+  });
+
+  test("opening a URL with scrollTo centers the viewport on that moment", async ({
+    page,
+  }) => {
+    await page.goto(TIMELINE_PATH);
+
+    const scrollContainer = page.getByTestId("timeline-scroll-container");
+    if (!(await scrollContainer.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    // Scroll to discover a real, in-range moment to jump back to.
+    await scrollContainer.evaluate((el) => {
+      el.scrollLeft = el.scrollLeft + 600;
+    });
+    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+
+    const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
+    expect(scrollTo).toBeTruthy();
+    const scrollLeftAfterScroll = await scrollContainer.evaluate(
+      (el) => el.scrollLeft,
+    );
+
+    // Reset by navigating away, then open the URL with scrollTo directly.
+    await page.goto(`${TIMELINE_PATH}?scrollTo=${encodeURIComponent(scrollTo as string)}`);
+    const reloadedContainer = page.getByTestId("timeline-scroll-container");
+    await expect(reloadedContainer).toBeVisible();
+
+    const scrollLeftOnLoad = await reloadedContainer.evaluate(
+      (el) => el.scrollLeft,
+    );
+
+    // Centering is deterministic given the same viewport width, so this
+    // should land close to where the debounced write captured it from.
+    expect(Math.abs(scrollLeftOnLoad - scrollLeftAfterScroll)).toBeLessThan(
+      10,
+    );
+  });
+
+  test("back from a set detail page and a full reload both restore the viewport position", async ({
+    page,
+  }) => {
+    await page.goto(TIMELINE_PATH);
+
+    const scrollContainer = page.getByTestId("timeline-scroll-container");
+    if (!(await scrollContainer.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    await scrollContainer.evaluate((el) => {
+      el.scrollLeft = el.scrollLeft + 500;
+    });
+    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+
+    const urlWithScroll = page.url();
+    const scrollLeftBeforeNav = await scrollContainer.evaluate(
+      (el) => el.scrollLeft,
+    );
+
+    const setLink = page.locator('a[href*="/sets/"]').first();
+    if (await setLink.isVisible().catch(() => false)) {
+      await setLink.click();
+      await page.goBack();
+      await expect(page).toHaveURL(urlWithScroll);
+
+      const restoredContainer = page.getByTestId("timeline-scroll-container");
+      await expect(restoredContainer).toBeVisible();
+      const scrollLeftAfterBack = await restoredContainer.evaluate(
+        (el) => el.scrollLeft,
+      );
+      expect(Math.abs(scrollLeftAfterBack - scrollLeftBeforeNav)).toBeLessThan(
+        10,
+      );
+    }
+
+    // A full reload of the same URL should independently restore the
+    // viewport position via mount-time centering on scrollTo.
+    await page.goto(urlWithScroll);
+    const reloadedContainer = page.getByTestId("timeline-scroll-container");
+    await expect(reloadedContainer).toBeVisible();
+    const scrollLeftAfterReload = await reloadedContainer.evaluate(
+      (el) => el.scrollLeft,
+    );
+    expect(Math.abs(scrollLeftAfterReload - scrollLeftBeforeNav)).toBeLessThan(
+      10,
+    );
+  });
+});

--- a/tests/e2e/timeline-scroll.spec.ts
+++ b/tests/e2e/timeline-scroll.spec.ts
@@ -1,19 +1,25 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 // Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
 // Fast-forwarded past the ~300ms debounce via Playwright's fake clock.
 const SCROLL_DEBOUNCE_WAIT_MS = 600;
 
+async function openTimeline(page: Page) {
+  await page.clock.install();
+  await page.goto(TIMELINE_PATH);
+
+  const scrollContainer = page.getByTestId("timeline-scroll-container");
+  if (!(await scrollContainer.isVisible().catch(() => false))) {
+    test.skip(true, "Schedule not revealed in this environment");
+  }
+
+  return scrollContainer;
+}
+
 test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("untouched timeline has no scrollTo in the URL", async ({ page }) => {
-    await page.clock.install();
-    await page.goto(TIMELINE_PATH);
-
-    const scrollContainer = page.getByTestId("timeline-scroll-container");
-    if (!(await scrollContainer.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    await openTimeline(page);
 
     expect(new URL(page.url()).searchParams.has("scrollTo")).toBe(false);
   });
@@ -21,13 +27,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("scrolling writes a debounced, rounded scrollTo via history replace", async ({
     page,
   }) => {
-    await page.clock.install();
-    await page.goto(TIMELINE_PATH);
-
-    const scrollContainer = page.getByTestId("timeline-scroll-container");
-    if (!(await scrollContainer.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    const scrollContainer = await openTimeline(page);
 
     const historyLengthBeforeScroll = await page.evaluate(
       () => window.history.length,
@@ -66,13 +66,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("opening a URL with scrollTo centers the viewport on that moment", async ({
     page,
   }) => {
-    await page.clock.install();
-    await page.goto(TIMELINE_PATH);
-
-    const scrollContainer = page.getByTestId("timeline-scroll-container");
-    if (!(await scrollContainer.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    const scrollContainer = await openTimeline(page);
 
     // Scroll to discover a real, in-range moment to jump back to.
     await scrollContainer.evaluate((el) => {
@@ -105,13 +99,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
   test("back from a set detail page and a full reload both restore the viewport position", async ({
     page,
   }) => {
-    await page.clock.install();
-    await page.goto(TIMELINE_PATH);
-
-    const scrollContainer = page.getByTestId("timeline-scroll-container");
-    if (!(await scrollContainer.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    const scrollContainer = await openTimeline(page);
 
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 500;
@@ -124,10 +112,7 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     );
 
     const setLink = page.locator('a[href*="/sets/"]').first();
-    test.skip(
-      !(await setLink.isVisible().catch(() => false)),
-      "No set detail link rendered in this environment",
-    );
+    await expect(setLink).toBeVisible();
     await setLink.click();
     await page.goBack();
     await expect(page).toHaveURL(urlWithScroll);


### PR DESCRIPTION
Stacked on the #191 branch (`claude/188-191-timeline-geometry`) / PR. Adds a `scrollTo` search param that captures the moment centered in the Timeline viewport, with a pure precedence function deciding the mount position and a dedicated hook owning one-way scroll<->URL sync.

Closes #192

## Verification
- Load the timeline with no `scrollTo` in the URL; scroll the horizontal timeline and confirm `scrollTo` appears in the URL (~300ms after scrolling stops), rounded to 5 minutes, via history replace (back doesn't land on an intermediate scroll state).
- Load a timeline URL with `scrollTo` set; confirm the viewport centers on that moment on mount.
- Change the day filter with no `scrollTo` present; confirm the viewport centers on that day's start.
- Scroll the timeline and confirm the day/time/stage filters and rendered schedule do not recompute (no flicker/reflow) purely from the `scrollTo` write.
- Run `pnpm vitest run` — includes new unit tests for `resolveTimelineMountMoment` and `roundToNearestMinutes` in `src/lib/timelineMountMoment.test.ts`.
- New Playwright spec `tests/e2e/timeline-scroll.spec.ts` covers scroll-to-URL writing, mount centering, and back/reload restoring the viewport (runs in CI, not run locally in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AziTqr3f12fxALYD6jhrW8)_