### PR TITLE
feat(timeline): sticky header strip + unboxed timeline

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,7 @@ The set of artists associated with an edition. Visible to voters once the editio
 _Avoid_: Roster, bill
 
 **Schedule**:
-The arrangement of an edition's **sets** across **stages** and time. Presented to users via the Timeline and List views on the Schedule tab. Not a stored entity — derived from sets + stages of an edition.
+The arrangement of an edition's **sets** across **stages** and time. Presented to users via the Now, Timeline, and List views on the Schedule tab. Not a stored entity — derived from sets + stages of an edition.
 _Avoid_: Lineup (lineup = who; schedule = when/where), program, timetable
 
 **Festival phase**:

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -12,7 +12,7 @@ export const STICKY_TOP_BELOW_TOP_BAR_CLASS = "top-16 md:top-20";
 // The timeline toolbar sits at the very top of its scroll region (above
 // everything else), so the header strip below it stacks on top of the
 // toolbar's own height.
-export const TIMELINE_TOOLBAR_HEIGHT_PX = { mobile: 52, desktop: 52 } as const;
+export const TIMELINE_TOOLBAR_HEIGHT_PX = { mobile: 63, desktop: 63 } as const;
 
 export const HEADER_STRIP_TOP_PX = {
   mobile: TOP_BAR_HEIGHT_PX.mobile + TIMELINE_TOOLBAR_HEIGHT_PX.mobile,

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -22,3 +22,10 @@ export const HEADER_STRIP_TOP_PX = {
   mobile: TOP_BAR_HEIGHT_PX.mobile + TIMELINE_TOOLBAR_HEIGHT_PX.mobile,
   desktop: TOP_BAR_HEIGHT_PX.desktop + TIMELINE_TOOLBAR_HEIGHT_PX.desktop,
 } as const;
+
+// Tailwind classes matching HEADER_STRIP_TOP_PX, expressed responsively so
+// the offset doesn't depend on a JS media-query hook (which starts at
+// `false` and would flash the desktop offset on mobile before settling).
+// Written as a literal string (not interpolated from the px constants
+// above) so Tailwind's static class scanner can pick it up.
+export const HEADER_STRIP_TOP_CLASS = "top-[127px] md:top-[143px]";

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -9,24 +9,12 @@ export const TOP_BAR_HEIGHT_PX = { mobile: 64, desktop: 80 } as const;
 // directly below it (timeline toolbar/header strip, list day headers).
 export const STICKY_TOP_BELOW_TOP_BAR_CLASS = "top-16 md:top-20";
 
-// The Now/Timeline/List switcher (ScheduleNavigation) is sticky just below
-// the top bar, above the Outlet content, on every schedule view — so
-// anything sticky inside the Outlet (timeline toolbar/header strip, list
-// day headers) must dock below it too.
-export const SWITCHER_HEIGHT_PX = { mobile: 56, desktop: 56 } as const;
-
-export const STICKY_TOP_BELOW_SWITCHER_PX = {
-  mobile: TOP_BAR_HEIGHT_PX.mobile + SWITCHER_HEIGHT_PX.mobile,
-  desktop: TOP_BAR_HEIGHT_PX.desktop + SWITCHER_HEIGHT_PX.desktop,
-} as const;
-
-// Tailwind class equivalent of STICKY_TOP_BELOW_SWITCHER_PX (written as a
-// literal so Tailwind's content scanner can statically find it — must stay
-// in sync with STICKY_TOP_BELOW_SWITCHER_PX above), for sticky elements that
-// don't otherwise need a JS media-query (toolbar, day header).
-export const STICKY_TOP_BELOW_SWITCHER_CLASS = "top-[120px] md:top-[136px]";
-
 // The timeline toolbar sits at the very top of its scroll region (above
 // everything else), so the header strip below it stacks on top of the
 // toolbar's own height.
 export const TIMELINE_TOOLBAR_HEIGHT_PX = { mobile: 52, desktop: 52 } as const;
+
+export const HEADER_STRIP_TOP_PX = {
+  mobile: TOP_BAR_HEIGHT_PX.mobile + TIMELINE_TOOLBAR_HEIGHT_PX.mobile,
+  desktop: TOP_BAR_HEIGHT_PX.desktop + TIMELINE_TOOLBAR_HEIGHT_PX.desktop,
+} as const;

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -9,14 +9,15 @@ export const TOP_BAR_HEIGHT_PX = { mobile: 64, desktop: 80 } as const;
 // directly below it (timeline toolbar/header strip, list day headers).
 export const STICKY_TOP_BELOW_TOP_BAR_CLASS = "top-16 md:top-20";
 
-// The timeline toolbar sits at the very top of its scroll region (above
-// everything else), so the header strip below it stacks on top of the
-// toolbar's own height.
-// Measured from the rendered toolbar (padding + border + content), not a
-// Tailwind spacing-scale value — re-measure and update by hand if the
-// toolbar's own layout changes.
+// The timeline toolbar (TimelineToolbar.tsx) sits at the very top of its
+// scroll region (above everything else), so the header strip below it
+// stacks on top of the toolbar's own height.
+// Measured from the rendered toolbar (padding + border + content).
 export const TIMELINE_TOOLBAR_HEIGHT_PX = { mobile: 63, desktop: 63 } as const;
 
+// Used by the timeline header strip (TimeScaleContainer.tsx) to dock below
+// the toolbar. Measured from the rendered toolbar (padding + border +
+// content).
 export const HEADER_STRIP_TOP_PX = {
   mobile: TOP_BAR_HEIGHT_PX.mobile + TIMELINE_TOOLBAR_HEIGHT_PX.mobile,
   desktop: TOP_BAR_HEIGHT_PX.desktop + TIMELINE_TOOLBAR_HEIGHT_PX.desktop,

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -12,6 +12,9 @@ export const STICKY_TOP_BELOW_TOP_BAR_CLASS = "top-16 md:top-20";
 // The timeline toolbar sits at the very top of its scroll region (above
 // everything else), so the header strip below it stacks on top of the
 // toolbar's own height.
+// Measured from the rendered toolbar (padding + border + content), not a
+// Tailwind spacing-scale value — re-measure and update by hand if the
+// toolbar's own layout changes.
 export const TIMELINE_TOOLBAR_HEIGHT_PX = { mobile: 63, desktop: 63 } as const;
 
 export const HEADER_STRIP_TOP_PX = {

--- a/src/lib/layout-constants.ts
+++ b/src/lib/layout-constants.ts
@@ -1,0 +1,32 @@
+// Shared sticky-offset constants so sticky bars (timeline toolbar/header
+// strip, list-view day headers) derive their `top` from one source instead
+// of scattered magic numbers.
+
+export const TOP_BAR_HEIGHT_PX = { mobile: 64, desktop: 80 } as const;
+
+// Tailwind utility classes matching TOP_BAR_HEIGHT_PX (the fixed top bar's
+// `h-16 md:h-20` spacer in TopBar.tsx) — used by sticky elements docking
+// directly below it (timeline toolbar/header strip, list day headers).
+export const STICKY_TOP_BELOW_TOP_BAR_CLASS = "top-16 md:top-20";
+
+// The Now/Timeline/List switcher (ScheduleNavigation) is sticky just below
+// the top bar, above the Outlet content, on every schedule view — so
+// anything sticky inside the Outlet (timeline toolbar/header strip, list
+// day headers) must dock below it too.
+export const SWITCHER_HEIGHT_PX = { mobile: 56, desktop: 56 } as const;
+
+export const STICKY_TOP_BELOW_SWITCHER_PX = {
+  mobile: TOP_BAR_HEIGHT_PX.mobile + SWITCHER_HEIGHT_PX.mobile,
+  desktop: TOP_BAR_HEIGHT_PX.desktop + SWITCHER_HEIGHT_PX.desktop,
+} as const;
+
+// Tailwind class equivalent of STICKY_TOP_BELOW_SWITCHER_PX (written as a
+// literal so Tailwind's content scanner can statically find it — must stay
+// in sync with STICKY_TOP_BELOW_SWITCHER_PX above), for sticky elements that
+// don't otherwise need a JS media-query (toolbar, day header).
+export const STICKY_TOP_BELOW_SWITCHER_CLASS = "top-[120px] md:top-[136px]";
+
+// The timeline toolbar sits at the very top of its scroll region (above
+// everything else), so the header strip below it stacks on top of the
+// toolbar's own height.
+export const TIMELINE_TOOLBAR_HEIGHT_PX = { mobile: 52, desktop: 52 } as const;

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
@@ -9,19 +9,17 @@ export function ScheduleNavigation() {
   const showNow = phase === "live" && canShowTime;
 
   return (
-    <div className="py-2">
-      <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
-        <div className="flex items-center justify-center gap-1">
-          {showNow && (
-            <ScheduleNavigationItem view="now" label="Now" icon={Radio} />
-          )}
-          <ScheduleNavigationItem
-            view="timeline"
-            label="Timeline"
-            icon={Calendar}
-          />
-          <ScheduleNavigationItem view="list" label="List" icon={List} />
-        </div>
+    <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
+      <div className="flex items-center justify-center gap-1">
+        {showNow && (
+          <ScheduleNavigationItem view="now" label="Now" icon={Radio} />
+        )}
+        <ScheduleNavigationItem
+          view="timeline"
+          label="Timeline"
+          icon={Calendar}
+        />
+        <ScheduleNavigationItem view="list" label="List" icon={List} />
       </div>
     </div>
   );

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
@@ -2,6 +2,8 @@ import { Calendar, List, Radio } from "lucide-react";
 import { useFestivalPhase } from "@/hooks/useFestivalPhase";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNavigationItem } from "./ScheduleNavigationItem";
+import { STICKY_TOP_BELOW_TOP_BAR_CLASS } from "@/lib/layout-constants";
+import { cn } from "@/lib/utils";
 
 export function ScheduleNavigation() {
   const { phase } = useFestivalPhase();
@@ -9,17 +11,24 @@ export function ScheduleNavigation() {
   const showNow = phase === "live" && canShowTime;
 
   return (
-    <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
-      <div className="flex items-center justify-center gap-1">
-        {showNow && (
-          <ScheduleNavigationItem view="now" label="Now" icon={Radio} />
-        )}
-        <ScheduleNavigationItem
-          view="timeline"
-          label="Timeline"
-          icon={Calendar}
-        />
-        <ScheduleNavigationItem view="list" label="List" icon={List} />
+    <div
+      className={cn(
+        "sticky z-30 bg-background/95 backdrop-blur-md py-2",
+        STICKY_TOP_BELOW_TOP_BAR_CLASS,
+      )}
+    >
+      <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
+        <div className="flex items-center justify-center gap-1">
+          {showNow && (
+            <ScheduleNavigationItem view="now" label="Now" icon={Radio} />
+          )}
+          <ScheduleNavigationItem
+            view="timeline"
+            label="Timeline"
+            icon={Calendar}
+          />
+          <ScheduleNavigationItem view="list" label="List" icon={List} />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleNavigation.tsx
@@ -2,8 +2,6 @@ import { Calendar, List, Radio } from "lucide-react";
 import { useFestivalPhase } from "@/hooks/useFestivalPhase";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNavigationItem } from "./ScheduleNavigationItem";
-import { STICKY_TOP_BELOW_TOP_BAR_CLASS } from "@/lib/layout-constants";
-import { cn } from "@/lib/utils";
 
 export function ScheduleNavigation() {
   const { phase } = useFestivalPhase();
@@ -11,12 +9,7 @@ export function ScheduleNavigation() {
   const showNow = phase === "live" && canShowTime;
 
   return (
-    <div
-      className={cn(
-        "sticky z-30 bg-background/95 backdrop-blur-md py-2",
-        STICKY_TOP_BELOW_TOP_BAR_CLASS,
-      )}
-    >
+    <div className="py-2">
       <div className="bg-white/10 backdrop-blur-md rounded-lg p-1">
         <div className="flex items-center justify-center gap-1">
           {showNow && (

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
@@ -6,7 +6,7 @@ interface StageLabelsProps {
 
 export function StageLabels({ stages }: StageLabelsProps) {
   return (
-    <div className="absolute top-12 z-20 space-y-16">
+    <div className="absolute top-4 z-20 space-y-16">
       {stages.map((stage) => (
         <div key={stage.name} className="h-20 flex items-center">
           <div

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
@@ -4,18 +4,11 @@ interface StageLabelsProps {
   stages: Array<{ name: string; color?: string }>;
 }
 
-// Each label sits in the blank gap directly above its stage's row (the
-// row's own space-y-12 gap, 48px), flush against the row's top edge, so it
-// never covers a set block — the row track itself has no headroom (its
-// cards sit flush at its own top). Must stay in lockstep with the stage
-// row stack's own spacing (mt-12 + space-y-12 track height in
-// TimelineContainer): label height 48px (h-12) + 96px row height
-// (space-y-24) == one row's full 144px period.
 export function StageLabels({ stages }: StageLabelsProps) {
   return (
     <div className="absolute top-0 z-20 space-y-24">
       {stages.map((stage) => (
-        <div key={stage.name} className="h-12 flex items-end">
+        <div key={stage.name} className="h-12 flex items-center">
           <div
             className="text-sm font-medium text-white px-2 py-1 rounded"
             style={{

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
@@ -4,11 +4,18 @@ interface StageLabelsProps {
   stages: Array<{ name: string; color?: string }>;
 }
 
+// Each label sits in the blank gap directly above its stage's row (the
+// row's own space-y-12 gap, 48px), flush against the row's top edge, so it
+// never covers a set block — the row track itself has no headroom (its
+// cards sit flush at its own top). Must stay in lockstep with the stage
+// row stack's own spacing (mt-12 + space-y-12 track height in
+// TimelineContainer): label height 48px (h-12) + 96px row height
+// (space-y-24) == one row's full 144px period.
 export function StageLabels({ stages }: StageLabelsProps) {
   return (
-    <div className="absolute top-4 z-20 space-y-16">
+    <div className="absolute top-0 z-20 space-y-24">
       {stages.map((stage) => (
-        <div key={stage.name} className="h-20 flex items-center">
+        <div key={stage.name} className="h-12 flex items-end">
           <div
             className="text-sm font-medium text-white px-2 py-1 rounded"
             style={{

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -5,13 +5,29 @@ interface TimeScaleProps {
   timeSlots: Date[];
   totalWidth: number;
   timezone: string;
+  scrollLeft: number;
 }
 
 const dateFormat = "MMMM d";
 
-// Pure layout of the canvas at `totalWidth` — the parent (TimelineContainer)
-// hosts it inside a sticky, horizontally-synced strip.
-export function TimeScale({ timeSlots, totalWidth, timezone }: TimeScaleProps) {
+// Width of the day-boundary gap between adjacent date backgrounds.
+const DAY_GAP_PX = 5;
+
+// Distance (px) from the next day boundary at which its label starts fading in.
+const UPCOMING_FADE_THRESHOLD_PX = 100;
+
+// Renders the date band + hour markers for the timeline. The parent
+// (TimelineContainer) hosts this inside a sticky strip that mirrors
+// horizontal scroll via `transform: translateX(-scrollLeft)`; this
+// component receives that same `scrollLeft` so the current day's label
+// can stay pinned to the left edge of the strip while scrolling through
+// that day, fading over to the next day's label as its boundary nears.
+export function TimeScale({
+  timeSlots,
+  totalWidth,
+  timezone,
+  scrollLeft,
+}: TimeScaleProps) {
   const dateChanges = timeSlots.reduce(
     (changes, timeSlot, index) => {
       if (index === 0) {
@@ -35,25 +51,79 @@ export function TimeScale({ timeSlots, totalWidth, timezone }: TimeScaleProps) {
     [] as Array<{ date: Date; position: number }>,
   );
 
+  const currentDateIndex = dateChanges.findLastIndex(
+    (change) => change.position <= scrollLeft,
+  );
+  const currentDate =
+    currentDateIndex >= 0 ? dateChanges[currentDateIndex] : dateChanges[0];
+  const nextDate =
+    currentDateIndex >= 0 && currentDateIndex < dateChanges.length - 1
+      ? dateChanges[currentDateIndex + 1]
+      : null;
+
+  const currentDayEndPosition = nextDate
+    ? nextDate.position - DAY_GAP_PX
+    : totalWidth;
+  const currentDayWidth = currentDayEndPosition - currentDate.position;
+  const distanceToNextDay = nextDate
+    ? nextDate.position - scrollLeft
+    : Infinity;
+  const shouldShowUpcoming =
+    nextDate !== null && distanceToNextDay <= UPCOMING_FADE_THRESHOLD_PX;
+
+  // Pinned label stays within its own day block: not before the day starts,
+  // not past the day's end (leaving room for the label's own width).
+  const currentDateStickyLeft = Math.min(
+    Math.max(0, scrollLeft - currentDate.position),
+    Math.max(0, currentDayWidth - 120),
+  );
+
   return (
     <div className="relative" style={{ minWidth: totalWidth }}>
-      <div className="flex-1 relative h-8">
+      <div className="relative h-8">
         {dateChanges.map((dateChange, index) => {
           const nextDateChange = dateChanges[index + 1];
-          const width = nextDateChange
+          const fullWidth = nextDateChange
             ? nextDateChange.position - dateChange.position
             : totalWidth - dateChange.position;
+          const width = fullWidth - DAY_GAP_PX;
 
           return (
             <div
-              key={`date-${index}`}
-              className="absolute top-0 h-full flex items-center bg-purple-800 px-3 text-sm font-semibold text-white whitespace-nowrap"
-              style={{ left: `${dateChange.position}px`, width: `${width}px` }}
-            >
-              {formatInTimeZone(dateChange.date, timezone, dateFormat)}
-            </div>
+              key={`date-bg-${index}`}
+              className="absolute top-0 h-full bg-purple-900/60 border border-purple-400/30"
+              style={{
+                left: `${dateChange.position}px`,
+                width: `${width}px`,
+              }}
+            />
           );
         })}
+
+        <div
+          className="absolute top-0 z-10 flex h-full items-center px-3 text-sm font-medium text-purple-100 whitespace-nowrap"
+          style={{
+            left: `${currentDate.position + currentDateStickyLeft}px`,
+            opacity: scrollLeft - currentDate.position >= 0 ? 1 : 0,
+          }}
+        >
+          {formatInTimeZone(currentDate.date, timezone, dateFormat)}
+        </div>
+
+        {shouldShowUpcoming && nextDate && (
+          <div
+            className="absolute top-0 z-10 flex h-full items-center px-3 text-sm font-medium text-purple-50 whitespace-nowrap"
+            style={{
+              left: `${nextDate.position}px`,
+              opacity: Math.min(
+                1,
+                (UPCOMING_FADE_THRESHOLD_PX - distanceToNextDay) / 50,
+              ),
+            }}
+          >
+            {formatInTimeZone(nextDate.date, timezone, dateFormat)}
+          </div>
+        )}
       </div>
 
       <div className="hour-markers relative h-10">

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -9,9 +9,8 @@ interface TimeScaleProps {
 
 const dateFormat = "MMMM d";
 
-// Renders the date band + hour markers for the timeline. This is a pure
-// layout of the canvas at `totalWidth`; the parent (TimelineContainer) hosts
-// it inside a sticky, horizontally-synced strip.
+// Pure layout of the canvas at `totalWidth` — the parent (TimelineContainer)
+// hosts it inside a sticky, horizontally-synced strip.
 export function TimeScale({ timeSlots, totalWidth, timezone }: TimeScaleProps) {
   const dateChanges = timeSlots.reduce(
     (changes, timeSlot, index) => {

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -1,11 +1,13 @@
 import { formatInTimeZone } from "date-fns-tz";
+import { useEffect, useState } from "react";
 import { timeToOffset } from "@/lib/timelineCalculator";
 
 interface TimeScaleProps {
   timeSlots: Date[];
   totalWidth: number;
   timezone: string;
-  scrollLeft: number;
+  scrollContainerRef: React.RefObject<HTMLDivElement>;
+  stickyTop: number;
 }
 
 const dateFormat = "MMMM d";
@@ -16,18 +18,27 @@ const DAY_GAP_PX = 5;
 // Distance (px) from the next day boundary at which its label starts fading in.
 const UPCOMING_FADE_THRESHOLD_PX = 100;
 
-// Renders the date band + hour markers for the timeline. The parent
-// (TimelineContainer) hosts this inside a sticky strip that mirrors
-// horizontal scroll via `transform: translateX(-scrollLeft)`; this
-// component receives that same `scrollLeft` so the current day's label
-// can stay pinned to the left edge of the strip while scrolling through
-// that day, fading over to the next day's label as its boundary nears.
 export function TimeScale({
   timeSlots,
   totalWidth,
   timezone,
-  scrollLeft,
+  scrollContainerRef,
+  stickyTop,
 }: TimeScaleProps) {
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    function handleScroll() {
+      setScrollLeft(container!.scrollLeft);
+    }
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [scrollContainerRef]);
+
   const dateChanges = timeSlots.reduce(
     (changes, timeSlot, index) => {
       if (index === 0) {
@@ -79,7 +90,10 @@ export function TimeScale({
   );
 
   return (
-    <div className="relative" style={{ minWidth: totalWidth }}>
+    <div
+      className="sticky z-30 bg-gray-900/95 backdrop-blur-md"
+      style={{ top: stickyTop, minWidth: totalWidth }}
+    >
       <div className="relative h-8">
         {dateChanges.map((dateChange, index) => {
           const nextDateChange = dateChanges[index + 1];

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -47,7 +47,7 @@ export function TimeScale({ timeSlots, totalWidth, timezone }: TimeScaleProps) {
           return (
             <div
               key={`date-${index}`}
-              className="absolute top-0 flex items-center text-sm font-medium text-purple-200 whitespace-nowrap"
+              className="absolute top-0 h-full flex items-center bg-purple-800 px-3 text-sm font-semibold text-white whitespace-nowrap"
               style={{ left: `${dateChange.position}px`, width: `${width}px` }}
             >
               {formatInTimeZone(dateChange.date, timezone, dateFormat)}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -1,189 +1,75 @@
-import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
-import { useEffect, useState, useRef } from "react";
+import { formatInTimeZone } from "date-fns-tz";
 import { timeToOffset } from "@/lib/timelineCalculator";
 
 interface TimeScaleProps {
   timeSlots: Date[];
   totalWidth: number;
-  scrollContainerRef: React.RefObject<HTMLDivElement>;
   timezone: string;
 }
 
 const dateFormat = "MMMM d";
 
-export function TimeScale({
-  timeSlots,
-  totalWidth,
-  scrollContainerRef,
-  timezone,
-}: TimeScaleProps) {
-  const [scrollLeft, setScrollLeft] = useState(0);
-  const timeScaleRef = useRef<HTMLDivElement>(null);
-
-  // Find where dates change to position floating date labels
+// Renders the date band + hour markers for the timeline. This is a pure
+// layout of the canvas at `totalWidth`; the parent (TimelineContainer) hosts
+// it inside a sticky, horizontally-synced strip.
+export function TimeScale({ timeSlots, totalWidth, timezone }: TimeScaleProps) {
   const dateChanges = timeSlots.reduce(
     (changes, timeSlot, index) => {
       if (index === 0) {
         changes.push({ date: timeSlot, position: 0 });
-      } else {
-        const prevDate = formatInTimeZone(
-          timeSlots[index - 1],
-          timezone,
-          "yyyy-MM-dd",
-        );
-        const currentDate = formatInTimeZone(timeSlot, timezone, "yyyy-MM-dd");
-        if (prevDate !== currentDate) {
-          // Position based on festival-timezone midnight of the new date
-          const midnightOfNewDate = fromZonedTime(
-            `${currentDate}T00:00:00`,
-            timezone,
-          );
-
-          // Calculate position relative to festival start
-          const festivalStart = timeSlots[0];
-          const position = timeToOffset(midnightOfNewDate, festivalStart) + 20;
-
-          changes.push({ date: midnightOfNewDate, position });
-        }
+        return changes;
+      }
+      const prevDate = formatInTimeZone(
+        timeSlots[index - 1],
+        timezone,
+        "yyyy-MM-dd",
+      );
+      const currentDate = formatInTimeZone(timeSlot, timezone, "yyyy-MM-dd");
+      if (prevDate !== currentDate) {
+        changes.push({
+          date: timeSlot,
+          position: timeToOffset(timeSlot, timeSlots[0]),
+        });
       }
       return changes;
     },
     [] as Array<{ date: Date; position: number }>,
   );
 
-  // Track scroll position for sticky date labels
-  useEffect(() => {
-    if (!scrollContainerRef.current) return;
-
-    function handleScroll() {
-      setScrollLeft(scrollContainerRef.current?.scrollLeft || 0);
-    }
-
-    const scrollContainer = scrollContainerRef.current;
-    scrollContainer.addEventListener("scroll", handleScroll);
-
-    return () => {
-      scrollContainer.removeEventListener("scroll", handleScroll);
-    };
-  }, [scrollContainerRef]);
-
-  // Find which dates should be visible based on scroll position
-  const visiblePosition = scrollLeft;
-
-  // Find current day (the day we're currently viewing)
-  const currentDateIndex = dateChanges.findLastIndex(
-    (change) => change.position <= visiblePosition,
-  );
-  const currentDate =
-    currentDateIndex >= 0 ? dateChanges[currentDateIndex] : dateChanges[0];
-  const nextDate =
-    currentDateIndex >= 0 && currentDateIndex < dateChanges.length - 1
-      ? dateChanges[currentDateIndex + 1]
-      : null;
-
-  // Calculate positions for sticky dates
-  const currentDayEndPosition = nextDate ? nextDate.position - 5 : totalWidth; // -5 for the gap
-  const currentDayWidth = currentDayEndPosition - currentDate.position;
-  const scrolledIntoCurrentDay = visiblePosition - currentDate.position;
-
-  // When to show upcoming date (e.g., when within 100px of next day)
-  const showUpcomingThreshold = 100;
-  const distanceToNextDay = nextDate
-    ? nextDate.position - visiblePosition
-    : Infinity;
-  const shouldShowUpcoming =
-    nextDate && distanceToNextDay <= showUpcomingThreshold;
-
-  // Position for current day label (constrained to its day block)
-  const currentDateStickyLeft = Math.min(
-    Math.max(0, scrollLeft - currentDate.position), // Don't go before day start
-    currentDayWidth - 120, // Don't go past day end (120px for label width)
-  );
-
   return (
-    <div className="relative">
-      {/* Current day sticky label - stays within its day block */}
-      <div
-        className="absolute top-0 z-30 text-sm font-medium px-3 py-1 rounded shadow-lg  text-purple-200 whitespace-nowrap"
-        style={{
-          left: `${currentDate.position + currentDateStickyLeft}px`,
-          opacity: scrolledIntoCurrentDay >= 0 ? 1 : 0,
-        }}
-      >
-        {currentDate
-          ? formatInTimeZone(currentDate.date, timezone, dateFormat)
-          : "Loading..."}
+    <div className="relative" style={{ minWidth: totalWidth }}>
+      <div className="flex-1 relative h-8">
+        {dateChanges.map((dateChange, index) => {
+          const nextDateChange = dateChanges[index + 1];
+          const width = nextDateChange
+            ? nextDateChange.position - dateChange.position
+            : totalWidth - dateChange.position;
+
+          return (
+            <div
+              key={`date-${index}`}
+              className="absolute top-0 flex items-center text-sm font-medium text-purple-200 whitespace-nowrap"
+              style={{ left: `${dateChange.position}px`, width: `${width}px` }}
+            >
+              {formatInTimeZone(dateChange.date, timezone, dateFormat)}
+            </div>
+          );
+        })}
       </div>
 
-      {/* Upcoming day sticky label - appears when approaching next day */}
-      {shouldShowUpcoming && nextDate && (
-        <div
-          className="absolute top-0 z-30 text-sm font-medium px-3 py-1 rounded shadow-lg  text-purple-100 whitespace-nowrap "
-          style={{
-            left: `${nextDate.position}px`, // Show to the right of current view
-            opacity: Math.min(
-              1,
-              (showUpcomingThreshold - distanceToNextDay) / 50,
-            ), // Fade in effect
-          }}
-        >
-          {formatInTimeZone(nextDate.date, timezone, dateFormat)}
-        </div>
-      )}
-
-      <div
-        ref={timeScaleRef}
-        className="flex items-center mb-[72px] relative"
-        style={{ minWidth: totalWidth }}
-      >
-        <div className="flex-1 relative">
-          {/* Floating date labels spanning the width of each day */}
-          {dateChanges.map((dateChange, index) => {
-            // Calculate width from this date to the next date (or end of timeline)
-            const nextDateChange = dateChanges[index + 1];
-            const fullWidth = nextDateChange
-              ? nextDateChange.position - dateChange.position
-              : totalWidth - dateChange.position;
-
-            const space = 5;
-            const width = fullWidth - space;
-            const left = dateChange.position;
-
-            return (
-              <div
-                key={`date-${index}`}
-                className="absolute top-0 text-sm font-medium text-purple-200 bg-purple-900/60 px-2 py-1 border border-purple-400/30 flex items-center justify-center"
-                style={{
-                  left: `${left}px`,
-                  width: `${width}px`,
-                  minWidth: "100px", // Ensure minimum readability
-                }}
-              >
-                {/* {format(dateChange.date, dateFormat)} */}
-                &nbsp;
-              </div>
-            );
-          })}
-
-          {/* Hour markers */}
-          <div className="hour-markers">
-            {timeSlots.map((timeSlot, index) => (
-              <div
-                key={index}
-                className="absolute flex flex-col items-center"
-                style={{ left: `${timeToOffset(timeSlot, timeSlots[0])}px` }}
-              >
-                <div className="text-sm font-medium text-purple-300 mb-2 mt-10">
-                  {formatInTimeZone(timeSlot, timezone, "HH:mm")}
-                </div>
-                <div className="w-px h-4 bg-purple-400/30"></div>
-              </div>
-            ))}
+      <div className="hour-markers relative h-10">
+        {timeSlots.map((timeSlot, index) => (
+          <div
+            key={index}
+            className="absolute flex flex-col items-center"
+            style={{ left: `${timeToOffset(timeSlot, timeSlots[0])}px` }}
+          >
+            <div className="text-sm font-medium text-purple-300">
+              {formatInTimeZone(timeSlot, timezone, "HH:mm")}
+            </div>
+            <div className="w-px h-4 bg-purple-400/30" />
           </div>
-
-          {/* Horizontal grid line */}
-          <div className="absolute top-16 left-0 right-0 h-px bg-purple-400/20"></div>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -1,13 +1,11 @@
 import { formatInTimeZone } from "date-fns-tz";
-import { useEffect, useState } from "react";
 import { timeToOffset } from "@/lib/timelineCalculator";
 
 interface TimeScaleProps {
   timeSlots: Date[];
   totalWidth: number;
   timezone: string;
-  scrollContainerRef: React.RefObject<HTMLDivElement>;
-  stickyTop: number;
+  scrollLeft: number;
 }
 
 const dateFormat = "MMMM d";
@@ -18,27 +16,18 @@ const DAY_GAP_PX = 5;
 // Distance (px) from the next day boundary at which its label starts fading in.
 const UPCOMING_FADE_THRESHOLD_PX = 100;
 
+// Renders the date band + hour markers for the timeline. The parent
+// (TimelineContainer) hosts this inside a sticky strip that mirrors
+// horizontal scroll via `transform: translateX(-scrollLeft)`; this
+// component receives that same `scrollLeft` so the current day's label
+// can stay pinned to the left edge of the strip while scrolling through
+// that day, fading over to the next day's label as its boundary nears.
 export function TimeScale({
   timeSlots,
   totalWidth,
   timezone,
-  scrollContainerRef,
-  stickyTop,
+  scrollLeft,
 }: TimeScaleProps) {
-  const [scrollLeft, setScrollLeft] = useState(0);
-
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    function handleScroll() {
-      setScrollLeft(container!.scrollLeft);
-    }
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, [scrollContainerRef]);
-
   const dateChanges = timeSlots.reduce(
     (changes, timeSlot, index) => {
       if (index === 0) {
@@ -90,10 +79,7 @@ export function TimeScale({
   );
 
   return (
-    <div
-      className="sticky z-30 bg-gray-900/95 backdrop-blur-md"
-      style={{ top: stickyTop, minWidth: totalWidth }}
-    >
+    <div className="relative" style={{ minWidth: totalWidth }}>
       <div className="relative h-8">
         {dateChanges.map((dateChange, index) => {
           const nextDateChange = dateChanges[index + 1];

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -16,12 +16,9 @@ const DAY_GAP_PX = 5;
 // Distance (px) from the next day boundary at which its label starts fading in.
 const UPCOMING_FADE_THRESHOLD_PX = 100;
 
-// Renders the date band + hour markers for the timeline. The parent
-// (TimelineContainer) hosts this inside a sticky strip that mirrors
-// horizontal scroll via `transform: translateX(-scrollLeft)`; this
-// component receives that same `scrollLeft` so the current day's label
-// can stay pinned to the left edge of the strip while scrolling through
-// that day, fading over to the next day's label as its boundary nears.
+// `scrollLeft` keeps the current day's label pinned to the strip's left
+// edge while scrolling through that day, fading in the next day's label
+// as its boundary nears.
 export function TimeScale({
   timeSlots,
   totalWidth,

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
@@ -1,19 +1,22 @@
 import { TimeScale } from "./TimeScale";
 import type { TimelineData } from "@/lib/timelineCalculator";
+import { HEADER_STRIP_TOP_PX } from "@/lib/layout-constants";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface TimeScaleContainerProps {
   timelineData: TimelineData;
   timezone: string;
   scrollLeft: number;
-  top: number;
 }
 
 export function TimeScaleContainer({
   timelineData,
   timezone,
   scrollLeft,
-  top,
 }: TimeScaleContainerProps) {
+  const isMobile = useIsMobile();
+  const top = isMobile ? HEADER_STRIP_TOP_PX.mobile : HEADER_STRIP_TOP_PX.desktop;
+
   return (
     <div
       className="sticky z-30 overflow-hidden rounded-b-lg bg-gray-900/95 backdrop-blur-md"

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
@@ -1,7 +1,7 @@
 import { TimeScale } from "./TimeScale";
 import type { TimelineData } from "@/lib/timelineCalculator";
-import { HEADER_STRIP_TOP_PX } from "@/lib/layout-constants";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { HEADER_STRIP_TOP_CLASS } from "@/lib/layout-constants";
+import { cn } from "@/lib/utils";
 
 interface TimeScaleContainerProps {
   timelineData: TimelineData;
@@ -14,13 +14,12 @@ export function TimeScaleContainer({
   timezone,
   scrollLeft,
 }: TimeScaleContainerProps) {
-  const isMobile = useIsMobile();
-  const top = isMobile ? HEADER_STRIP_TOP_PX.mobile : HEADER_STRIP_TOP_PX.desktop;
-
   return (
     <div
-      className="sticky z-30 overflow-hidden rounded-b-lg bg-gray-900/95 backdrop-blur-md"
-      style={{ top }}
+      className={cn(
+        "sticky z-30 overflow-hidden rounded-b-lg bg-gray-900",
+        HEADER_STRIP_TOP_CLASS,
+      )}
     >
       <div
         style={{

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
@@ -16,7 +16,7 @@ export function TimeScaleContainer({
 }: TimeScaleContainerProps) {
   return (
     <div
-      className="sticky z-30 overflow-hidden bg-gray-900/95 backdrop-blur-md"
+      className="sticky z-30 overflow-hidden rounded-b-lg bg-gray-900/95 backdrop-blur-md"
       style={{ top }}
     >
       <div

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScaleContainer.tsx
@@ -1,0 +1,37 @@
+import { TimeScale } from "./TimeScale";
+import type { TimelineData } from "@/lib/timelineCalculator";
+
+interface TimeScaleContainerProps {
+  timelineData: TimelineData;
+  timezone: string;
+  scrollLeft: number;
+  top: number;
+}
+
+export function TimeScaleContainer({
+  timelineData,
+  timezone,
+  scrollLeft,
+  top,
+}: TimeScaleContainerProps) {
+  return (
+    <div
+      className="sticky z-30 overflow-hidden bg-gray-900/95 backdrop-blur-md"
+      style={{ top }}
+    >
+      <div
+        style={{
+          transform: `translateX(-${scrollLeft}px)`,
+          width: timelineData.totalWidth,
+        }}
+      >
+        <TimeScale
+          timeSlots={timelineData.timeSlots}
+          totalWidth={timelineData.totalWidth}
+          timezone={timezone}
+          scrollLeft={scrollLeft}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -112,17 +112,13 @@ export function Timeline() {
   }
 
   return (
-    <div className="space-y-8">
-      <div className="bg-white/5 rounded-lg p-4">
-        <TimelineContainer
-          timelineData={timelineData}
-          timezone={festival.timezone}
-          scheduleDays={scheduleDays}
-          selectedDay={selectedDay}
-          scheduleWindow={scheduleWindow}
-          now={now}
-        />
-      </div>
-    </div>
+    <TimelineContainer
+      timelineData={timelineData}
+      timezone={festival.timezone}
+      scheduleDays={scheduleDays}
+      selectedDay={selectedDay}
+      scheduleWindow={scheduleWindow}
+      now={now}
+    />
   );
 }

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -126,6 +126,7 @@ export function TimelineContainer({
             timeSlots={timelineData.timeSlots}
             totalWidth={timelineData.totalWidth}
             timezone={timezone}
+            scrollLeft={scrollLeft}
           />
         </div>
       </div>
@@ -138,7 +139,7 @@ export function TimelineContainer({
           className="overflow-x-auto overflow-y-hidden pb-20"
         >
           <div className="relative">
-            <div className="space-y-12 mt-4">
+            <div className="space-y-12 mt-12">
               {timelineData.stages.map((stage) => (
                 <StageRow
                   key={stage.name}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -15,10 +15,7 @@ import type { ScheduleDay } from "@/hooks/useScheduleData";
 import { useTimelineScrollSync } from "@/hooks/useTimelineScrollSync";
 import { jumpToTimelineMoment } from "@/lib/timelineDayJump";
 import { useActiveTimelineDay } from "@/hooks/useActiveTimelineDay";
-import {
-  STICKY_TOP_BELOW_SWITCHER_PX,
-  TIMELINE_TOOLBAR_HEIGHT_PX,
-} from "@/lib/layout-constants";
+import { HEADER_STRIP_TOP_PX } from "@/lib/layout-constants";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 interface TimelineContainerProps {
@@ -42,11 +39,9 @@ export function TimelineContainer({
   const [isOverviewExpanded, setIsOverviewExpanded] = useState(false);
   const [scrollLeft, setScrollLeft] = useState(0);
   const isMobile = useIsMobile();
-  function pick(sizes: { mobile: number; desktop: number }) {
-    return isMobile ? sizes.mobile : sizes.desktop;
-  }
-  const headerStripTop =
-    pick(STICKY_TOP_BELOW_SWITCHER_PX) + pick(TIMELINE_TOOLBAR_HEIGHT_PX);
+  const headerStripTop = isMobile
+    ? HEADER_STRIP_TOP_PX.mobile
+    : HEADER_STRIP_TOP_PX.desktop;
 
   useEffect(() => {
     const container = scrollContainerRef.current;

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { TimeScale } from "./TimeScale";
 import { StageRow } from "./StageRow";
 import { StageLabels } from "./StageLabels";
@@ -43,18 +43,6 @@ export function TimelineContainer({
     ? HEADER_STRIP_TOP_PX.mobile
     : HEADER_STRIP_TOP_PX.desktop;
 
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    function handleScroll() {
-      setScrollLeft(container!.scrollLeft);
-    }
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, []);
-
   useTimelineScrollSync({
     scrollContainerRef,
     festivalStart: timelineData.festivalStart,
@@ -62,6 +50,23 @@ export function TimelineContainer({
     timezone,
     now,
   });
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    function handleScroll() {
+      setScrollLeft(container!.scrollLeft);
+    }
+
+    // Read the initial position after useTimelineScrollSync's own mount
+    // scroll (also a layout effect, run before this one) so the header
+    // strip doesn't flash at translateX(0) before the first scroll event.
+    setScrollLeft(container.scrollLeft);
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, []);
   const activeDay = useActiveTimelineDay({
     scrollContainerRef,
     days: scheduleDays,

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { TimeScale } from "./TimeScale";
 import { StageRow } from "./StageRow";
 import { StageLabels } from "./StageLabels";
@@ -37,6 +37,7 @@ export function TimelineContainer({
 }: TimelineContainerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isOverviewExpanded, setIsOverviewExpanded] = useState(false);
+  const [scrollLeft, setScrollLeft] = useState(0);
   const isMobile = useIsMobile();
   const headerStripTop = isMobile
     ? HEADER_STRIP_TOP_PX.mobile
@@ -50,6 +51,22 @@ export function TimelineContainer({
     now,
   });
 
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    function handleScroll() {
+      setScrollLeft(container!.scrollLeft);
+    }
+
+    // Read the initial position after useTimelineScrollSync's own mount
+    // scroll (also a layout effect, run before this one) so the header
+    // strip doesn't flash at translateX(0) before the first scroll event.
+    setScrollLeft(container.scrollLeft);
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, []);
   const activeDay = useActiveTimelineDay({
     scrollContainerRef,
     days: scheduleDays,
@@ -95,21 +112,32 @@ export function TimelineContainer({
           onJump={(moment) => jumpTo(moment, "center")}
         />
       )}
-      <div className="relative">
-        <StageLabels stages={timelineData.stages} />
+      <div
+        className="sticky z-30 overflow-hidden bg-gray-900/95 backdrop-blur-md"
+        style={{ top: headerStripTop }}
+      >
         <div
-          ref={scrollContainerRef}
-          data-testid="timeline-scroll-container"
-          className="overflow-x-auto pb-20"
+          style={{
+            transform: `translateX(-${scrollLeft}px)`,
+            width: timelineData.totalWidth,
+          }}
         >
           <TimeScale
             timeSlots={timelineData.timeSlots}
             totalWidth={timelineData.totalWidth}
             timezone={timezone}
-            scrollContainerRef={scrollContainerRef}
-            stickyTop={headerStripTop}
+            scrollLeft={scrollLeft}
           />
+        </div>
+      </div>
 
+      <div className="relative">
+        <StageLabels stages={timelineData.stages} />
+        <div
+          ref={scrollContainerRef}
+          data-testid="timeline-scroll-container"
+          className="overflow-x-auto overflow-y-hidden pb-20"
+        >
           <div className="relative">
             <div className="space-y-12 mt-12">
               {timelineData.stages.map((stage) => (

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -16,8 +16,6 @@ import { useTimelineScrollSync } from "@/hooks/useTimelineScrollSync";
 import { jumpToTimelineMoment } from "@/lib/timelineDayJump";
 import { useActiveTimelineDay } from "@/hooks/useActiveTimelineDay";
 import { useScrollLeft } from "./useScrollLeft";
-import { HEADER_STRIP_TOP_PX } from "@/lib/layout-constants";
-import { useIsMobile } from "@/hooks/use-mobile";
 
 interface TimelineContainerProps {
   timelineData: TimelineData;
@@ -39,10 +37,6 @@ export function TimelineContainer({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isOverviewExpanded, setIsOverviewExpanded] = useState(false);
   const scrollLeft = useScrollLeft(scrollContainerRef);
-  const isMobile = useIsMobile();
-  const headerStripTop = isMobile
-    ? HEADER_STRIP_TOP_PX.mobile
-    : HEADER_STRIP_TOP_PX.desktop;
 
   useTimelineScrollSync({
     scrollContainerRef,
@@ -101,7 +95,6 @@ export function TimelineContainer({
         timelineData={timelineData}
         timezone={timezone}
         scrollLeft={scrollLeft}
-        top={headerStripTop}
       />
 
       <div className="relative">

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { TimeScale } from "./TimeScale";
 import { StageRow } from "./StageRow";
 import { StageLabels } from "./StageLabels";
@@ -37,7 +37,6 @@ export function TimelineContainer({
 }: TimelineContainerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isOverviewExpanded, setIsOverviewExpanded] = useState(false);
-  const [scrollLeft, setScrollLeft] = useState(0);
   const isMobile = useIsMobile();
   const headerStripTop = isMobile
     ? HEADER_STRIP_TOP_PX.mobile
@@ -51,22 +50,6 @@ export function TimelineContainer({
     now,
   });
 
-  useLayoutEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    function handleScroll() {
-      setScrollLeft(container!.scrollLeft);
-    }
-
-    // Read the initial position after useTimelineScrollSync's own mount
-    // scroll (also a layout effect, run before this one) so the header
-    // strip doesn't flash at translateX(0) before the first scroll event.
-    setScrollLeft(container.scrollLeft);
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, []);
   const activeDay = useActiveTimelineDay({
     scrollContainerRef,
     days: scheduleDays,
@@ -112,32 +95,21 @@ export function TimelineContainer({
           onJump={(moment) => jumpTo(moment, "center")}
         />
       )}
-      <div
-        className="sticky z-30 overflow-hidden bg-gray-900/95 backdrop-blur-md"
-        style={{ top: headerStripTop }}
-      >
-        <div
-          style={{
-            transform: `translateX(-${scrollLeft}px)`,
-            width: timelineData.totalWidth,
-          }}
-        >
-          <TimeScale
-            timeSlots={timelineData.timeSlots}
-            totalWidth={timelineData.totalWidth}
-            timezone={timezone}
-            scrollLeft={scrollLeft}
-          />
-        </div>
-      </div>
-
       <div className="relative">
         <StageLabels stages={timelineData.stages} />
         <div
           ref={scrollContainerRef}
           data-testid="timeline-scroll-container"
-          className="overflow-x-auto overflow-y-hidden pb-20"
+          className="overflow-x-auto pb-20"
         >
+          <TimeScale
+            timeSlots={timelineData.timeSlots}
+            totalWidth={timelineData.totalWidth}
+            timezone={timezone}
+            scrollContainerRef={scrollContainerRef}
+            stickyTop={headerStripTop}
+          />
+
           <div className="relative">
             <div className="space-y-12 mt-12">
               {timelineData.stages.map((stage) => (

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TimeScale } from "./TimeScale";
 import { StageRow } from "./StageRow";
 import { StageLabels } from "./StageLabels";
@@ -15,6 +15,11 @@ import type { ScheduleDay } from "@/hooks/useScheduleData";
 import { useTimelineScrollSync } from "@/hooks/useTimelineScrollSync";
 import { jumpToTimelineMoment } from "@/lib/timelineDayJump";
 import { useActiveTimelineDay } from "@/hooks/useActiveTimelineDay";
+import {
+  STICKY_TOP_BELOW_SWITCHER_PX,
+  TIMELINE_TOOLBAR_HEIGHT_PX,
+} from "@/lib/layout-constants";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface TimelineContainerProps {
   timelineData: TimelineData;
@@ -35,6 +40,25 @@ export function TimelineContainer({
 }: TimelineContainerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isOverviewExpanded, setIsOverviewExpanded] = useState(false);
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const isMobile = useIsMobile();
+  function pick(sizes: { mobile: number; desktop: number }) {
+    return isMobile ? sizes.mobile : sizes.desktop;
+  }
+  const headerStripTop =
+    pick(STICKY_TOP_BELOW_SWITCHER_PX) + pick(TIMELINE_TOOLBAR_HEIGHT_PX);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    function handleScroll() {
+      setScrollLeft(container!.scrollLeft);
+    }
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, []);
 
   useTimelineScrollSync({
     scrollContainerRef,
@@ -88,6 +112,24 @@ export function TimelineContainer({
           onJump={(moment) => jumpTo(moment, "center")}
         />
       )}
+      <div
+        className="sticky z-30 overflow-hidden bg-gray-900/95 backdrop-blur-md"
+        style={{ top: headerStripTop }}
+      >
+        <div
+          style={{
+            transform: `translateX(-${scrollLeft}px)`,
+            width: timelineData.totalWidth,
+          }}
+        >
+          <TimeScale
+            timeSlots={timelineData.timeSlots}
+            totalWidth={timelineData.totalWidth}
+            timezone={timezone}
+          />
+        </div>
+      </div>
+
       <div className="relative">
         <StageLabels stages={timelineData.stages} />
         <div
@@ -96,14 +138,7 @@ export function TimelineContainer({
           className="overflow-x-auto overflow-y-hidden pb-20"
         >
           <div className="relative">
-            <TimeScale
-              timeSlots={timelineData.timeSlots}
-              totalWidth={timelineData.totalWidth}
-              scrollContainerRef={scrollContainerRef}
-              timezone={timezone}
-            />
-
-            <div className="space-y-12 mt-28">
+            <div className="space-y-12 mt-4">
               {timelineData.stages.map((stage) => (
                 <StageRow
                   key={stage.name}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineContainer.tsx
@@ -1,5 +1,5 @@
-import { useLayoutEffect, useRef, useState } from "react";
-import { TimeScale } from "./TimeScale";
+import { useRef, useState } from "react";
+import { TimeScaleContainer } from "./TimeScaleContainer";
 import { StageRow } from "./StageRow";
 import { StageLabels } from "./StageLabels";
 import { TimelineToolbar } from "./TimelineToolbar";
@@ -15,6 +15,7 @@ import type { ScheduleDay } from "@/hooks/useScheduleData";
 import { useTimelineScrollSync } from "@/hooks/useTimelineScrollSync";
 import { jumpToTimelineMoment } from "@/lib/timelineDayJump";
 import { useActiveTimelineDay } from "@/hooks/useActiveTimelineDay";
+import { useScrollLeft } from "./useScrollLeft";
 import { HEADER_STRIP_TOP_PX } from "@/lib/layout-constants";
 import { useIsMobile } from "@/hooks/use-mobile";
 
@@ -37,7 +38,7 @@ export function TimelineContainer({
 }: TimelineContainerProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isOverviewExpanded, setIsOverviewExpanded] = useState(false);
-  const [scrollLeft, setScrollLeft] = useState(0);
+  const scrollLeft = useScrollLeft(scrollContainerRef);
   const isMobile = useIsMobile();
   const headerStripTop = isMobile
     ? HEADER_STRIP_TOP_PX.mobile
@@ -51,22 +52,6 @@ export function TimelineContainer({
     now,
   });
 
-  useLayoutEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    function handleScroll() {
-      setScrollLeft(container!.scrollLeft);
-    }
-
-    // Read the initial position after useTimelineScrollSync's own mount
-    // scroll (also a layout effect, run before this one) so the header
-    // strip doesn't flash at translateX(0) before the first scroll event.
-    setScrollLeft(container.scrollLeft);
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, []);
   const activeDay = useActiveTimelineDay({
     scrollContainerRef,
     days: scheduleDays,
@@ -112,24 +97,12 @@ export function TimelineContainer({
           onJump={(moment) => jumpTo(moment, "center")}
         />
       )}
-      <div
-        className="sticky z-30 overflow-hidden bg-gray-900/95 backdrop-blur-md"
-        style={{ top: headerStripTop }}
-      >
-        <div
-          style={{
-            transform: `translateX(-${scrollLeft}px)`,
-            width: timelineData.totalWidth,
-          }}
-        >
-          <TimeScale
-            timeSlots={timelineData.timeSlots}
-            totalWidth={timelineData.totalWidth}
-            timezone={timezone}
-            scrollLeft={scrollLeft}
-          />
-        </div>
-      </div>
+      <TimeScaleContainer
+        timelineData={timelineData}
+        timezone={timezone}
+        scrollLeft={scrollLeft}
+        top={headerStripTop}
+      />
 
       <div className="relative">
         <StageLabels stages={timelineData.stages} />

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
@@ -7,7 +7,7 @@ import { ScheduleFilterSheet } from "../ScheduleFilterSheet";
 import { VoteFilterChips } from "../VoteFilterChips";
 import type { ScheduleDay } from "@/hooks/useScheduleData";
 import { useScrollEdgeFade } from "./useScrollEdgeFade";
-import { STICKY_TOP_BELOW_SWITCHER_CLASS } from "@/lib/layout-constants";
+import { STICKY_TOP_BELOW_TOP_BAR_CLASS } from "@/lib/layout-constants";
 
 interface TimelineToolbarProps {
   days: ScheduleDay[];
@@ -61,7 +61,7 @@ export function TimelineToolbar({
       data-testid="timeline-day-toolbar"
       role="toolbar"
       aria-label="Timeline navigation"
-      className={`sticky ${STICKY_TOP_BELOW_SWITCHER_CLASS} z-40 mb-4 flex items-end gap-1 rounded-lg border border-purple-400/20 bg-gray-900/95 px-2 pb-2.5 pt-2 backdrop-blur-md`}
+      className={`sticky ${STICKY_TOP_BELOW_TOP_BAR_CLASS} z-40 mb-4 flex items-end gap-1 rounded-lg border border-purple-400/20 bg-gray-900/95 px-2 pb-2.5 pt-2 backdrop-blur-md`}
     >
       <div
         ref={dayRowRef}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
@@ -8,6 +8,7 @@ import { VoteFilterChips } from "../VoteFilterChips";
 import type { ScheduleDay } from "@/hooks/useScheduleData";
 import { useScrollEdgeFade } from "./useScrollEdgeFade";
 import { STICKY_TOP_BELOW_TOP_BAR_CLASS } from "@/lib/layout-constants";
+import { cn } from "@/lib/utils";
 
 interface TimelineToolbarProps {
   days: ScheduleDay[];
@@ -61,7 +62,10 @@ export function TimelineToolbar({
       data-testid="timeline-day-toolbar"
       role="toolbar"
       aria-label="Timeline navigation"
-      className={`sticky ${STICKY_TOP_BELOW_TOP_BAR_CLASS} z-40 mb-4 flex items-end gap-1 rounded-lg border border-purple-400/20 bg-gray-900/95 px-2 pb-2.5 pt-2 backdrop-blur-md`}
+      className={cn(
+        "sticky z-40 mb-4 flex items-end gap-1 rounded-lg border border-purple-400/20 bg-gray-900/95 px-2 pb-2.5 pt-2 backdrop-blur-md",
+        STICKY_TOP_BELOW_TOP_BAR_CLASS,
+      )}
     >
       <div
         ref={dayRowRef}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineToolbar.tsx
@@ -7,6 +7,7 @@ import { ScheduleFilterSheet } from "../ScheduleFilterSheet";
 import { VoteFilterChips } from "../VoteFilterChips";
 import type { ScheduleDay } from "@/hooks/useScheduleData";
 import { useScrollEdgeFade } from "./useScrollEdgeFade";
+import { STICKY_TOP_BELOW_SWITCHER_CLASS } from "@/lib/layout-constants";
 
 interface TimelineToolbarProps {
   days: ScheduleDay[];
@@ -60,7 +61,7 @@ export function TimelineToolbar({
       data-testid="timeline-day-toolbar"
       role="toolbar"
       aria-label="Timeline navigation"
-      className="sticky top-0 z-40 mb-4 flex items-end gap-1 rounded-lg border border-purple-400/20 bg-gray-900/95 px-2 pb-2.5 pt-2 backdrop-blur-md"
+      className={`sticky ${STICKY_TOP_BELOW_SWITCHER_CLASS} z-40 mb-4 flex items-end gap-1 rounded-lg border border-purple-400/20 bg-gray-900/95 px-2 pb-2.5 pt-2 backdrop-blur-md`}
     >
       <div
         ref={dayRowRef}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/useScrollLeft.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/useScrollLeft.ts
@@ -1,9 +1,10 @@
 import { useLayoutEffect, useState } from "react";
 import type { RefObject } from "react";
 
-// Reads the initial position after useTimelineScrollSync's own mount scroll
-// (also a layout effect, run before this one) so the header strip doesn't
-// flash at translateX(0) before the first scroll event.
+/**
+ * The scroll container's live `scrollLeft`, kept in sync with its native
+ * scroll events.
+ */
 export function useScrollLeft(
   scrollContainerRef: RefObject<HTMLDivElement>,
 ): number {
@@ -17,6 +18,9 @@ export function useScrollLeft(
       setScrollLeft(container!.scrollLeft);
     }
 
+    // Read the initial position after useTimelineScrollSync's own mount
+    // scroll (also a layout effect, run before this one) so the header
+    // strip doesn't flash at translateX(0) before the first scroll event.
     setScrollLeft(container.scrollLeft);
 
     container.addEventListener("scroll", handleScroll, { passive: true });

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/useScrollLeft.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/useScrollLeft.ts
@@ -1,0 +1,27 @@
+import { useLayoutEffect, useState } from "react";
+import type { RefObject } from "react";
+
+// Reads the initial position after useTimelineScrollSync's own mount scroll
+// (also a layout effect, run before this one) so the header strip doesn't
+// flash at translateX(0) before the first scroll event.
+export function useScrollLeft(
+  scrollContainerRef: RefObject<HTMLDivElement>,
+): number {
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    function handleScroll() {
+      setScrollLeft(container!.scrollLeft);
+    }
+
+    setScrollLeft(container.scrollLeft);
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [scrollContainerRef]);
+
+  return scrollLeft;
+}


### PR DESCRIPTION
Lifts the date band + hour scale out of the horizontal scroller into a sticky strip below the toolbar, synced to horizontal scroll via translateX(-scrollLeft), with a constant opaque background. The timeline drops its framing panel so it uses the full content width.

Builds on #233 (base branch). Closes #234.

## Verification
- Open the Timeline view and scroll down through stages; the date band + hour scale stay pinned and readable.
- Scroll horizontally; the pinned header strip tracks the sets under it without lag or misalignment.
- Confirm the header strip keeps a solid background — set blocks never show through it while scrolling.
- Confirm the timeline has no surrounding framing panel and spans the full content width.

---
_Generated by [Claude Code](https://claude.ai/code/session_011MJJ4etMSZmx916fNiyzqF)_