### PR TITLE
feat(schedule): sticky view switcher + shared layout constants

### DIFF
--- a/.claude/skills/continue-pr/SKILL.md
+++ b/.claude/skills/continue-pr/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: continue-pr
+description: "Resume work on an existing PR branch — an issue is already in progress with an open PR, and the ask is to pick it back up rather than start fresh. Use when the user gives a branch + PR and says to continue, keep working, or work on the PR (not a new branch)."
+---
+
+# Continue PR
+
+Pick up an in-progress PR rather than starting over. Checkout the named branch — never create a new one — and fetch the PR to ground the rest of the work.
+
+1. **Checkout the existing branch.** `git fetch origin <branch>` then `git checkout <branch>`. If the PR is already merged, this is fresh work instead: restart the branch from the base branch's tip (see CLAUDE.md's merged-PR rule) rather than stacking on merged history.
+
+2. **Read the PR, not just the issue.** Fetch the PR body, diff stat, and review comments. The PR body says what's already done; unresolved review comments are the real remaining work list — treat each one as a task, not a suggestion to skim.
+
+3. **Diff the issue's acceptance criteria against what's already on the branch.** Some criteria may already be met by existing commits — verify each one against the actual code, don't assume unchecked means undone.
+
+4. **Do the remaining work.** Typecheck, run the relevant tests, and close any gap found in steps 2-3.
+
+5. **Reply to review comments you addressed**, and resolve their threads. If a comment is already satisfied by existing code, say so and resolve it rather than re-doing the work.
+
+6. **Commit and push to the same branch** (`git push -u origin <branch>`). Don't open a new PR — the existing one tracks this branch.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,7 @@ The set of artists associated with an edition. Visible to voters once the editio
 _Avoid_: Roster, bill
 
 **Schedule**:
-The arrangement of an edition's **sets** across **stages** and time. Presented to users via the Timeline and List views on the Schedule tab. Not a stored entity — derived from sets + stages of an edition.
+The arrangement of an edition's **sets** across **stages** and time. Presented to users via the Now, Timeline, and List views on the Schedule tab. Not a stored entity — derived from sets + stages of an edition.
 _Avoid_: Lineup (lineup = who; schedule = when/where), program, timetable
 
 **Festival phase**:

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -12,8 +12,15 @@ export const STICKY_TOP_BELOW_TOP_BAR_CLASS = "top-16 md:top-20";
 // The Now/Timeline/List switcher (ScheduleNavigation) is sticky just below
 // the top bar, above the Outlet content, on every schedule view — so
 // anything sticky inside the Outlet (timeline toolbar/header strip, list
