### PR TITLE
test(e2e): replace redundant waitForTimeout with auto-waiting assertions

### DIFF
--- a/tests/e2e/timeline-day-toolbar.spec.ts
+++ b/tests/e2e/timeline-day-toolbar.spec.ts
@@ -49,8 +49,6 @@ test.describe("Timeline day-jump toolbar", () => {
     // Jump to the last day, which should be far from the initial viewport.
     await dayButtons.last().click();
 
-    await page.waitForTimeout(SCROLL_ANIMATION_WAIT_MS);
-
     await expect(page).toHaveURL(/scrollTo=/);
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
     expect(scrollTo).toBeTruthy();

--- a/tests/e2e/timeline-now-indicator.spec.ts
+++ b/tests/e2e/timeline-now-indicator.spec.ts
@@ -5,7 +5,6 @@ import { test, expect } from "@playwright/test";
 // (earliest set start) through Sun Jul 14 23:00 UTC (latest set end) - the
 // rendered timeline's festival window.
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
-const SCROLL_ANIMATION_WAIT_MS = 800; // > smooth-scroll animation + the ~300ms debounce
 
 // Comfortably inside the seeded festival window.
 const NOW_INSIDE_WINDOW = new Date("2025-07-13T12:00:00Z");
@@ -89,7 +88,6 @@ test.describe("Timeline Now pill and current-time indicator", () => {
     });
 
     await nowButton.click();
-    await page.waitForTimeout(SCROLL_ANIMATION_WAIT_MS);
 
     await expect(page).toHaveURL(/scrollTo=/);
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");

--- a/tests/e2e/timeline-overview.spec.ts
+++ b/tests/e2e/timeline-overview.spec.ts
@@ -3,8 +3,6 @@ import { test, expect } from "@playwright/test";
 // Seeded in supabase/seed.sql: festival slug "test", edition slug "2025",
 // three festival days (Jul 12-14, 2025) each with timed sets.
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
-const SCROLL_ANIMATION_WAIT_MS = 800; // > smooth-scroll animation + the ~300ms debounce
-const DEBOUNCE_WAIT_MS = 600; // > the ~300ms debounce in useTimelineScrollSync
 
 test.describe("Timeline overview mini-map", () => {
   test("collapsed by default; toggle expands and collapses it", async ({
@@ -52,8 +50,6 @@ test.describe("Timeline overview mini-map", () => {
     // Click near the right edge of the map, far from wherever the strip
     // is currently centered.
     await page.mouse.click(mapBox.x + mapBox.width * 0.9, mapBox.y + mapBox.height / 2);
-
-    await page.waitForTimeout(SCROLL_ANIMATION_WAIT_MS);
 
     await expect(page).toHaveURL(/scrollTo=/);
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
@@ -103,7 +99,6 @@ test.describe("Timeline overview mini-map", () => {
 
     await page.mouse.up();
 
-    await page.waitForTimeout(DEBOUNCE_WAIT_MS);
     await expect(page).toHaveURL(/scrollTo=/);
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
     expect(scrollTo).toBeTruthy();

--- a/tests/e2e/timeline-scroll.spec.ts
+++ b/tests/e2e/timeline-scroll.spec.ts
@@ -2,10 +2,6 @@ import { test, expect, type Page } from "@playwright/test";
 
 // Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
-// Comfortably past the ~300ms scroll->URL debounce. Uses real time rather than
-// a fake clock: installing a fake clock stalls the timers the data fetch and
-// re-navigations depend on, which prevents the timeline from rendering.
-const SCROLL_DEBOUNCE_WAIT_MS = 600;
 
 async function openTimeline(page: Page) {
   await page.goto(TIMELINE_PATH);
@@ -40,7 +36,6 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await page.waitForTimeout(100);
     expect(new URL(page.url()).searchParams.has("scrollTo")).toBe(false);
 
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
     await expect(page).toHaveURL(/scrollTo=/);
 
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
@@ -54,7 +49,9 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 200;
     });
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("scrollTo"))
+      .not.toBe(scrollTo);
 
     const historyLengthAfterScroll = await page.evaluate(
       () => window.history.length,
@@ -71,7 +68,9 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 600;
     });
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
+      .toBe(true);
 
     const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
     expect(scrollTo).toBeTruthy();
@@ -103,7 +102,9 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 500;
     });
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
+      .toBe(true);
 
     const urlWithScroll = page.url();
     const scrollLeftBeforeNav = await scrollContainer.evaluate(
@@ -143,7 +144,9 @@ test.describe("Timeline scroll position (scrollTo URL state)", () => {
     await scrollContainer.evaluate((el) => {
       el.scrollLeft = el.scrollLeft + 500;
     });
-    await page.waitForTimeout(SCROLL_DEBOUNCE_WAIT_MS);
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
+      .toBe(true);
 
     const urlWithScroll = page.url();
     expect(new URL(urlWithScroll).searchParams.has("scrollTo")).toBe(true);


### PR DESCRIPTION
Removes fixed `waitForTimeout` sleeps that preceded assertions which already auto-wait, and converts a few "wait then check" patterns to `expect.poll`. Genuine real-time debounce-settle waits are kept where no assertion could substitute.

Closes #218

## Verification
- `pnpm run test:e2e -- timeline-overview.spec.ts timeline-day-toolbar.spec.ts timeline-scroll.spec.ts timeline-now-indicator.spec.ts` passes with the same assertions as before, just without padded fixed sleeps.

---
_Generated by [Claude Code](https://claude.ai/code/session_011XrexnBRbv2yBwQPDZ6GJi)_