### PR TITLE
feat(nav): auto-hide mobile bottom tab bar on scroll

### DIFF
--- a/src/hooks/useHideOnScrollDown.ts
+++ b/src/hooks/useHideOnScrollDown.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+// Hides while scrolling down past `threshold`, returns on any scroll-up or
+// once back near the top. The 4px jitter guard avoids flicker from
+// sub-pixel/inertial scroll noise.
+const SCROLL_JITTER_GUARD_PX = 4;
+
+export function useHideOnScrollDown(threshold = 80) {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let lastY = window.scrollY;
+
+    function handleScroll() {
+      const y = window.scrollY;
+      if (y <= threshold) {
+        setHidden(false);
+      } else if (Math.abs(y - lastY) > SCROLL_JITTER_GUARD_PX) {
+        setHidden(y > lastY);
+      }
+      lastY = y;
+    }
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [threshold]);
+
+  return hidden;
+}

--- a/src/pages/EditionView/TabNavigation/TabNavigation.tsx
+++ b/src/pages/EditionView/TabNavigation/TabNavigation.tsx
@@ -5,6 +5,8 @@ import { useFestivalPhase } from "@/hooks/useFestivalPhase";
 import { DesktopTabButton } from "./DesktopTabButton";
 import { MobileTabButton } from "./MobileTabButton";
 import { config } from "./config";
+import { cn } from "@/lib/utils";
+import { useHideOnScrollDown } from "@/hooks/useHideOnScrollDown";
 
 const PRIMARY_TAB_LABEL = {
   "pre-schedule": "Lineup",
@@ -19,6 +21,7 @@ export function MainTabNavigation() {
     festivalInfoQuery(festival.id),
   );
   const { phase } = useFestivalPhase();
+  const hideBottomBar = useHideOnScrollDown();
 
   const visibleTabs = config
     .filter((config) => {
@@ -47,7 +50,13 @@ export function MainTabNavigation() {
       </div>
 
       {/* Mobile: Fixed bottom navigation */}
-      <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-gray-900/95 backdrop-blur-md border-t border-purple-400/20 safe-area-pb">
+      <div
+        data-testid="mobile-tab-bar"
+        className={cn(
+          "md:hidden fixed bottom-0 left-0 right-0 z-50 bg-gray-900/95 backdrop-blur-md border-t border-purple-400/20 safe-area-pb transition-transform duration-200",
+          hideBottomBar && "translate-y-full",
+        )}
+      >
         <div className="flex">
           {visibleTabs.map((config) => (
             <MobileTabButton key={config.key} config={config} />

--- a/tests/e2e/mobile-bottom-nav-autohide.spec.ts
+++ b/tests/e2e/mobile-bottom-nav-autohide.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+// Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
+const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
+
+test.describe("Mobile bottom tab bar auto-hide", () => {
+  test("hides on scroll down and returns on scroll up", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(LIST_PATH);
+
+    const listSchedule = page.getByTestId("list-schedule");
+    if (!(await listSchedule.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    const tabBar = page.getByTestId("mobile-tab-bar");
+    await expect(tabBar).toBeVisible();
+    await expect(tabBar).not.toHaveClass(/translate-y-full/);
+
+    await page.mouse.wheel(0, 600);
+    await expect(tabBar).toHaveClass(/translate-y-full/);
+
+    await page.mouse.wheel(0, -600);
+    await expect(tabBar).not.toHaveClass(/translate-y-full/);
+  });
+});


### PR DESCRIPTION
Bottom tab bar hides on scroll-down past an ~80px threshold (with a jitter guard) and returns on any scroll-up or near the top, giving content the full screen height. Applies uniformly across every edition tab and mobile viewport size; desktop's top tab nav is unaffected.

Closes #236.

## Verification
- On mobile, scroll down on any edition tab; the bottom tab bar slides out of view past the threshold.
- Scroll up, or scroll to near the top; the bar returns immediately.
- Repeat on a different edition tab and a different mobile viewport size; behavior is identical.
- On desktop, confirm nothing hides — the top tab nav is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_011MJJ4etMSZmx916fNiyzqF)_