-// day headers) must dock below it too.
-export const SWITCHER_HEIGHT_PX = { mobile: 56, desktop: 56 } as const;
+// day headers) must dock below it too. Given a fixed height (rather than
+// letting padding/content determine it) so this constant is exact, not a
+// guess — ScheduleNavigation applies SWITCHER_HEIGHT_CLASS below and must
+// stay in sync with these numbers.
+export const SWITCHER_HEIGHT_PX = { mobile: 56, desktop: 64 } as const;
+
+// Tailwind height classes matching SWITCHER_HEIGHT_PX exactly — applied to
+// ScheduleNavigation's sticky container.
+export const SWITCHER_HEIGHT_CLASS = "h-14 md:h-16";
 
 export const STICKY_TOP_BELOW_SWITCHER_PX = {
   mobile: TOP_BAR_HEIGHT_PX.mobile + SWITCHER_HEIGHT_PX.mobile,
@@ -24,7 +31,7 @@ export const STICKY_TOP_BELOW_SWITCHER_PX = {
 // literal so Tailwind's content scanner can statically find it — must stay
 // in sync with STICKY_TOP_BELOW_SWITCHER_PX above), for sticky elements that
 // don't otherwise need a JS media-query (toolbar, day header).
-export const STICKY_TOP_BELOW_SWITCHER_CLASS = "top-[120px] md:top-[136px]";
+export const STICKY_TOP_BELOW_SWITCHER_CLASS = "top-[120px] md:top-[144px]";
 
 // The timeline toolbar sits at the very top of its scroll region (above
 // everything else), so the header strip below it stacks on top of the

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -1,0 +1,32 @@
+// Shared sticky-offset constants so sticky bars (timeline toolbar/header
+// strip, list-view day headers) derive their `top` from one source instead
+// of scattered magic numbers.
+
+export const TOP_BAR_HEIGHT_PX = { mobile: 64, desktop: 80 } as const;
+
+// Tailwind utility classes matching TOP_BAR_HEIGHT_PX (the fixed top bar's
+// `h-16 md:h-20` spacer in TopBar.tsx) — used by sticky elements docking
+// directly below it (timeline toolbar/header strip, list day headers).
+export const STICKY_TOP_BELOW_TOP_BAR_CLASS = "top-16 md:top-20";
+
+// The Now/Timeline/List switcher (ScheduleNavigation) is sticky just below
+// the top bar, above the Outlet content, on every schedule view — so
+// anything sticky inside the Outlet (timeline toolbar/header strip, list
+// day headers) must dock below it too.
+export const SWITCHER_HEIGHT_PX = { mobile: 56, desktop: 56 } as const;
+
+export const STICKY_TOP_BELOW_SWITCHER_PX = {
+  mobile: TOP_BAR_HEIGHT_PX.mobile + SWITCHER_HEIGHT_PX.mobile,
+  desktop: TOP_BAR_HEIGHT_PX.desktop + SWITCHER_HEIGHT_PX.desktop,
+} as const;
+
+// Tailwind class equivalent of STICKY_TOP_BELOW_SWITCHER_PX (written as a
+// literal so Tailwind's content scanner can statically find it — must stay
+// in sync with STICKY_TOP_BELOW_SWITCHER_PX above), for sticky elements that
+// don't otherwise need a JS media-query (toolbar, day header).
+export const STICKY_TOP_BELOW_SWITCHER_CLASS = "top-[120px] md:top-[136px]";
+
+// The timeline toolbar sits at the very top of its scroll region (above
+// everything else), so the header strip below it stacks on top of the
+// toolbar's own height.
+export const TIMELINE_TOOLBAR_HEIGHT_PX = { mobile: 52, desktop: 52 } as const;

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
@@ -2,6 +2,8 @@ import { Calendar, List, Radio } from "lucide-react";
 import { useFestivalPhase } from "@/hooks/useFestivalPhase";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNavigationItem } from "./ScheduleNavigationItem";
+import { STICKY_TOP_BELOW_TOP_BAR_CLASS } from "@/lib/layout-constants";
+import { cn } from "@/lib/utils";
 
 export function ScheduleNavigation() {
   const { phase } = useFestivalPhase();
@@ -9,17 +11,24 @@ export function ScheduleNavigation() {
   const showNow = phase === "live" && canShowTime;
 
   return (
-    <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
-      <div className="flex items-center justify-center gap-1">
-        {showNow && (
-          <ScheduleNavigationItem view="now" label="Now" icon={Radio} />
-        )}
-        <ScheduleNavigationItem
-          view="timeline"
-          label="Timeline"
-          icon={Calendar}
-        />
-        <ScheduleNavigationItem view="list" label="List" icon={List} />
+    <div
+      className={cn(
+        "sticky z-30 bg-background/95 backdrop-blur-md py-2",
+        STICKY_TOP_BELOW_TOP_BAR_CLASS,
+      )}
+    >
+      <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
+        <div className="flex items-center justify-center gap-1">
+          {showNow && (
+            <ScheduleNavigationItem view="now" label="Now" icon={Radio} />
+          )}
+          <ScheduleNavigationItem
+            view="timeline"
+            label="Timeline"
+            icon={Calendar}
+          />
+          <ScheduleNavigationItem view="list" label="List" icon={List} />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
@@ -2,7 +2,10 @@ import { Calendar, List, Radio } from "lucide-react";
 import { useFestivalPhase } from "@/hooks/useFestivalPhase";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNavigationItem } from "./ScheduleNavigationItem";
-import { STICKY_TOP_BELOW_TOP_BAR_CLASS } from "@/lib/layout-constants";
+import {
+  STICKY_TOP_BELOW_TOP_BAR_CLASS,
+  SWITCHER_HEIGHT_CLASS,
+} from "@/lib/layout-constants";
 import { cn } from "@/lib/utils";
 
 export function ScheduleNavigation() {
@@ -13,11 +16,12 @@ export function ScheduleNavigation() {
   return (
     <div
       className={cn(
-        "sticky z-30 bg-background/95 backdrop-blur-md py-2",
+        "sticky z-30 flex items-center bg-background/95 backdrop-blur-md",
+        SWITCHER_HEIGHT_CLASS,
         STICKY_TOP_BELOW_TOP_BAR_CLASS,
       )}
     >
-      <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
+      <div className="w-full bg-white/10 backdrop-blur-md rounded-lg p-1">
         <div className="flex items-center justify-center gap-1">
           {showNow && (
             <ScheduleNavigationItem view="now" label="Now" icon={Radio} />


### PR DESCRIPTION
The Now/Timeline/List switcher now docks below the fixed top bar instead of scrolling behind it. Adds a shared layout-constants module so sticky bars derive their offsets from one source instead of scattered magic numbers; the timeline toolbar and list day header build on this in follow-up PRs (#234, #235).

Closes #233.

## Verification
- Open the Schedule tab on mobile and desktop; scroll down. The Now/Timeline/List switcher stays pinned just below the top bar instead of sliding under it.
- Switch between Now, Timeline, and List; the switcher looks and sits identically on all three.

---
_Generated by [Claude Code](https://claude.ai/code/session_011MJJ4etMSZmx916fNiyzqF)_