### PR TITLE
ci(e2e): split playwright browser cache per suite

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-all-browsers
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/tests/e2e/voting.spec.ts
+++ b/tests/e2e/voting.spec.ts
@@ -29,7 +29,7 @@ test.describe("Voting on a set", () => {
   });
 
   test.afterAll(async () => {
-    await context.close();
+    await context?.close();
   });
 
   test("casts a Must Go vote and reflects the selected state", async () => {


### PR DESCRIPTION
Scopes the Playwright browser cache key per workflow so the chromium-only smoke cache can no longer satisfy the nightly all-browsers job, which skipped install and failed every firefox/webkit test. Fixes #226.
Also guards the voting spec teardown so a launch failure isn't buried under a TypeError.

## Verification
- Trigger the nightly `E2E Tests` workflow via workflow_dispatch on this branch; the "Install Playwright Browsers" step runs (cache miss on the new `-all-browsers` key) and firefox/webkit tests launch.
- Re-run it; the cache hits its own key and tests still pass.
- Open a PR touching any file; the smoke workflow still passes on its `-chromium` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)