### PR TITLE
ci(e2e): split PR smoke suite from nightly full suite

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,53 @@
+name: E2E Smoke Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    env:
+      VITE_SUPABASE_URL: http://127.0.0.1:54321
+      VITE_SUPABASE_PUBLISHABLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Setup Supabase
+        run: |
+          npx supabase start
+          sleep 10
+          npx supabase db reset
+
+      - name: Build project
+        run: pnpm run build
+
+      - name: Run Playwright smoke tests
+        run: npx playwright test --project=chromium --retries=2 auth.spec.ts navigation.spec.ts artists.spec.ts voting.spec.ts onboarding.spec.ts
+        env:
+          TEST_SUPABASE_URL: http://localhost:54321
+          TEST_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCN9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: smoke-playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -26,8 +26,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Setup Supabase
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,10 +1,9 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
 
 jobs:
   test:
@@ -62,6 +61,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
@@ -86,7 +87,7 @@ jobs:
 
       - name: Generate summary comment
         uses: daun/playwright-report-summary@v4
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         with:
           report-file: all-json-reports.json
 
@@ -98,3 +99,36 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+      - name: Report nightly failure as a GitHub issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Nightly E2E suite failing";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `The nightly E2E suite failed.\n\nRun: ${runUrl}`;
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "nightly-e2e-failure",
+            });
+
+            if (existing.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["nightly-e2e-failure"],
+              });
+            }

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -117,19 +117,36 @@ jobs:
           retention-days: 30
 
       - name: Report nightly failure as a GitHub issue
-        if: failure()
+        if: failure() || needs.test.result == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
             const title = "Nightly E2E suite failing";
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = `The nightly E2E suite failed.\n\nRun: ${runUrl}`;
+            const label = "nightly-e2e-failure";
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: "d73a4a",
+                description: "Nightly E2E full-suite run failed",
+              });
+            }
 
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: "open",
-              labels: "nightly-e2e-failure",
+              labels: label,
             });
 
             if (existing.length > 0) {
@@ -145,6 +162,6 @@ jobs:
                 repo: context.repo.repo,
                 title,
                 body,
-                labels: ["nightly-e2e-failure"],
+                labels: [label],
               });
             }

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,8 +32,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
 
       - name: Setup Supabase
         run: |


### PR DESCRIPTION
Splits E2E testing into a fast chromium-only smoke suite gating PRs/pushes to `main`, and moves the full 3-browser matrix to a nightly cron with failure alerting. Also removes redundant `waitForTimeout` waits and caches Playwright browser binaries in both workflows.

Closes #217, #218, #219, #222, #223

## Verification
- Open a PR against `main` and confirm only `E2E Smoke Tests` runs (auth, navigation, artists, voting, onboarding specs, chromium only) — not the full `E2E Tests` workflow.
- Confirm `E2E Tests` no longer triggers on push/PR; trigger it manually via `workflow_dispatch` and confirm it still runs all specs across chromium/firefox/webkit, sharded.
- Break a spec temporarily and re-run `E2E Tests` via `workflow_dispatch` to confirm a `nightly-e2e-failure`-labeled issue is created (then revert).
- Re-run either workflow twice in a row and confirm the second run's "Install Playwright Browsers" step is skipped in favor of the faster `install-deps` step (cache hit).

---
_Generated by [Claude Code](https://claude.ai/code/session_011XrexnBRbv2yBwQPDZ6GJi)_