### PR TITLE
feat(schedule): add my-vote filter chips

### DIFF
--- a/src/hooks/useTimelineUrlState.ts
+++ b/src/hooks/useTimelineUrlState.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useSearch, useNavigate } from "@tanstack/react-router";
 import type { TimelineSearch } from "@/lib/searchSchemas";
+import type { VoteType } from "@/lib/voteConfig";
 
 export type TimeFilter = TimelineSearch["time"];
 
@@ -13,6 +14,7 @@ export function useTimelineUrlState(tab: "timeline" | "list" = "timeline") {
       day: search.day,
       time: search.time,
       stages: search.stages,
+      votes: search.votes,
     }),
   });
   const navigate = useNavigate({ from: route });
@@ -50,6 +52,17 @@ export function useTimelineUrlState(tab: "timeline" | "list" = "timeline") {
     [navigate],
   );
 
+  const updateVotes = useCallback(
+    (votes: VoteType[]) => {
+      navigate({
+        to: ".",
+        search: (prev) => ({ ...prev, votes }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
   const clearFilters = useCallback(() => {
     navigate({
       to: ".",
@@ -62,9 +75,11 @@ export function useTimelineUrlState(tab: "timeline" | "list" = "timeline") {
     day: state.day,
     time: state.time,
     stages: state.stages,
+    votes: state.votes,
     updateDay,
     updateTime,
     updateStages,
+    updateVotes,
     clearFilters,
   };
 }

--- a/src/lib/scheduleFilter.test.ts
+++ b/src/lib/scheduleFilter.test.ts
@@ -193,6 +193,148 @@ describe("filterScheduleDays", () => {
     });
   });
 
+  describe("vote-type predicate (my-vote chips)", () => {
+    it("keeps all sets when no vote types are selected", () => {
+      const days = [
+        makeDay({
+          stages: [
+            {
+              id: "stage-1",
+              name: "Main Stage",
+              stage_order: 1,
+              sets: [makeSet({ id: "set-1" }), makeSet({ id: "set-2" })],
+            },
+          ],
+        }),
+      ];
+
+      const result = filterScheduleDays(
+        days,
+        baseCriteria({ voteTypes: [], userVotes: { "set-1": 2 } }),
+        TIMEZONE,
+      );
+
+      expect(result[0].stages[0].sets.map((s) => s.id)).toEqual([
+        "set-1",
+        "set-2",
+      ]);
+    });
+
+    it("keeps only sets matching a single selected vote type", () => {
+      const days = [
+        makeDay({
+          stages: [
+            {
+              id: "stage-1",
+              name: "Main Stage",
+              stage_order: 1,
+              sets: [makeSet({ id: "must-go-set" }), makeSet({ id: "interested-set" })],
+            },
+          ],
+        }),
+      ];
+
+      const result = filterScheduleDays(
+        days,
+        baseCriteria({
+          voteTypes: ["mustGo"],
+          userVotes: { "must-go-set": 2, "interested-set": 1 },
+        }),
+        TIMEZONE,
+      );
+
+      expect(result[0].stages[0].sets.map((s) => s.id)).toEqual([
+        "must-go-set",
+      ]);
+    });
+
+    it("OR-s together a union of selected vote types", () => {
+      const days = [
+        makeDay({
+          stages: [
+            {
+              id: "stage-1",
+              name: "Main Stage",
+              stage_order: 1,
+              sets: [
+                makeSet({ id: "must-go-set" }),
+                makeSet({ id: "interested-set" }),
+                makeSet({ id: "wont-go-set" }),
+              ],
+            },
+          ],
+        }),
+      ];
+
+      const result = filterScheduleDays(
+        days,
+        baseCriteria({
+          voteTypes: ["mustGo", "interested"],
+          userVotes: {
+            "must-go-set": 2,
+            "interested-set": 1,
+            "wont-go-set": -1,
+          },
+        }),
+        TIMEZONE,
+      );
+
+      expect(result[0].stages[0].sets.map((s) => s.id)).toEqual([
+        "must-go-set",
+        "interested-set",
+      ]);
+    });
+
+    it("excludes a set with no vote when the filter is active", () => {
+      const days = [
+        makeDay({
+          stages: [
+            {
+              id: "stage-1",
+              name: "Main Stage",
+              stage_order: 1,
+              sets: [makeSet({ id: "unvoted-set" })],
+            },
+          ],
+        }),
+      ];
+
+      const result = filterScheduleDays(
+        days,
+        baseCriteria({ voteTypes: ["mustGo"], userVotes: {} }),
+        TIMEZONE,
+      );
+
+      expect(result[0].stages[0].sets).toHaveLength(0);
+    });
+
+    it("excludes a set missing from the votes map entirely", () => {
+      const days = [
+        makeDay({
+          stages: [
+            {
+              id: "stage-1",
+              name: "Main Stage",
+              stage_order: 1,
+              sets: [makeSet({ id: "not-in-map" })],
+            },
+          ],
+        }),
+      ];
+
+      const result = filterScheduleDays(
+        days,
+        baseCriteria({
+          voteTypes: ["mustGo"],
+          userVotes: { "some-other-set": 2 },
+        }),
+        TIMEZONE,
+      );
+
+      expect(result[0].stages[0].sets).toHaveLength(0);
+    });
+  });
+
   describe("combinations", () => {
     it("applies day, time and stage predicates together", () => {
       const days = [

--- a/src/lib/scheduleFilter.test.ts
+++ b/src/lib/scheduleFilter.test.ts
@@ -308,6 +308,58 @@ describe("filterScheduleDays", () => {
       expect(result[0].stages[0].sets).toHaveLength(0);
     });
 
+    it("is inert when userVotes is undefined (no viewer identity)", () => {
+      const days = [
+        makeDay({
+          stages: [
+            {
+              id: "stage-1",
+              name: "Main Stage",
+              stage_order: 1,
+              sets: [makeSet({ id: "set-1" }), makeSet({ id: "set-2" })],
+            },
+          ],
+        }),
+      ];
+
+      const result = filterScheduleDays(
+        days,
+        baseCriteria({ voteTypes: ["mustGo"], userVotes: undefined }),
+        TIMEZONE,
+      );
+
+      expect(result[0].stages[0].sets.map((s) => s.id)).toEqual([
+        "set-1",
+        "set-2",
+      ]);
+    });
+
+    it("excludes a set whose vote value is unrecognized", () => {
+      const days = [
+        makeDay({
+          stages: [
+            {
+              id: "stage-1",
+              name: "Main Stage",
+              stage_order: 1,
+              sets: [makeSet({ id: "weird-vote-set" })],
+            },
+          ],
+        }),
+      ];
+
+      const result = filterScheduleDays(
+        days,
+        baseCriteria({
+          voteTypes: ["mustGo"],
+          userVotes: { "weird-vote-set": 0 },
+        }),
+        TIMEZONE,
+      );
+
+      expect(result[0].stages[0].sets).toHaveLength(0);
+    });
+
     it("excludes a set missing from the votes map entirely", () => {
       const days = [
         makeDay({

--- a/src/lib/scheduleFilter.ts
+++ b/src/lib/scheduleFilter.ts
@@ -10,23 +10,12 @@ import type {
 export type ScheduleTimeFilter = TimelineSearch["time"];
 
 export interface ScheduleFilterCriteria {
-  // "all" or a festival day key (yyyy-MM-dd, see getFestivalDayKey).
   day: string;
-  // Time-of-day bucket, computed in the festival timezone via getFestivalHour.
   time: ScheduleTimeFilter;
-  // Stage ids to include; an empty array means all stages.
   stages: string[];
-  // My-vote chips (PRD #188): selected vote types, OR-ed together. Empty or
-  // omitted turns the filter off (all sets kept, `userVotes` unconsulted).
-  // Always the viewer's own votes - group-vote scopes are out of scope here.
   voteTypes?: VoteType[];
-  // The viewer's own votes, keyed by set id -> vote value (same shape as
-  // useUserVotes' return). Passed in, never fetched inside - keeps this
-  // function pure. The absent/empty distinction matters: `undefined` means
-  // there is no viewer identity (logged out), so vote filtering is INERT and
-  // every set passes even with `voteTypes` selected (a shared `?votes=` link
-  // must never dead-end a logged-out visitor); an empty object means a
-  // logged-in viewer with no votes, so an active filter excludes everything.
+  // `undefined` means no viewer identity (logged out): vote filtering is
+  // inert so a shared `?votes=` link never dead-ends a logged-out visitor.
   userVotes?: Record<string, number>;
 }
 
@@ -58,8 +47,6 @@ function matchesVoteTypes(
   userVotes: Record<string, number> | undefined,
 ): boolean {
   if (!voteTypes || voteTypes.length === 0) return true;
-  // No viewer identity (logged out): the vote filter is inert - see the
-  // absent-vs-empty note on ScheduleFilterCriteria.userVotes.
   if (userVotes === undefined) return true;
 
   const voteValue = userVotes[set.id];

--- a/src/lib/scheduleFilter.ts
+++ b/src/lib/scheduleFilter.ts
@@ -14,8 +14,7 @@ export interface ScheduleFilterCriteria {
   time: ScheduleTimeFilter;
   stages: string[];
   voteTypes?: VoteType[];
-  // `undefined` means no viewer identity (logged out): vote filtering is
-  // inert so a shared `?votes=` link never dead-ends a logged-out visitor.
+  /** `undefined` (logged out) makes vote filtering inert, not exclusionary. */
   userVotes?: Record<string, number>;
 }
 
@@ -56,12 +55,10 @@ function matchesVoteTypes(
   return voteType !== undefined && voteTypes.includes(voteType);
 }
 
-// Applies the day / time-of-day / stage predicates shared by both Schedule
-// views (Timeline and List). A day that doesn't match `criteria.day` is kept
-// as an entry with empty stages (rather than dropped) purely to mirror the
-// original inline Timeline logic; the strip's axis bounds derive from the
-// remaining sets' times, so an empty day entry contributes nothing and
-// dropping it would render identically.
+/**
+ * Applies the day / time-of-day / stage / vote predicates shared by both
+ * Schedule views. Non-matching days are kept with empty stages, not dropped.
+ */
 export function filterScheduleDays(
   scheduleDays: ScheduleDay[],
   criteria: ScheduleFilterCriteria,

--- a/src/lib/scheduleFilter.ts
+++ b/src/lib/scheduleFilter.ts
@@ -1,5 +1,6 @@
 import { getFestivalHour } from "@/lib/timeUtils";
 import type { TimelineSearch } from "@/lib/searchSchemas";
+import { getVoteConfig, type VoteType } from "@/lib/voteConfig";
 import type {
   ScheduleDay,
   ScheduleSet,
@@ -15,9 +16,14 @@ export interface ScheduleFilterCriteria {
   time: ScheduleTimeFilter;
   // Stage ids to include; an empty array means all stages.
   stages: string[];
-  // Future (PRD #188 - vote-type filtering): an optional field such as
-  // `voteTypes?: VoteType[]`, OR-ed against the viewer's own votes on each
-  // set, will slot in here without reshaping this interface.
+  // My-vote chips (PRD #188): selected vote types, OR-ed together. Empty or
+  // omitted turns the filter off (all sets kept, `userVotes` unconsulted).
+  // Always the viewer's own votes - group-vote scopes are out of scope here.
+  voteTypes?: VoteType[];
+  // The viewer's own votes, keyed by set id -> vote value (same shape as
+  // useUserVotes' return). Passed in, never fetched inside - keeps this
+  // function pure.
+  userVotes?: Record<string, number>;
 }
 
 function matchesTimeOfDay(
@@ -40,6 +46,20 @@ function matchesTimeOfDay(
     default:
       return true;
   }
+}
+
+function matchesVoteTypes(
+  set: ScheduleSet,
+  voteTypes: VoteType[] | undefined,
+  userVotes: Record<string, number> | undefined,
+): boolean {
+  if (!voteTypes || voteTypes.length === 0) return true;
+
+  const voteValue = userVotes?.[set.id];
+  if (voteValue === undefined) return false;
+
+  const voteType = getVoteConfig(voteValue);
+  return voteType !== undefined && voteTypes.includes(voteType);
 }
 
 // Applies the day / time-of-day / stage predicates shared by both Schedule
@@ -65,8 +85,10 @@ export function filterScheduleDays(
       )
       .map((stage) => ({
         ...stage,
-        sets: stage.sets.filter((set) =>
-          matchesTimeOfDay(set, criteria.time, timezone),
+        sets: stage.sets.filter(
+          (set) =>
+            matchesTimeOfDay(set, criteria.time, timezone) &&
+            matchesVoteTypes(set, criteria.voteTypes, criteria.userVotes),
         ),
       }));
 

--- a/src/lib/scheduleFilter.ts
+++ b/src/lib/scheduleFilter.ts
@@ -22,7 +22,11 @@ export interface ScheduleFilterCriteria {
   voteTypes?: VoteType[];
   // The viewer's own votes, keyed by set id -> vote value (same shape as
   // useUserVotes' return). Passed in, never fetched inside - keeps this
-  // function pure.
+  // function pure. The absent/empty distinction matters: `undefined` means
+  // there is no viewer identity (logged out), so vote filtering is INERT and
+  // every set passes even with `voteTypes` selected (a shared `?votes=` link
+  // must never dead-end a logged-out visitor); an empty object means a
+  // logged-in viewer with no votes, so an active filter excludes everything.
   userVotes?: Record<string, number>;
 }
 
@@ -54,8 +58,11 @@ function matchesVoteTypes(
   userVotes: Record<string, number> | undefined,
 ): boolean {
   if (!voteTypes || voteTypes.length === 0) return true;
+  // No viewer identity (logged out): the vote filter is inert - see the
+  // absent-vs-empty note on ScheduleFilterCriteria.userVotes.
+  if (userVotes === undefined) return true;
 
-  const voteValue = userVotes?.[set.id];
+  const voteValue = userVotes[set.id];
   if (voteValue === undefined) return false;
 
   const voteType = getVoteConfig(voteValue);

--- a/src/lib/searchSchemas.test.ts
+++ b/src/lib/searchSchemas.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { timelineSearchSchema } from "./searchSchemas";
+
+describe("timelineSearchSchema", () => {
+  describe("votes (my-vote chips)", () => {
+    it("keeps valid vote types", () => {
+      const parsed = timelineSearchSchema.parse({
+        votes: ["mustGo", "interested", "wontGo"],
+      });
+
+      expect(parsed.votes).toEqual(["mustGo", "interested", "wontGo"]);
+    });
+
+    it("drops only the invalid entries, keeping valid ones", () => {
+      const parsed = timelineSearchSchema.parse({
+        votes: ["mustGo", "bogus"],
+      });
+
+      expect(parsed.votes).toEqual(["mustGo"]);
+    });
+
+    it("falls back to an empty selection when votes is not an array", () => {
+      const parsed = timelineSearchSchema.parse({ votes: "junk" });
+
+      expect(parsed.votes).toEqual([]);
+    });
+
+    it("defaults to an empty selection when votes is absent", () => {
+      const parsed = timelineSearchSchema.parse({});
+
+      expect(parsed.votes).toEqual([]);
+    });
+  });
+});

--- a/src/lib/searchSchemas.test.ts
+++ b/src/lib/searchSchemas.test.ts
@@ -19,6 +19,14 @@ describe("timelineSearchSchema", () => {
       expect(parsed.votes).toEqual(["mustGo"]);
     });
 
+    it("de-duplicates repeated entries", () => {
+      const parsed = timelineSearchSchema.parse({
+        votes: ["mustGo", "mustGo", "interested"],
+      });
+
+      expect(parsed.votes).toEqual(["mustGo", "interested"]);
+    });
+
     it("falls back to an empty selection when votes is not an array", () => {
       const parsed = timelineSearchSchema.parse({ votes: "junk" });
 

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -43,11 +43,13 @@ export const timelineSearchSchema = z.object({
   votes: z
     .array(z.string())
     .catch([])
-    .transform((votes) =>
-      votes.filter((vote): vote is VoteType =>
-        (VOTES_TYPES as readonly string[]).includes(vote),
+    .transform((votes) => [
+      ...new Set(
+        votes.filter((vote): vote is VoteType =>
+          (VOTES_TYPES as readonly string[]).includes(vote),
+        ),
       ),
-    ),
+    ]),
   /** Viewport-centered moment; only written once the user scrolls. */
   scrollTo: z.string().optional().catch(undefined),
 });

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { VOTES_TYPES } from "@/lib/voteConfig";
 
 export const sortOptionSchema = z.enum([
   "name-asc",
@@ -38,6 +39,12 @@ export const timelineSearchSchema = z.object({
   day: z.string().catch("all"),
   time: z.enum(["all", "morning", "afternoon", "evening"]).catch("all"),
   stages: z.array(z.string()).catch([]),
+  // My-vote chips (PRD #188): selected vote types (mustGo/interested/wontGo),
+  // OR-ed together. Empty means the filter is off. Always the viewer's own
+  // votes, never a group-vote scope.
+  votes: z.array(z.enum(VOTES_TYPES)).catch([]),
+  // The moment (ISO datetime) centered in the timeline viewport. Absent by
+  // default; only written once the user scrolls. See useTimelineScrollSync.
   scrollTo: z.string().optional().catch(undefined),
 });
 
@@ -47,4 +54,5 @@ export const timelineSearchDefaults: TimelineSearch = {
   day: "all",
   time: "all",
   stages: [],
+  votes: [],
 };

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { VOTES_TYPES } from "@/lib/voteConfig";
+import { VOTES_TYPES, type VoteType } from "@/lib/voteConfig";
 
 export const sortOptionSchema = z.enum([
   "name-asc",
@@ -41,8 +41,17 @@ export const timelineSearchSchema = z.object({
   stages: z.array(z.string()).catch([]),
   // My-vote chips (PRD #188): selected vote types (mustGo/interested/wontGo),
   // OR-ed together. Empty means the filter is off. Always the viewer's own
-  // votes, never a group-vote scope.
-  votes: z.array(z.enum(VOTES_TYPES)).catch([]),
+  // votes, never a group-vote scope. Unknown entries are dropped one by one
+  // (not the whole array), so a partially malformed shared link keeps its
+  // valid selections.
+  votes: z
+    .array(z.string())
+    .catch([])
+    .transform((votes) =>
+      votes.filter((vote): vote is VoteType =>
+        (VOTES_TYPES as readonly string[]).includes(vote),
+      ),
+    ),
   // The moment (ISO datetime) centered in the timeline viewport. Absent by
   // default; only written once the user scrolls. See useTimelineScrollSync.
   scrollTo: z.string().optional().catch(undefined),

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -39,11 +39,8 @@ export const timelineSearchSchema = z.object({
   day: z.string().catch("all"),
   time: z.enum(["all", "morning", "afternoon", "evening"]).catch("all"),
   stages: z.array(z.string()).catch([]),
-  // My-vote chips (PRD #188): selected vote types (mustGo/interested/wontGo),
-  // OR-ed together. Empty means the filter is off. Always the viewer's own
-  // votes, never a group-vote scope. Unknown entries are dropped one by one
-  // (not the whole array), so a partially malformed shared link keeps its
-  // valid selections.
+  // Unknown entries are dropped individually so a partially malformed
+  // shared link keeps its valid selections.
   votes: z
     .array(z.string())
     .catch([])

--- a/src/lib/searchSchemas.ts
+++ b/src/lib/searchSchemas.ts
@@ -39,8 +39,7 @@ export const timelineSearchSchema = z.object({
   day: z.string().catch("all"),
   time: z.enum(["all", "morning", "afternoon", "evening"]).catch("all"),
   stages: z.array(z.string()).catch([]),
-  // Unknown entries are dropped individually so a partially malformed
-  // shared link keeps its valid selections.
+  /** Unknown entries are dropped individually, not the whole array. */
   votes: z
     .array(z.string())
     .catch([])
@@ -49,8 +48,7 @@ export const timelineSearchSchema = z.object({
         (VOTES_TYPES as readonly string[]).includes(vote),
       ),
     ),
-  // The moment (ISO datetime) centered in the timeline viewport. Absent by
-  // default; only written once the user scrolls. See useTimelineScrollSync.
+  /** Viewport-centered moment; only written once the user scrolls. */
   scrollTo: z.string().optional().catch(undefined),
 });
 

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
@@ -16,6 +16,7 @@ import { DayFilterSelect } from "./DayFilterSelect";
 import { TimeFilterSelect } from "./TimeFilterSelect";
 import { StageFilterButtons } from "./StageFilterButtons";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface ScheduleFilterSheetProps {
   tab: "timeline" | "list";
@@ -37,10 +38,14 @@ interface ScheduleFilterSheetProps {
  * and every selected stage counts 1 of its own (so picking two stages adds
  * 2). My-vote chips (rendered next to this trigger, not inside the sheet -
  * see VoteFilterChips) follow the same per-item rule: every selected vote
- * type counts 1 of its own, so picking Must Go + Interested adds 2.
+ * type counts 1 of its own, so picking Must Go + Interested adds 2 - but
+ * only while a viewer is logged in. Logged out, the vote filter is inert
+ * (see ScheduleFilterCriteria.userVotes), so the badge must not advertise
+ * it; "Clear all" still clears the `votes` param regardless.
  */
 export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
   const [open, setOpen] = useState(false);
+  const { user } = useAuth();
   const {
     day,
     time,
@@ -56,7 +61,7 @@ export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
     (day !== "all" ? 1 : 0) +
     (time !== "all" ? 1 : 0) +
     stages.length +
-    votes.length;
+    (user ? votes.length : 0);
   const hasActiveFilters = activeFilterCount > 0;
 
   return (

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
@@ -21,12 +21,31 @@ interface ScheduleFilterSheetProps {
   tab: "timeline" | "list";
 }
 
+/**
+ * Shared day / time-of-day / stage filter UI for both Schedule views
+ * (Timeline and List). Renders as a trigger button (with an active-filter
+ * count badge) plus a bottom sheet - the same component instance handles
+ * both the trigger and the sheet content so each view only has to render
+ * one thing in its filter row.
+ *
+ * Filter state is the shared URL state from `useTimelineUrlState`, so
+ * setting a filter on one view keeps it visible (and clearable) on the
+ * other. Opening, applying, or clearing filters here never scrolls either
+ * view - only day-jump navigation does that.
+ *
+ * Active-filter count: `day` and `time` each count 1 when away from "all",
+ * and every selected stage counts 1 of its own (so picking two stages adds
+ * 2). My-vote chips (rendered next to this trigger, not inside the sheet -
+ * see VoteFilterChips) follow the same per-item rule: every selected vote
+ * type counts 1 of its own, so picking Must Go + Interested adds 2.
+ */
 export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
   const [open, setOpen] = useState(false);
   const {
     day,
     time,
     stages,
+    votes,
     updateDay,
     updateTime,
     updateStages,
@@ -34,7 +53,10 @@ export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
   } = useTimelineUrlState(tab);
 
   const activeFilterCount =
-    (day !== "all" ? 1 : 0) + (time !== "all" ? 1 : 0) + stages.length;
+    (day !== "all" ? 1 : 0) +
+    (time !== "all" ? 1 : 0) +
+    stages.length +
+    votes.length;
   const hasActiveFilters = activeFilterCount > 0;
 
   return (

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
@@ -37,11 +37,8 @@ interface ScheduleFilterSheetProps {
  * Active-filter count: `day` and `time` each count 1 when away from "all",
  * and every selected stage counts 1 of its own (so picking two stages adds
  * 2). My-vote chips (rendered next to this trigger, not inside the sheet -
- * see VoteFilterChips) follow the same per-item rule: every selected vote
- * type counts 1 of its own, so picking Must Go + Interested adds 2 - but
- * only while a viewer is logged in. Logged out, the vote filter is inert
- * (see ScheduleFilterCriteria.userVotes), so the badge must not advertise
- * it; "Clear all" still clears the `votes` param regardless.
+ * see VoteFilterChips) follow the same rule, but only while logged in -
+ * logged out the vote filter is inert so the badge must not count it.
  */
 export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
   const [open, setOpen] = useState(false);

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
@@ -23,22 +23,9 @@ interface ScheduleFilterSheetProps {
 }
 
 /**
- * Shared day / time-of-day / stage filter UI for both Schedule views
- * (Timeline and List). Renders as a trigger button (with an active-filter
- * count badge) plus a bottom sheet - the same component instance handles
- * both the trigger and the sheet content so each view only has to render
- * one thing in its filter row.
- *
- * Filter state is the shared URL state from `useTimelineUrlState`, so
- * setting a filter on one view keeps it visible (and clearable) on the
- * other. Opening, applying, or clearing filters here never scrolls either
- * view - only day-jump navigation does that.
- *
- * Active-filter count: `day` and `time` each count 1 when away from "all",
- * and every selected stage counts 1 of its own (so picking two stages adds
- * 2). My-vote chips (rendered next to this trigger, not inside the sheet -
- * see VoteFilterChips) follow the same rule, but only while logged in -
- * logged out the vote filter is inert so the badge must not count it.
+ * Shared day / time-of-day / stage filter trigger + bottom sheet for both
+ * Schedule views, backed by the shared URL state so filters stay in sync.
+ * The badge excludes vote-chip selections while logged out (inert filter).
  */
 export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
   const [open, setOpen] = useState(false);

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
@@ -15,6 +15,7 @@ import {
 import { DayFilterSelect } from "./DayFilterSelect";
 import { TimeFilterSelect } from "./TimeFilterSelect";
 import { StageFilterButtons } from "./StageFilterButtons";
+import { VoteFilterChips } from "./VoteFilterChips";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -95,6 +96,15 @@ export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
             onStageToggle={handleStageToggle}
           />
         </div>
+
+        {user && (
+          <div className="mt-4 space-y-2 md:hidden">
+            <label className="text-sm font-medium text-purple-200">
+              My vote
+            </label>
+            <VoteFilterChips tab={tab} />
+          </div>
+        )}
 
         <SheetFooter className="mt-6">
           {hasActiveFilters && (

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteButtons.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteButtons.tsx
@@ -47,7 +47,7 @@ export function VoteButtons({ set }: VoteButtonsProps) {
   }, [set.votes]);
 
   return (
-    <div className="flex gap-3 mt-2">
+    <div className="flex gap-3 mt-2" data-testid={`vote-buttons-${set.id}`}>
       {VOTES_TYPES.map((voteType) => {
         return (
           <VoteButton
@@ -101,6 +101,7 @@ function VoteButton({
           : `${config.descColor} `,
       )}
       type="button"
+      data-testid={`vote-button-${voteType}`}
       onClick={() => onVote()}
     >
       <IconComponent className="h-3 w-3" />

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteButtons.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteButtons.tsx
@@ -47,7 +47,11 @@ export function VoteButtons({ set }: VoteButtonsProps) {
   }, [set.votes]);
 
   return (
-    <div className="flex gap-3 mt-2" data-testid={`vote-buttons-${set.id}`}>
+    <div
+      role="group"
+      aria-label={`Vote for ${set.name}`}
+      className="flex gap-3 mt-2"
+    >
       {VOTES_TYPES.map((voteType) => {
         return (
           <VoteButton
@@ -101,7 +105,8 @@ function VoteButton({
           : `${config.descColor} `,
       )}
       type="button"
-      data-testid={`vote-button-${voteType}`}
+      aria-pressed={isSelected}
+      aria-label={config.label}
       onClick={() => onVote()}
     >
       <IconComponent className="h-3 w-3" />

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
@@ -21,7 +21,11 @@ export function VoteFilterChips({ tab }: VoteFilterChipsProps) {
   }
 
   return (
-    <div data-testid="vote-filter-chips" className="flex items-center gap-1">
+    <div
+      role="group"
+      aria-label="Filter by my vote"
+      className="flex items-center gap-1"
+    >
       {VOTES_TYPES.map((voteType) => {
         const config = VOTE_CONFIG[voteType];
         const Icon = config.icon;
@@ -35,7 +39,6 @@ export function VoteFilterChips({ tab }: VoteFilterChipsProps) {
             size="icon"
             aria-pressed={isSelected}
             aria-label={config.label}
-            data-testid={`vote-filter-chip-${voteType}`}
             onClick={() => handleToggle(voteType)}
             className={cn(
               "h-8 w-8",

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
@@ -1,0 +1,71 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { VOTES_TYPES, VOTE_CONFIG, type VoteType } from "@/lib/voteConfig";
+import { useAuth } from "@/contexts/AuthContext";
+import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
+
+interface VoteFilterChipsProps {
+  tab: "timeline" | "list";
+}
+
+/**
+ * Compact icon-only chips for the three Vote types (Must Go / Interested /
+ * Won't Go), letting the viewer filter both Schedule views down to sets
+ * they voted on themselves. Pairs with the ScheduleFilterSheet trigger
+ * (rendered as a sibling, not inside the sheet) in both the Timeline
+ * toolbar and the List view's filter row.
+ *
+ * Selection is OR-ed and lives in the shared URL state
+ * (`useTimelineUrlState`), so it counts toward ScheduleFilterSheet's badge
+ * and stays in sync across views. Always the viewer's own votes - group-vote
+ * scopes are out of scope.
+ *
+ * Hidden entirely for logged-out visitors: no disabled state, no login
+ * teaser, just absent.
+ */
+export function VoteFilterChips({ tab }: VoteFilterChipsProps) {
+  const { user } = useAuth();
+  const { votes, updateVotes } = useTimelineUrlState(tab);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div data-testid="vote-filter-chips" className="flex items-center gap-1">
+      {VOTES_TYPES.map((voteType) => {
+        const config = VOTE_CONFIG[voteType];
+        const Icon = config.icon;
+        const isSelected = votes.includes(voteType);
+
+        return (
+          <Button
+            key={voteType}
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-pressed={isSelected}
+            aria-label={config.label}
+            data-testid={`vote-filter-chip-${voteType}`}
+            onClick={() => handleToggle(voteType)}
+            className={cn(
+              "h-8 w-8",
+              isSelected
+                ? `${config.circleColor} text-white hover:opacity-90`
+                : `${config.iconColor} hover:bg-white/10`,
+            )}
+          >
+            <Icon className="h-4 w-4" />
+          </Button>
+        );
+      })}
+    </div>
+  );
+
+  function handleToggle(voteType: VoteType) {
+    const next = votes.includes(voteType)
+      ? votes.filter((selected) => selected !== voteType)
+      : [...votes, voteType];
+    updateVotes(next);
+  }
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
@@ -9,10 +9,8 @@ interface VoteFilterChipsProps {
 }
 
 /**
- * Icon-only chips (Must Go / Interested / Won't Go) that filter both
- * Schedule views down to sets the viewer voted on themselves. Selection is
- * OR-ed and lives in the shared URL state, so it stays in sync with the
- * ScheduleFilterSheet badge across views. Hidden entirely when logged out.
+ * Icon-only chips that filter both Schedule views to sets the viewer voted
+ * on. OR-ed selection lives in shared URL state; hidden when logged out.
  */
 export function VoteFilterChips({ tab }: VoteFilterChipsProps) {
   const { user } = useAuth();

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
@@ -43,7 +43,7 @@ export function VoteFilterChips({ tab }: VoteFilterChipsProps) {
             className={cn(
               "h-8 w-8",
               isSelected
-                ? `${config.circleColor} text-white hover:opacity-90`
+                ? `${config.buttonSelected} text-white`
                 : `${config.iconColor} hover:bg-white/10`,
             )}
           >

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteFilterChips.tsx
@@ -9,19 +9,10 @@ interface VoteFilterChipsProps {
 }
 
 /**
- * Compact icon-only chips for the three Vote types (Must Go / Interested /
- * Won't Go), letting the viewer filter both Schedule views down to sets
- * they voted on themselves. Pairs with the ScheduleFilterSheet trigger
- * (rendered as a sibling, not inside the sheet) in both the Timeline
- * toolbar and the List view's filter row.
- *
- * Selection is OR-ed and lives in the shared URL state
- * (`useTimelineUrlState`), so it counts toward ScheduleFilterSheet's badge
- * and stays in sync across views. Always the viewer's own votes - group-vote
- * scopes are out of scope.
- *
- * Hidden entirely for logged-out visitors: no disabled state, no login
- * teaser, just absent.
+ * Icon-only chips (Must Go / Interested / Won't Go) that filter both
+ * Schedule views down to sets the viewer voted on themselves. Selection is
+ * OR-ed and lives in the shared URL state, so it stays in sync with the
+ * ScheduleFilterSheet badge across views. Hidden entirely when logged out.
  */
 export function VoteFilterChips({ tab }: VoteFilterChipsProps) {
   const { user } = useAuth();

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -15,6 +15,8 @@ import { filterScheduleDays } from "@/lib/scheduleFilter";
 import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNotRevealedPlaceholder } from "../ScheduleNotRevealedPlaceholder";
+import { useAuth } from "@/contexts/AuthContext";
+import { useUserVotes } from "@/api/voting/useUserVotes";
 
 export function Timeline() {
   const { festival } = useFestivalEdition();
@@ -26,6 +28,8 @@ export function Timeline() {
   const { data: editionSets = [], isLoading: setsLoading } =
     useEditionSetsQuery(edition.id);
   const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
+  const { user } = useAuth();
+  const { data: userVotes } = useUserVotes(user?.id);
 
   const { scheduleDays, loading, error } = useScheduleData({
     sets: editionSets,
@@ -36,6 +40,7 @@ export function Timeline() {
     day: selectedDay,
     time: selectedTime,
     stages: selectedStages,
+    votes: selectedVotes,
   } = useTimelineUrlState("timeline");
 
   const scheduleWindow = useMemo(
@@ -50,7 +55,13 @@ export function Timeline() {
 
     const filteredScheduleDays = filterScheduleDays(
       scheduleDays,
-      { day: selectedDay, time: selectedTime, stages: selectedStages },
+      {
+        day: selectedDay,
+        time: selectedTime,
+        stages: selectedStages,
+        voteTypes: selectedVotes,
+        userVotes,
+      },
       festival.timezone,
     );
 
@@ -66,6 +77,8 @@ export function Timeline() {
     selectedDay,
     selectedTime,
     selectedStages,
+    selectedVotes,
+    userVotes,
     stages,
     festival.timezone,
   ]);

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
@@ -4,6 +4,7 @@ import { DayJumpButtons } from "./DayJumpButtons";
 import { NowButton } from "./NowButton";
 import { Button } from "@/components/ui/button";
 import { ScheduleFilterSheet } from "../ScheduleFilterSheet";
+import { VoteFilterChips } from "../VoteFilterChips";
 import type { ScheduleDay } from "@/hooks/useScheduleData";
 import { useScrollEdgeFade } from "./useScrollEdgeFade";
 
@@ -22,10 +23,20 @@ interface TimelineToolbarProps {
 // Width of the edge-fade hinting that the day row scrolls further that way.
 const SCROLL_FADE_PX = 24;
 
-// Sticky nav toolbar above the Timeline strip. Navigation scrolls, it never
-// filters; with a day filter active only that day's button shows. Hosts the
-// Filters trigger (bottom sheet) inline in the same row - it never renders
-// on its own line.
+/**
+ * Sticky toolbar above the Timeline strip. Hosts day-jump buttons, the
+ * my-vote chips, and the Filters trigger (bottom sheet) inline in the same
+ * row - the Filters trigger never renders on its own line. Also hosts the
+ * Now pill and "Show overview" toggle.
+ *
+ * Day-jump buttons live inside their own `timeline-day-buttons` group so
+ * tests (and future additions to this row) can target them without also
+ * picking up the Filters trigger or other buttons that share the toolbar.
+ *
+ * Navigation only ever scrolls - it never filters the strip. When a `day`
+ * filter is active, nav operates on what's rendered, so only that day's
+ * button shows.
+ */
 export function TimelineToolbar({
   days,
   selectedDay,
@@ -92,6 +103,7 @@ export function TimelineToolbar({
             {isOverviewExpanded ? "Hide overview" : "Show overview"}
           </span>
         </Button>
+        <VoteFilterChips tab="timeline" />
         <ScheduleFilterSheet tab="timeline" />
       </div>
     </div>

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
@@ -24,18 +24,8 @@ interface TimelineToolbarProps {
 const SCROLL_FADE_PX = 24;
 
 /**
- * Sticky toolbar above the Timeline strip. Hosts day-jump buttons, the
- * my-vote chips, and the Filters trigger (bottom sheet) inline in the same
- * row - the Filters trigger never renders on its own line. Also hosts the
- * Now pill and "Show overview" toggle.
- *
- * Day-jump buttons live inside their own `timeline-day-buttons` group so
- * tests (and future additions to this row) can target them without also
- * picking up the Filters trigger or other buttons that share the toolbar.
- *
- * Navigation only ever scrolls - it never filters the strip. When a `day`
- * filter is active, nav operates on what's rendered, so only that day's
- * button shows.
+ * Sticky toolbar above the Timeline strip: day-jump, Now pill, overview
+ * toggle, my-vote chips, and the Filters trigger, all in one row.
  */
 export function TimelineToolbar({
   days,

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
@@ -93,7 +93,9 @@ export function TimelineToolbar({
             {isOverviewExpanded ? "Hide overview" : "Show overview"}
           </span>
         </Button>
-        <VoteFilterChips tab="timeline" />
+        <div className="hidden md:block">
+          <VoteFilterChips tab="timeline" />
+        </div>
         <ScheduleFilterSheet tab="timeline" />
       </div>
     </div>

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
@@ -12,6 +12,8 @@ import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
 import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNotRevealedPlaceholder } from "../ScheduleNotRevealedPlaceholder";
+import { useAuth } from "@/contexts/AuthContext";
+import { useUserVotes } from "@/api/voting/useUserVotes";
 
 interface TimeSlot {
   time: Date;
@@ -27,6 +29,8 @@ export function ListSchedule() {
   const { data: editionSets = [], isLoading: setsLoading } =
     useEditionSetsQuery(edition.id);
   const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
+  const { user } = useAuth();
+  const { data: userVotes } = useUserVotes(user?.id);
   const { scheduleDays, loading, error } = useScheduleData({
     sets: editionSets,
     stages,
@@ -36,6 +40,7 @@ export function ListSchedule() {
     day: selectedDay,
     time: selectedTime,
     stages: selectedStages,
+    votes: selectedVotes,
   } = useTimelineUrlState("list");
 
   const timeSlots = useMemo(() => {
@@ -43,7 +48,13 @@ export function ListSchedule() {
 
     const filteredScheduleDays = filterScheduleDays(
       scheduleDays,
-      { day: selectedDay, time: selectedTime, stages: selectedStages },
+      {
+        day: selectedDay,
+        time: selectedTime,
+        stages: selectedStages,
+        voteTypes: selectedVotes,
+        userVotes,
+      },
       festival.timezone,
     );
 
@@ -101,6 +112,8 @@ export function ListSchedule() {
     selectedDay,
     selectedTime,
     selectedStages,
+    selectedVotes,
+    userVotes,
     stages,
     festival.timezone,
   ]);

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
@@ -1,6 +1,7 @@
 import { FestivalTimeBadge } from "../FestivalTimeBadge";
 import { ListSchedule } from "./ListSchedule";
 import { ScheduleFilterSheet } from "../ScheduleFilterSheet";
+import { VoteFilterChips } from "../VoteFilterChips";
 import { FilterContainer } from "@/components/filters/FilterContainer";
 
 export function ScheduleTabList() {
@@ -12,6 +13,7 @@ export function ScheduleTabList() {
         <div className="flex items-center gap-2 flex-wrap">
           <h3 className="text-purple-100 font-medium">Filters</h3>
           <div className="ml-auto" />
+          <VoteFilterChips tab="list" />
           <ScheduleFilterSheet tab="list" />
         </div>
       </FilterContainer>

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
@@ -13,7 +13,9 @@ export function ScheduleTabList() {
         <div className="flex items-center gap-2 flex-wrap">
           <h3 className="text-purple-100 font-medium">Filters</h3>
           <div className="ml-auto" />
-          <VoteFilterChips tab="list" />
+          <div className="hidden md:block">
+            <VoteFilterChips tab="list" />
+          </div>
           <ScheduleFilterSheet tab="list" />
         </div>
       </FilterContainer>

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -47,6 +47,25 @@ test.describe("My-vote chips", () => {
     await expect(page.getByTestId("vote-filter-chips")).toHaveCount(0);
   });
 
+  test("a shared ?votes= link is inert for logged-out visitors - sets still show", async ({
+    page,
+  }) => {
+    await page.goto(`${LIST_PATH}?votes=mustGo`);
+
+    const listSchedule = page.getByTestId("list-schedule");
+    if (!(await listSchedule.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    // No viewer identity, so the vote filter must not empty the schedule.
+    await expect(
+      page.getByTestId(`vote-buttons-${MAYA_SET_ID}`),
+    ).toBeVisible();
+    await expect(page.getByTestId("vote-filter-chips")).toHaveCount(0);
+    // The badge must not advertise the inert vote filter.
+    await expect(page.getByTestId("schedule-filters-badge")).toHaveCount(0);
+  });
+
   test("two-tap 'my schedule': Must Go + Interested filters both views to the viewer's own votes", async ({
     page,
   }) => {

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -90,7 +90,6 @@ test.describe("My-vote chips", () => {
 
     await expect(page.getByTestId("vote-filter-chips")).toBeVisible();
 
-    // Two taps: Must Go, then Interested.
     await page.getByTestId("vote-filter-chip-mustGo").click();
     await page.getByTestId("vote-filter-chip-interested").click();
 

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { TestHelpers } from "../utils/test-helpers";
+import { signIn } from "../utils/login";
 
 // Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
@@ -12,10 +12,6 @@ const KIARA_SET_NAME = "Kiara Scuro";
 
 function voteGroup(page: import("@playwright/test").Page, setName: string) {
   return page.getByRole("group", { name: `Vote for ${setName}` });
-}
-
-async function signIn(page: import("@playwright/test").Page) {
-  await new TestHelpers(page).signIn();
 }
 
 test.describe("My-vote chips", () => {

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -67,7 +67,14 @@ test.describe("My-vote chips", () => {
       .getByRole("button", { name: "Interested" })
       .click();
 
-    const chips = page.getByRole("group", { name: "Filter by my vote" });
+    // Below md the chips live inside the filter sheet, not the toolbar.
+    let chips = page.getByRole("group", { name: "Filter by my vote" });
+    if (!(await chips.isVisible())) {
+      await page.getByTestId("schedule-filters-trigger").click();
+      chips = page.getByRole("dialog").getByRole("group", {
+        name: "Filter by my vote",
+      });
+    }
     await expect(chips).toBeVisible();
 
     await chips.getByRole("button", { name: "Must Go" }).click();

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -69,7 +69,8 @@ test.describe("My-vote chips", () => {
 
     // Below md the chips live inside the filter sheet, not the toolbar.
     let chips = page.getByRole("group", { name: "Filter by my vote" });
-    if (!(await chips.isVisible())) {
+    const inSheet = !(await chips.isVisible());
+    if (inSheet) {
       await page.getByTestId("schedule-filters-trigger").click();
       chips = page.getByRole("dialog").getByRole("group", {
         name: "Filter by my vote",
@@ -79,6 +80,11 @@ test.describe("My-vote chips", () => {
 
     await chips.getByRole("button", { name: "Must Go" }).click();
     await chips.getByRole("button", { name: "Interested" }).click();
+
+    if (inSheet) {
+      await page.getByRole("dialog").getByRole("button", { name: "Done" }).click();
+      await expect(page.getByRole("dialog")).toHaveCount(0);
+    }
 
     await expect(page).toHaveURL(/votes=/);
     await expect(page.getByTestId("schedule-filters-badge")).toHaveText("2");

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -14,19 +14,8 @@ function voteGroup(page: import("@playwright/test").Page, setName: string) {
   return page.getByRole("group", { name: `Vote for ${setName}` });
 }
 
-async function signInOrSkip(page: import("@playwright/test").Page) {
-  const testHelpers = new TestHelpers(page);
-  try {
-    await testHelpers.signIn();
-  } catch {
-    // Ignore - handled by the isAuthenticated check below.
-  }
-
-  const authenticated = await testHelpers.isAuthenticated();
-  test.skip(
-    !authenticated,
-    "Seeded environment can't authenticate a voting user",
-  );
+async function signIn(page: import("@playwright/test").Page) {
+  await new TestHelpers(page).signIn();
 }
 
 test.describe("My-vote chips", () => {
@@ -77,7 +66,7 @@ test.describe("My-vote chips", () => {
   test("two-tap 'my schedule': Must Go + Interested filters both views to the viewer's own votes", async ({
     page,
   }) => {
-    await signInOrSkip(page);
+    await signIn(page);
 
     await page.goto(LIST_PATH);
     const listSchedule = page.getByTestId("list-schedule");

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "@playwright/test";
+import { TestHelpers } from "../utils/test-helpers";
+
+// Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
+const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
+const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
+
+// Sets seeded on Friday July 12, 2025 (see `public.sets` inserts in seed.sql).
+const MAYA_SET_ID = "11111111-1111-1111-1111-111111111111";
+const BEN_SET_ID = "22222222-2222-2222-2222-222222222222";
+const KIARA_SET_ID = "33333333-3333-3333-3333-333333333333";
+
+async function signInOrSkip(page: import("@playwright/test").Page) {
+  const testHelpers = new TestHelpers(page);
+  try {
+    await testHelpers.signIn();
+  } catch {
+    // Ignore - handled by the isAuthenticated check below.
+  }
+
+  const authenticated = await testHelpers.isAuthenticated();
+  test.skip(
+    !authenticated,
+    "Seeded environment can't authenticate a voting user",
+  );
+}
+
+test.describe("My-vote chips", () => {
+  test("do not render for logged-out visitors on either view", async ({
+    page,
+  }) => {
+    await page.goto(TIMELINE_PATH);
+
+    const scrollContainer = page.getByTestId("timeline-scroll-container");
+    if (!(await scrollContainer.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    await expect(page.getByTestId("vote-filter-chips")).toHaveCount(0);
+
+    await page.goto(LIST_PATH);
+    const listSchedule = page.getByTestId("list-schedule");
+    if (!(await listSchedule.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    await expect(page.getByTestId("vote-filter-chips")).toHaveCount(0);
+  });
+
+  test("two-tap 'my schedule': Must Go + Interested filters both views to the viewer's own votes", async ({
+    page,
+  }) => {
+    await signInOrSkip(page);
+
+    await page.goto(LIST_PATH);
+    const listSchedule = page.getByTestId("list-schedule");
+    if (!(await listSchedule.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    // Vote Must Go on one set and Interested on another, leaving a third
+    // (Kiara Scuro) unvoted.
+    await page
+      .getByTestId(`vote-buttons-${MAYA_SET_ID}`)
+      .getByTestId("vote-button-mustGo")
+      .click();
+    await page
+      .getByTestId(`vote-buttons-${BEN_SET_ID}`)
+      .getByTestId("vote-button-interested")
+      .click();
+
+    await expect(page.getByTestId("vote-filter-chips")).toBeVisible();
+
+    // Two taps: Must Go, then Interested.
+    await page.getByTestId("vote-filter-chip-mustGo").click();
+    await page.getByTestId("vote-filter-chip-interested").click();
+
+    await expect(page).toHaveURL(/votes=/);
+    await expect(page.getByTestId("schedule-filters-badge")).toHaveText("2");
+
+    await expect(
+      page.getByTestId(`vote-buttons-${MAYA_SET_ID}`),
+    ).toBeVisible();
+    await expect(page.getByTestId(`vote-buttons-${BEN_SET_ID}`)).toBeVisible();
+    await expect(
+      page.getByTestId(`vote-buttons-${KIARA_SET_ID}`),
+    ).toHaveCount(0);
+
+    // Shared URL state: the Timeline view sees the same selection and badge.
+    const url = new URL(page.url());
+    await page.goto(`${TIMELINE_PATH}${url.search}`);
+
+    const scrollContainer = page.getByTestId("timeline-scroll-container");
+    if (!(await scrollContainer.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    await expect(page.getByTestId("schedule-filters-badge")).toHaveText("2");
+    await expect(
+      page.getByTestId(`vote-buttons-${MAYA_SET_ID}`),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId(`vote-buttons-${KIARA_SET_ID}`),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -6,9 +6,13 @@ const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
 const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 
 // Sets seeded on Friday July 12, 2025 (see `public.sets` inserts in seed.sql).
-const MAYA_SET_ID = "11111111-1111-1111-1111-111111111111";
-const BEN_SET_ID = "22222222-2222-2222-2222-222222222222";
-const KIARA_SET_ID = "33333333-3333-3333-3333-333333333333";
+const MAYA_SET_NAME = "Maya Jane Coles";
+const BEN_SET_NAME = "Ben Böhmer";
+const KIARA_SET_NAME = "Kiara Scuro";
+
+function voteGroup(page: import("@playwright/test").Page, setName: string) {
+  return page.getByRole("group", { name: `Vote for ${setName}` });
+}
 
 async function signInOrSkip(page: import("@playwright/test").Page) {
   const testHelpers = new TestHelpers(page);
@@ -36,7 +40,9 @@ test.describe("My-vote chips", () => {
       test.skip(true, "Schedule not revealed in this environment");
     }
 
-    await expect(page.getByTestId("vote-filter-chips")).toHaveCount(0);
+    await expect(
+      page.getByRole("group", { name: "Filter by my vote" }),
+    ).toHaveCount(0);
 
     await page.goto(LIST_PATH);
     const listSchedule = page.getByTestId("list-schedule");
@@ -44,7 +50,9 @@ test.describe("My-vote chips", () => {
       test.skip(true, "Schedule not revealed in this environment");
     }
 
-    await expect(page.getByTestId("vote-filter-chips")).toHaveCount(0);
+    await expect(
+      page.getByRole("group", { name: "Filter by my vote" }),
+    ).toHaveCount(0);
   });
 
   test("a shared ?votes= link is inert for logged-out visitors - sets still show", async ({
@@ -58,10 +66,10 @@ test.describe("My-vote chips", () => {
     }
 
     // No viewer identity, so the vote filter must not empty the schedule.
+    await expect(voteGroup(page, MAYA_SET_NAME)).toBeVisible();
     await expect(
-      page.getByTestId(`vote-buttons-${MAYA_SET_ID}`),
-    ).toBeVisible();
-    await expect(page.getByTestId("vote-filter-chips")).toHaveCount(0);
+      page.getByRole("group", { name: "Filter by my vote" }),
+    ).toHaveCount(0);
     // The badge must not advertise the inert vote filter.
     await expect(page.getByTestId("schedule-filters-badge")).toHaveCount(0);
   });
@@ -79,30 +87,25 @@ test.describe("My-vote chips", () => {
 
     // Vote Must Go on one set and Interested on another, leaving a third
     // (Kiara Scuro) unvoted.
-    await page
-      .getByTestId(`vote-buttons-${MAYA_SET_ID}`)
-      .getByTestId("vote-button-mustGo")
+    await voteGroup(page, MAYA_SET_NAME)
+      .getByRole("button", { name: "Must Go" })
       .click();
-    await page
-      .getByTestId(`vote-buttons-${BEN_SET_ID}`)
-      .getByTestId("vote-button-interested")
+    await voteGroup(page, BEN_SET_NAME)
+      .getByRole("button", { name: "Interested" })
       .click();
 
-    await expect(page.getByTestId("vote-filter-chips")).toBeVisible();
+    const chips = page.getByRole("group", { name: "Filter by my vote" });
+    await expect(chips).toBeVisible();
 
-    await page.getByTestId("vote-filter-chip-mustGo").click();
-    await page.getByTestId("vote-filter-chip-interested").click();
+    await chips.getByRole("button", { name: "Must Go" }).click();
+    await chips.getByRole("button", { name: "Interested" }).click();
 
     await expect(page).toHaveURL(/votes=/);
     await expect(page.getByTestId("schedule-filters-badge")).toHaveText("2");
 
-    await expect(
-      page.getByTestId(`vote-buttons-${MAYA_SET_ID}`),
-    ).toBeVisible();
-    await expect(page.getByTestId(`vote-buttons-${BEN_SET_ID}`)).toBeVisible();
-    await expect(
-      page.getByTestId(`vote-buttons-${KIARA_SET_ID}`),
-    ).toHaveCount(0);
+    await expect(voteGroup(page, MAYA_SET_NAME)).toBeVisible();
+    await expect(voteGroup(page, BEN_SET_NAME)).toBeVisible();
+    await expect(voteGroup(page, KIARA_SET_NAME)).toHaveCount(0);
 
     // Shared URL state: the Timeline view sees the same selection and badge.
     const url = new URL(page.url());
@@ -114,11 +117,7 @@ test.describe("My-vote chips", () => {
     }
 
     await expect(page.getByTestId("schedule-filters-badge")).toHaveText("2");
-    await expect(
-      page.getByTestId(`vote-buttons-${MAYA_SET_ID}`),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId(`vote-buttons-${KIARA_SET_ID}`),
-    ).toHaveCount(0);
+    await expect(voteGroup(page, MAYA_SET_NAME)).toBeVisible();
+    await expect(voteGroup(page, KIARA_SET_NAME)).toHaveCount(0);
   });
 });

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -23,21 +23,16 @@ test.describe("My-vote chips", () => {
     page,
   }) => {
     await page.goto(TIMELINE_PATH);
-
-    const scrollContainer = page.getByTestId("timeline-scroll-container");
-    if (!(await scrollContainer.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    await expect(
+      page.getByTestId("timeline-scroll-container"),
+    ).toBeVisible();
 
     await expect(
       page.getByRole("group", { name: "Filter by my vote" }),
     ).toHaveCount(0);
 
     await page.goto(LIST_PATH);
-    const listSchedule = page.getByTestId("list-schedule");
-    if (!(await listSchedule.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    await expect(page.getByTestId("list-schedule")).toBeVisible();
 
     await expect(
       page.getByRole("group", { name: "Filter by my vote" }),
@@ -48,11 +43,7 @@ test.describe("My-vote chips", () => {
     page,
   }) => {
     await page.goto(`${LIST_PATH}?votes=mustGo`);
-
-    const listSchedule = page.getByTestId("list-schedule");
-    if (!(await listSchedule.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    await expect(page.getByTestId("list-schedule")).toBeVisible();
 
     // No viewer identity, so the vote filter must not empty the schedule.
     await expect(voteGroup(page, MAYA_SET_NAME)).toBeVisible();
@@ -69,10 +60,7 @@ test.describe("My-vote chips", () => {
     await signIn(page);
 
     await page.goto(LIST_PATH);
-    const listSchedule = page.getByTestId("list-schedule");
-    if (!(await listSchedule.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    await expect(page.getByTestId("list-schedule")).toBeVisible();
 
     // Vote Must Go on one set and Interested on another, leaving a third
     // (Kiara Scuro) unvoted.
@@ -99,11 +87,9 @@ test.describe("My-vote chips", () => {
     // Shared URL state: the Timeline view sees the same selection and badge.
     const url = new URL(page.url());
     await page.goto(`${TIMELINE_PATH}${url.search}`);
-
-    const scrollContainer = page.getByTestId("timeline-scroll-container");
-    if (!(await scrollContainer.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
+    await expect(
+      page.getByTestId("timeline-scroll-container"),
+    ).toBeVisible();
 
     await expect(page.getByTestId("schedule-filters-badge")).toHaveText("2");
     await expect(voteGroup(page, MAYA_SET_NAME)).toBeVisible();


### PR DESCRIPTION
Adds Must Go / Interested / Won't Go chips to the Schedule filters, letting the viewer filter both Timeline and List to sets they voted on themselves.
Selection is OR-ed, persists in the URL, and counts toward the filter badge.

Closes #196. Stacked on the #195 filter-sheet branch/PR - review only the top commit if that PR is still open.

## Verification
- Sign in, vote Must Go on one set and Interested on another, tap both chips: only those two sets remain visible on List; the same holds after switching to Timeline.
- Tap a selected chip again to deselect: all sets return (OR semantics, off when none selected).
- Sign out: the chips are absent from both the Timeline toolbar and the List filter row (no disabled state, no login teaser).
- Filter badge count increases by one per selected chip and matches across Timeline/List for the same URL.
- `pnpm run lint`, `pnpm run typecheck`, `pnpm vitest run` all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AziTqr3f12fxALYD6jhrW8)_