### PR TITLE
feat(schedule): group list view by festival day with sticky header

### DIFF
--- a/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/ScheduleFilterSheet.tsx
@@ -57,6 +57,11 @@ export function ScheduleFilterSheet({ tab }: ScheduleFilterSheetProps) {
           variant="ghost"
           size="sm"
           data-testid="schedule-filters-trigger"
+          aria-label={
+            hasActiveFilters
+              ? `Filters (${activeFilterCount} active)`
+              : "Filters"
+          }
           className={
             hasActiveFilters
               ? "flex items-center gap-2 bg-purple-600/50 text-purple-100 hover:bg-purple-600/60"

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListDayGroup.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListDayGroup.tsx
@@ -1,0 +1,56 @@
+import { Calendar } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { STICKY_TOP_BELOW_TOP_BAR_CLASS } from "@/lib/layout-constants";
+import { getFestivalDayLabel } from "@/lib/timeUtils";
+import { ScheduleFilterSheet } from "../ScheduleFilterSheet";
+import { VoteFilterChips } from "../VoteFilterChips";
+import { TimeSlotGroup } from "./TimeSlotGroup";
+import type { ScheduleSet } from "@/hooks/useScheduleData";
+
+interface TimeSlot {
+  time: Date;
+  sets: (ScheduleSet & { stageName: string; stageColor?: string })[];
+}
+
+interface ListDayGroupProps {
+  dayKey: string;
+  slots: TimeSlot[];
+  timezone?: string;
+}
+
+// The section is the sticky containing block, so the header stays docked
+// for the whole day instead of just its first time slot.
+export function ListDayGroup({ dayKey, slots, timezone }: ListDayGroupProps) {
+  return (
+    <section data-testid="list-day-group" data-day={dayKey}>
+      <div
+        data-testid="list-day-header"
+        className={cn(
+          "sticky z-10 mb-4 flex items-center gap-2 rounded-lg border border-purple-400/20 bg-gray-900/95 px-4 py-2 backdrop-blur-md",
+          STICKY_TOP_BELOW_TOP_BAR_CLASS,
+        )}
+      >
+        <Calendar className="h-4 w-4 text-purple-300" />
+        <h2 className="text-lg font-semibold text-purple-100">
+          {getFestivalDayLabel(dayKey)}
+        </h2>
+        <div className="ml-auto flex items-center gap-1">
+          <div className="hidden md:block">
+            <VoteFilterChips tab="list" />
+          </div>
+          <ScheduleFilterSheet tab="list" />
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {slots.map((slot) => (
+          <TimeSlotGroup
+            key={slot.time.toISOString()}
+            timeSlot={slot}
+            timezone={timezone}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListDayGroup.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListDayGroup.tsx
@@ -21,26 +21,25 @@ interface ListDayGroupProps {
 // The section is the sticky containing block, so the header stays docked
 // for the whole day instead of just its first time slot.
 export function ListDayGroup({ dayKey, slots, timezone }: ListDayGroupProps) {
+  const dayLabel = getFestivalDayLabel(dayKey) ?? undefined;
+
   return (
-    <section data-testid="list-day-group" data-day={dayKey}>
-      <div
-        data-testid="list-day-header"
+    <section aria-label={dayLabel} data-day={dayKey}>
+      <header
         className={cn(
           "sticky z-10 mb-4 flex items-center gap-2 rounded-lg border border-purple-400/20 bg-gray-900/95 px-4 py-2 backdrop-blur-md",
           STICKY_TOP_BELOW_TOP_BAR_CLASS,
         )}
       >
         <Calendar className="h-4 w-4 text-purple-300" />
-        <h2 className="text-lg font-semibold text-purple-100">
-          {getFestivalDayLabel(dayKey)}
-        </h2>
+        <h2 className="text-lg font-semibold text-purple-100">{dayLabel}</h2>
         <div className="ml-auto flex items-center gap-1">
           <div className="hidden md:block">
             <VoteFilterChips tab="list" />
           </div>
           <ScheduleFilterSheet tab="list" />
         </div>
-      </div>
+      </header>
 
       <div className="space-y-6">
         {slots.map((slot) => (

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
@@ -6,7 +6,7 @@ import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { useSetsByEditionQuery as useEditionSetsQuery } from "@/api/sets/useSetsByEdition";
 import { getFestivalDayKey } from "@/lib/timeUtils";
 import { filterScheduleDays } from "@/lib/scheduleFilter";
-import { TimeSlotGroup } from "./TimeSlotGroup";
+import { ListDayGroup } from "./ListDayGroup";
 import type { ScheduleSet } from "@/hooks/useScheduleData";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
 import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
@@ -18,6 +18,11 @@ import { useUserVotes } from "@/api/voting/useUserVotes";
 interface TimeSlot {
   time: Date;
   sets: (ScheduleSet & { stageName: string; stageColor?: string })[];
+}
+
+interface DayGroup {
+  dayKey: string;
+  slots: TimeSlot[];
 }
 
 export function ListSchedule() {
@@ -43,7 +48,7 @@ export function ListSchedule() {
     votes: selectedVotes,
   } = useTimelineUrlState("list");
 
-  const timeSlots = useMemo(() => {
+  const dayGroups = useMemo(() => {
     if (!scheduleDays.length) return [];
 
     const filteredScheduleDays = filterScheduleDays(
@@ -106,7 +111,24 @@ export function ListSchedule() {
       }))
       .sort((a, b) => a.time.getTime() - b.time.getTime());
 
-    return slots;
+    // Group time slots by festival calendar day so each day renders as one
+    // continuous section under a single sticky header.
+    const groups = new Map<string, TimeSlot[]>();
+    slots.forEach((slot) => {
+      const dayKey = getFestivalDayKey(
+        slot.time.toISOString(),
+        festival.timezone,
+      );
+      if (!dayKey) return;
+      if (!groups.has(dayKey)) groups.set(dayKey, []);
+      groups.get(dayKey)!.push(slot);
+    });
+
+    const sortedDayGroups: DayGroup[] = Array.from(groups.entries())
+      .map(([dayKey, daySlots]) => ({ dayKey, slots: daySlots }))
+      .sort((a, b) => a.dayKey.localeCompare(b.dayKey));
+
+    return sortedDayGroups;
   }, [
     scheduleDays,
     selectedDay,
@@ -138,7 +160,7 @@ export function ListSchedule() {
     return <ScheduleNotRevealedPlaceholder />;
   }
 
-  if (!timeSlots.length) {
+  if (!dayGroups.length) {
     return (
       <div className="text-center text-purple-300 py-12">
         <p>No scheduled sets found.</p>
@@ -147,23 +169,15 @@ export function ListSchedule() {
   }
 
   return (
-    <div className="space-y-6" data-testid="list-schedule">
-      {timeSlots.map((slot, index) => {
-        const prevSlot = index > 0 ? timeSlots[index - 1] : null;
-        const showDateHeader =
-          !prevSlot ||
-          getFestivalDayKey(slot.time.toISOString(), festival.timezone) !==
-            getFestivalDayKey(prevSlot.time.toISOString(), festival.timezone);
-
-        return (
-          <TimeSlotGroup
-            key={slot.time.toISOString()}
-            timeSlot={slot}
-            timezone={festival.timezone}
-            showDateHeader={showDateHeader}
-          />
-        );
-      })}
+    <div className="space-y-8" data-testid="list-schedule">
+      {dayGroups.map((day) => (
+        <ListDayGroup
+          key={day.dayKey}
+          dayKey={day.dayKey}
+          slots={day.slots}
+          timezone={festival.timezone}
+        />
+      ))}
     </div>
   );
 }

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
@@ -7,6 +7,7 @@ import { useSetsByEditionQuery as useEditionSetsQuery } from "@/api/sets/useSets
 import { getFestivalDayKey } from "@/lib/timeUtils";
 import { filterScheduleDays } from "@/lib/scheduleFilter";
 import { ListDayGroup } from "./ListDayGroup";
+import { ScheduleFilterSheet } from "../ScheduleFilterSheet";
 import type { ScheduleSet } from "@/hooks/useScheduleData";
 import { useTimelineUrlState } from "@/hooks/useTimelineUrlState";
 import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
@@ -164,6 +165,9 @@ export function ListSchedule() {
     return (
       <div className="text-center text-purple-300 py-12">
         <p>No scheduled sets found.</p>
+        <div className="mt-4 flex justify-center">
+          <ScheduleFilterSheet tab="list" />
+        </div>
       </div>
     );
   }

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
@@ -112,8 +112,6 @@ export function ListSchedule() {
       }))
       .sort((a, b) => a.time.getTime() - b.time.getTime());
 
-    // Group time slots by festival calendar day so each day renders as one
-    // continuous section under a single sticky header.
     const groups = new Map<string, TimeSlot[]>();
     slots.forEach((slot) => {
       const dayKey = getFestivalDayKey(

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
@@ -1,22 +1,5 @@
 import { ListSchedule } from "./ListSchedule";
-import { ScheduleFilterSheet } from "../ScheduleFilterSheet";
-import { VoteFilterChips } from "../VoteFilterChips";
-import { FilterContainer } from "@/components/filters/FilterContainer";
 
 export function ScheduleTabList() {
-  return (
-    <>
-      <FilterContainer>
-        <div className="flex items-center gap-2 flex-wrap">
-          <h3 className="text-purple-100 font-medium">Filters</h3>
-          <div className="ml-auto" />
-          <div className="hidden md:block">
-            <VoteFilterChips tab="list" />
-          </div>
-          <ScheduleFilterSheet tab="list" />
-        </div>
-      </FilterContainer>
-      <ListSchedule />
-    </>
-  );
+  return <ListSchedule />;
 }

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListTab.tsx
@@ -1,5 +1,0 @@
-import { ListSchedule } from "./ListSchedule";
-
-export function ScheduleTabList() {
-  return <ListSchedule />;
-}

--- a/src/pages/EditionView/tabs/ScheduleTab/list/TimeSlotGroup.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/TimeSlotGroup.tsx
@@ -1,5 +1,5 @@
-import { Clock, Calendar } from "lucide-react";
-import { formatDayOnly, formatTimeOnly } from "@/lib/timeUtils";
+import { Clock } from "lucide-react";
+import { formatTimeOnly } from "@/lib/timeUtils";
 import { MobileSetCard } from "./MobileSetCard";
 import type { ScheduleSet } from "@/hooks/useScheduleData";
 
@@ -10,62 +10,46 @@ interface TimeSlot {
 
 interface TimeSlotGroupProps {
   timeSlot: TimeSlot;
-  showDateHeader: boolean;
   timezone?: string;
 }
 
-export function TimeSlotGroup({
-  timeSlot,
-  showDateHeader,
-  timezone,
-}: TimeSlotGroupProps) {
+export function TimeSlotGroup({ timeSlot, timezone }: TimeSlotGroupProps) {
   return (
-    <div>
-      {showDateHeader && (
-        <div className="flex items-center gap-2 mb-4 px-4 py-2 bg-purple-900/40 rounded-lg backdrop-blur-sm sticky top-0 z-10">
-          <Calendar className="h-4 w-4 text-purple-300" />
-          <h2 className="text-lg font-semibold text-purple-100">
-            {formatDayOnly(timeSlot.time.toISOString(), timezone)}
-          </h2>
+    <div className="relative">
+      {/* Time indicator */}
+      <div className="flex items-center gap-3 mb-3 px-1">
+        <div className="flex items-center gap-2 bg-purple-800/50 px-3 py-1.5 rounded-full">
+          <Clock className="h-3 w-3 text-purple-300" />
+          <span className="text-sm font-medium text-purple-200">
+            {formatTimeOnly(timeSlot.time.toISOString(), null, true, timezone)}
+          </span>
         </div>
-      )}
+        <div className="flex-1 h-px bg-purple-400/20"></div>
+      </div>
 
-      <div className="relative">
-        {/* Time indicator */}
-        <div className="flex items-center gap-3 mb-3 px-1">
-          <div className="flex items-center gap-2 bg-purple-800/50 px-3 py-1.5 rounded-full">
-            <Clock className="h-3 w-3 text-purple-300" />
-            <span className="text-sm font-medium text-purple-200">
-              {formatTimeOnly(timeSlot.time.toISOString(), null, true, timezone)}
-            </span>
-          </div>
-          <div className="flex-1 h-px bg-purple-400/20"></div>
+      <div className="space-y-3">
+        {/* Mobile: Stack all sets vertically */}
+        <div className="block md:hidden space-y-3">
+          {timeSlot.sets.map((set) => (
+            <MobileSetCard key={set.id} set={set} timezone={timezone} />
+          ))}
         </div>
 
-        <div className="space-y-3">
-          {/* Mobile: Stack all sets vertically */}
-          <div className="block md:hidden space-y-3">
-            {timeSlot.sets.map((set) => (
-              <MobileSetCard key={set.id} set={set} timezone={timezone} />
-            ))}
-          </div>
-
-          {/* Desktop: Show sets side by side when space allows */}
-          <div className="hidden md:block">
-            {timeSlot.sets.length === 1 ? (
-              <MobileSetCard
-                key={timeSlot.sets[0].id}
-                set={timeSlot.sets[0]}
-                timezone={timezone}
-              />
-            ) : (
-              <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
-                {timeSlot.sets.map((set) => (
-                  <MobileSetCard key={set.id} set={set} timezone={timezone} />
-                ))}
-              </div>
-            )}
-          </div>
+        {/* Desktop: Show sets side by side when space allows */}
+        <div className="hidden md:block">
+          {timeSlot.sets.length === 1 ? (
+            <MobileSetCard
+              key={timeSlot.sets[0].id}
+              set={timeSlot.sets[0]}
+              timezone={timezone}
+            />
+          ) : (
+            <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+              {timeSlot.sets.map((set) => (
+                <MobileSetCard key={set.id} set={set} timezone={timezone} />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/EditionView/tabs/ScheduleTab/list/TimeSlotGroup.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/TimeSlotGroup.tsx
@@ -1,6 +1,7 @@
 import { Clock } from "lucide-react";
 import { formatTimeOnly } from "@/lib/timeUtils";
 import { MobileSetCard } from "./MobileSetCard";
+import { cn } from "@/lib/utils";
 import type { ScheduleSet } from "@/hooks/useScheduleData";
 
 interface TimeSlot {
@@ -16,7 +17,6 @@ interface TimeSlotGroupProps {
 export function TimeSlotGroup({ timeSlot, timezone }: TimeSlotGroupProps) {
   return (
     <div className="relative">
-      {/* Time indicator */}
       <div className="flex items-center gap-3 mb-3 px-1">
         <div className="flex items-center gap-2 bg-purple-800/50 px-3 py-1.5 rounded-full">
           <Clock className="h-3 w-3 text-purple-300" />
@@ -27,30 +27,15 @@ export function TimeSlotGroup({ timeSlot, timezone }: TimeSlotGroupProps) {
         <div className="flex-1 h-px bg-purple-400/20"></div>
       </div>
 
-      <div className="space-y-3">
-        {/* Mobile: Stack all sets vertically */}
-        <div className="block md:hidden space-y-3">
-          {timeSlot.sets.map((set) => (
-            <MobileSetCard key={set.id} set={set} timezone={timezone} />
-          ))}
-        </div>
-
-        {/* Desktop: Show sets side by side when space allows */}
-        <div className="hidden md:block">
-          {timeSlot.sets.length === 1 ? (
-            <MobileSetCard
-              key={timeSlot.sets[0].id}
-              set={timeSlot.sets[0]}
-              timezone={timezone}
-            />
-          ) : (
-            <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
-              {timeSlot.sets.map((set) => (
-                <MobileSetCard key={set.id} set={set} timezone={timezone} />
-              ))}
-            </div>
-          )}
-        </div>
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-3",
+          timeSlot.sets.length > 1 && "lg:grid-cols-2 xl:grid-cols-3",
+        )}
+      >
+        {timeSlot.sets.map((set) => (
+          <MobileSetCard key={set.id} set={set} timezone={timezone} />
+        ))}
       </div>
     </div>
   );

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/schedule/list.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/schedule/list.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
-import { ScheduleTabList } from "@/pages/EditionView/tabs/ScheduleTab/list/ListTab";
+import { ListSchedule } from "@/pages/EditionView/tabs/ScheduleTab/list/ListSchedule";
 import {
   timelineSearchDefaults,
   timelineSearchSchema,
@@ -8,7 +8,7 @@ import {
 export const Route = createFileRoute(
   "/festivals/$festivalSlug/editions/$editionSlug/schedule/list",
 )({
-  component: ScheduleTabList,
+  component: ListSchedule,
   validateSearch: timelineSearchSchema,
   search: {
     middlewares: [stripSearchParams(timelineSearchDefaults)],

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -7,10 +7,7 @@ const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 const MAIN_STAGE_ID = "11111111-1111-1111-1111-11111111111a";
 
 async function openSheet(page: import("@playwright/test").Page) {
-  // The List view renders one trigger per festival day header; the
-  // Timeline view renders exactly one in its toolbar. Either way the first
-  // match opens the same shared sheet.
-  await page.getByTestId("schedule-filters-trigger").first().click();
+  await page.getByRole("button", { name: /Filters/ }).first().click();
   await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
 }
 
@@ -46,13 +43,10 @@ test.describe("Schedule filter sheet", () => {
   }) => {
     await page.goto(LIST_PATH);
 
-    const listSchedule = page.getByTestId("list-schedule");
-    if (!(await listSchedule.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
-
     const dayGroup = page.getByRole("region").first();
-    await expect(dayGroup.getByTestId("schedule-filters-trigger")).toBeVisible();
+    await expect(
+      dayGroup.getByRole("button", { name: /Filters/ }),
+    ).toBeVisible();
 
     await openSheet(page);
     await expect(

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -7,7 +7,13 @@ const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 const MAIN_STAGE_ID = "11111111-1111-1111-1111-11111111111a";
 
 async function openSheet(page: import("@playwright/test").Page) {
-  await page.getByRole("button", { name: /Filters/ }).first().click();
+  // The List view renders one region per festival day, each with its own
+  // Filters trigger; the Timeline view has no regions and a single trigger
+  // in its toolbar. Scope to the first day region when present so the click
+  // targets a specific group instead of relying on page-wide DOM order.
+  const regions = page.getByRole("region");
+  const scope = (await regions.count()) > 0 ? regions.first() : page;
+  await scope.getByRole("button", { name: /Filters/ }).click();
   await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
 }
 

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -7,8 +7,9 @@ const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 const MAIN_STAGE_ID = "11111111-1111-1111-1111-11111111111a";
 
 async function openSheet(page: import("@playwright/test").Page) {
-  const firstDayRegion = page.getByRole("region", { name: /Jul 12/ });
-  const scope = (await firstDayRegion.count()) > 0 ? firstDayRegion : page;
+  const scope = page.url().includes(LIST_PATH)
+    ? page.getByRole("region", { name: /Jul 12/ })
+    : page;
   await scope.getByRole("button", { name: /Filters/ }).click();
   await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
 }

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -7,11 +7,6 @@ const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 const MAIN_STAGE_ID = "11111111-1111-1111-1111-11111111111a";
 
 async function openSheet(page: import("@playwright/test").Page) {
-  // The List view renders one region per festival day, named after that
-  // day (e.g. "Friday, Jul 12"), each with its own Filters trigger; the
-  // Timeline view has no regions and a single trigger in its toolbar.
-  // Target the seeded first day by name when present, rather than relying
-  // on page-wide DOM order.
   const firstDayRegion = page.getByRole("region", { name: /Jul 12/ });
   const scope = (await firstDayRegion.count()) > 0 ? firstDayRegion : page;
   await scope.getByRole("button", { name: /Filters/ }).click();

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -6,11 +6,11 @@ const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
 const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 const MAIN_STAGE_ID = "11111111-1111-1111-1111-11111111111a";
 
-async function openSheet(page: import("@playwright/test").Page) {
-  const scope = page.url().includes(LIST_PATH)
-    ? page.getByRole("region", { name: /Jul 12/ })
-    : page;
-  await scope.getByRole("button", { name: /Filters/ }).click();
+async function openSheet(
+  page: import("@playwright/test").Page,
+  trigger: import("@playwright/test").Locator,
+) {
+  await trigger.click();
   await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
 }
 
@@ -47,11 +47,10 @@ test.describe("Schedule filter sheet", () => {
     await page.goto(LIST_PATH);
 
     const dayGroup = page.getByRole("region", { name: /Jul 12/ });
-    await expect(
-      dayGroup.getByRole("button", { name: /Filters/ }),
-    ).toBeVisible();
+    const trigger = dayGroup.getByRole("button", { name: /Filters/ });
+    await expect(trigger).toBeVisible();
 
-    await openSheet(page);
+    await openSheet(page, trigger);
     await expect(
       page.getByTestId("schedule-filter-sheet").getByText("Filter schedule"),
     ).toBeVisible();
@@ -73,7 +72,7 @@ test.describe("Schedule filter sheet", () => {
       (el) => el.scrollLeft,
     );
 
-    await openSheet(page);
+    await openSheet(page, page.getByRole("button", { name: /Filters/ }));
     await page.getByTestId("day-filter-trigger").click();
     await page.getByRole("option", { name: /^Saturday$/ }).click();
     await page.getByTestId("schedule-filter-sheet").getByText("Done").click();
@@ -110,7 +109,7 @@ test.describe("Schedule filter sheet", () => {
 
     await expect(page.getByTestId("schedule-filters-badge")).toHaveText("2");
 
-    await openSheet(page);
+    await openSheet(page, page.getByRole("button", { name: /Filters/ }));
     await page.getByTestId("schedule-filters-clear").click();
 
     await expect(page.getByTestId("schedule-filters-badge")).toHaveCount(0);

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -7,12 +7,13 @@ const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 const MAIN_STAGE_ID = "11111111-1111-1111-1111-11111111111a";
 
 async function openSheet(page: import("@playwright/test").Page) {
-  // The List view renders one region per festival day, each with its own
-  // Filters trigger; the Timeline view has no regions and a single trigger
-  // in its toolbar. Scope to the first day region when present so the click
-  // targets a specific group instead of relying on page-wide DOM order.
-  const regions = page.getByRole("region");
-  const scope = (await regions.count()) > 0 ? regions.first() : page;
+  // The List view renders one region per festival day, named after that
+  // day (e.g. "Friday, Jul 12"), each with its own Filters trigger; the
+  // Timeline view has no regions and a single trigger in its toolbar.
+  // Target the seeded first day by name when present, rather than relying
+  // on page-wide DOM order.
+  const firstDayRegion = page.getByRole("region", { name: /Jul 12/ });
+  const scope = (await firstDayRegion.count()) > 0 ? firstDayRegion : page;
   await scope.getByRole("button", { name: /Filters/ }).click();
   await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
 }
@@ -49,7 +50,7 @@ test.describe("Schedule filter sheet", () => {
   }) => {
     await page.goto(LIST_PATH);
 
-    const dayGroup = page.getByRole("region").first();
+    const dayGroup = page.getByRole("region", { name: /Jul 12/ });
     await expect(
       dayGroup.getByRole("button", { name: /Filters/ }),
     ).toBeVisible();

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -7,7 +7,10 @@ const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 const MAIN_STAGE_ID = "11111111-1111-1111-1111-11111111111a";
 
 async function openSheet(page: import("@playwright/test").Page) {
-  await page.getByTestId("schedule-filters-trigger").click();
+  // The List view renders one trigger per festival day header; the
+  // Timeline view renders exactly one in its toolbar. Either way the first
+  // match opens the same shared sheet.
+  await page.getByTestId("schedule-filters-trigger").first().click();
   await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
 }
 
@@ -38,7 +41,7 @@ test.describe("Schedule filter sheet", () => {
     ).toBeVisible();
   });
 
-  test("opens from the List view's filter row into the same sheet", async ({
+  test("opens from the List view's sticky day header into the same sheet", async ({
     page,
   }) => {
     await page.goto(LIST_PATH);
@@ -47,6 +50,9 @@ test.describe("Schedule filter sheet", () => {
     if (!(await listSchedule.isVisible().catch(() => false))) {
       test.skip(true, "Schedule not revealed in this environment");
     }
+
+    const dayHeader = page.getByTestId("list-day-header").first();
+    await expect(dayHeader.getByTestId("schedule-filters-trigger")).toBeVisible();
 
     await openSheet(page);
     await expect(

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -51,8 +51,8 @@ test.describe("Schedule filter sheet", () => {
       test.skip(true, "Schedule not revealed in this environment");
     }
 
-    const dayHeader = page.getByTestId("list-day-header").first();
-    await expect(dayHeader.getByTestId("schedule-filters-trigger")).toBeVisible();
+    const dayGroup = page.getByRole("region").first();
+    await expect(dayGroup.getByTestId("schedule-filters-trigger")).toBeVisible();
 
     await openSheet(page);
     await expect(

--- a/tests/e2e/schedule-list-day-header.spec.ts
+++ b/tests/e2e/schedule-list-day-header.spec.ts
@@ -10,9 +10,6 @@ test.describe("List view sticky day header", () => {
   }) => {
     await page.goto(LIST_PATH);
 
-    // Each festival day renders as an accessible region, labeled by its day
-    // name, with a heading hosting the sticky header content. Seeded across
-    // three festival days (Jul 12-14), so at least two are always present.
     const dayGroups = page.getByRole("region");
     await expect(dayGroups).toHaveCount(3);
 
@@ -22,10 +19,6 @@ test.describe("List view sticky day header", () => {
       (el) => el.getBoundingClientRect().top,
     );
 
-    // Scroll partway through the first day's section: the header must
-    // remain stuck at the same docked offset the whole way, not just for
-    // the first screen. Sub-pixel rounding can shift getBoundingClientRect
-    // by <1px across scroll events, so allow a small tolerance.
     await page.mouse.wheel(0, 600);
     await expect
       .poll(async () =>
@@ -34,8 +27,6 @@ test.describe("List view sticky day header", () => {
       .toBeCloseTo(topBefore, 0);
     await expect(firstHeading).toHaveText(firstHeadingText);
 
-    // Scroll to the very end of the first day's section: the next day's
-    // header takes over, docked at the same offset.
     const firstGroupBox = await dayGroups.nth(0).boundingBox();
     expect(firstGroupBox).not.toBeNull();
     await page.mouse.wheel(0, (firstGroupBox?.height ?? 0) + 800);

--- a/tests/e2e/schedule-list-day-header.spec.ts
+++ b/tests/e2e/schedule-list-day-header.spec.ts
@@ -29,13 +29,14 @@ test.describe("List view sticky day header", () => {
 
     // Scroll partway through the first day's section: the header must
     // remain stuck at the same docked offset the whole way, not just for
-    // the first screen.
+    // the first screen. Sub-pixel rounding can shift getBoundingClientRect
+    // by <1px across scroll events, so allow a small tolerance.
     await page.mouse.wheel(0, 600);
     await expect
       .poll(async () =>
         firstHeader.evaluate((el) => el.getBoundingClientRect().top),
       )
-      .toBe(topBefore);
+      .toBeCloseTo(topBefore, 0);
     await expect(firstHeader).toHaveText(firstHeaderText);
 
     // Scroll to the very end of the first day's section: the next day's
@@ -52,7 +53,7 @@ test.describe("List view sticky day header", () => {
     const topAfter = await secondHeader.evaluate(
       (el) => el.getBoundingClientRect().top,
     );
-    expect(topAfter).toBe(topBefore);
+    expect(topAfter).toBeCloseTo(topBefore, 0);
   });
 
   test("opens the filter sheet from the sticky day header", async ({

--- a/tests/e2e/schedule-list-day-header.spec.ts
+++ b/tests/e2e/schedule-list-day-header.spec.ts
@@ -15,15 +15,17 @@ test.describe("List view sticky day header", () => {
       test.skip(true, "Schedule not revealed in this environment");
     }
 
-    const dayGroups = page.getByTestId("list-day-group");
+    // Each festival day renders as an accessible region, labeled by its day
+    // name, with a heading hosting the sticky header content.
+    const dayGroups = page.getByRole("region");
     const groupCount = await dayGroups.count();
     if (groupCount < 2) {
       test.skip(true, "Needs at least two festival days of sets seeded");
     }
 
-    const firstHeader = dayGroups.nth(0).getByTestId("list-day-header");
-    const firstHeaderText = await firstHeader.innerText();
-    const topBefore = await firstHeader.evaluate(
+    const firstHeading = dayGroups.nth(0).getByRole("heading", { level: 2 });
+    const firstHeadingText = await firstHeading.innerText();
+    const topBefore = await firstHeading.evaluate(
       (el) => el.getBoundingClientRect().top,
     );
 
@@ -34,10 +36,10 @@ test.describe("List view sticky day header", () => {
     await page.mouse.wheel(0, 600);
     await expect
       .poll(async () =>
-        firstHeader.evaluate((el) => el.getBoundingClientRect().top),
+        firstHeading.evaluate((el) => el.getBoundingClientRect().top),
       )
       .toBeCloseTo(topBefore, 0);
-    await expect(firstHeader).toHaveText(firstHeaderText);
+    await expect(firstHeading).toHaveText(firstHeadingText);
 
     // Scroll to the very end of the first day's section: the next day's
     // header takes over, docked at the same offset.
@@ -45,12 +47,12 @@ test.describe("List view sticky day header", () => {
     expect(firstGroupBox).not.toBeNull();
     await page.mouse.wheel(0, (firstGroupBox?.height ?? 0) + 800);
 
-    const secondHeader = dayGroups.nth(1).getByTestId("list-day-header");
-    await expect(secondHeader).toBeVisible();
-    const secondHeaderText = await secondHeader.innerText();
-    expect(secondHeaderText).not.toBe(firstHeaderText);
+    const secondHeading = dayGroups.nth(1).getByRole("heading", { level: 2 });
+    await expect(secondHeading).toBeVisible();
+    const secondHeadingText = await secondHeading.innerText();
+    expect(secondHeadingText).not.toBe(firstHeadingText);
 
-    const topAfter = await secondHeader.evaluate(
+    const topAfter = await secondHeading.evaluate(
       (el) => el.getBoundingClientRect().top,
     );
     expect(topAfter).toBeCloseTo(topBefore, 0);
@@ -66,8 +68,8 @@ test.describe("List view sticky day header", () => {
       test.skip(true, "Schedule not revealed in this environment");
     }
 
-    const dayHeader = page.getByTestId("list-day-header").first();
-    const trigger = dayHeader.getByTestId("schedule-filters-trigger");
+    const dayGroup = page.getByRole("region").first();
+    const trigger = dayGroup.getByTestId("schedule-filters-trigger");
     await expect(trigger).toBeVisible();
     await expect(trigger).toHaveAccessibleName(/Filters/);
 

--- a/tests/e2e/schedule-list-day-header.spec.ts
+++ b/tests/e2e/schedule-list-day-header.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+// Seeded in supabase/seed.sql: festival slug "test", edition slug "2025",
+// three festival days (Jul 12-14, 2025), stages "Main Stage" and "Club Stage".
+const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
+
+test.describe("List view sticky day header", () => {
+  test("stays stuck across a full day's sets and hands over to the next day", async ({
+    page,
+  }) => {
+    await page.goto(LIST_PATH);
+
+    const listSchedule = page.getByTestId("list-schedule");
+    if (!(await listSchedule.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    const dayGroups = page.getByTestId("list-day-group");
+    const groupCount = await dayGroups.count();
+    if (groupCount < 2) {
+      test.skip(true, "Needs at least two festival days of sets seeded");
+    }
+
+    const firstHeader = dayGroups.nth(0).getByTestId("list-day-header");
+    const firstHeaderText = await firstHeader.innerText();
+    const topBefore = await firstHeader.evaluate(
+      (el) => el.getBoundingClientRect().top,
+    );
+
+    // Scroll partway through the first day's section: the header must
+    // remain stuck at the same docked offset the whole way, not just for
+    // the first screen.
+    await page.mouse.wheel(0, 600);
+    await expect
+      .poll(async () =>
+        firstHeader.evaluate((el) => el.getBoundingClientRect().top),
+      )
+      .toBe(topBefore);
+    await expect(firstHeader).toHaveText(firstHeaderText);
+
+    // Scroll to the very end of the first day's section: the next day's
+    // header takes over, docked at the same offset.
+    const firstGroupBox = await dayGroups.nth(0).boundingBox();
+    expect(firstGroupBox).not.toBeNull();
+    await page.mouse.wheel(0, (firstGroupBox?.height ?? 0) + 800);
+
+    const secondHeader = dayGroups.nth(1).getByTestId("list-day-header");
+    await expect(secondHeader).toBeVisible();
+    const secondHeaderText = await secondHeader.innerText();
+    expect(secondHeaderText).not.toBe(firstHeaderText);
+
+    const topAfter = await secondHeader.evaluate(
+      (el) => el.getBoundingClientRect().top,
+    );
+    expect(topAfter).toBe(topBefore);
+  });
+
+  test("opens the filter sheet from the sticky day header", async ({
+    page,
+  }) => {
+    await page.goto(LIST_PATH);
+
+    const listSchedule = page.getByTestId("list-schedule");
+    if (!(await listSchedule.isVisible().catch(() => false))) {
+      test.skip(true, "Schedule not revealed in this environment");
+    }
+
+    const dayHeader = page.getByTestId("list-day-header").first();
+    const trigger = dayHeader.getByTestId("schedule-filters-trigger");
+    await expect(trigger).toBeVisible();
+    await expect(trigger).toHaveAccessibleName(/Filters/);
+
+    await trigger.click();
+    await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
+  });
+});

--- a/tests/e2e/schedule-list-day-header.spec.ts
+++ b/tests/e2e/schedule-list-day-header.spec.ts
@@ -56,7 +56,7 @@ test.describe("List view sticky day header", () => {
   }) => {
     await page.goto(LIST_PATH);
 
-    const dayGroup = page.getByRole("region").first();
+    const dayGroup = page.getByRole("region", { name: /Jul 12/ });
     const trigger = dayGroup.getByRole("button", { name: /Filters/ });
     await expect(trigger).toBeVisible();
 

--- a/tests/e2e/schedule-list-day-header.spec.ts
+++ b/tests/e2e/schedule-list-day-header.spec.ts
@@ -10,18 +10,11 @@ test.describe("List view sticky day header", () => {
   }) => {
     await page.goto(LIST_PATH);
 
-    const listSchedule = page.getByTestId("list-schedule");
-    if (!(await listSchedule.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
-
     // Each festival day renders as an accessible region, labeled by its day
-    // name, with a heading hosting the sticky header content.
+    // name, with a heading hosting the sticky header content. Seeded across
+    // three festival days (Jul 12-14), so at least two are always present.
     const dayGroups = page.getByRole("region");
-    const groupCount = await dayGroups.count();
-    if (groupCount < 2) {
-      test.skip(true, "Needs at least two festival days of sets seeded");
-    }
+    await expect(dayGroups).toHaveCount(3);
 
     const firstHeading = dayGroups.nth(0).getByRole("heading", { level: 2 });
     const firstHeadingText = await firstHeading.innerText();
@@ -63,15 +56,9 @@ test.describe("List view sticky day header", () => {
   }) => {
     await page.goto(LIST_PATH);
 
-    const listSchedule = page.getByTestId("list-schedule");
-    if (!(await listSchedule.isVisible().catch(() => false))) {
-      test.skip(true, "Schedule not revealed in this environment");
-    }
-
     const dayGroup = page.getByRole("region").first();
-    const trigger = dayGroup.getByTestId("schedule-filters-trigger");
+    const trigger = dayGroup.getByRole("button", { name: /Filters/ });
     await expect(trigger).toBeVisible();
-    await expect(trigger).toHaveAccessibleName(/Filters/);
 
     await trigger.click();
     await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();


### PR DESCRIPTION
Groups the List view's sets into per-day sections (day boundary computed in the festival timezone) so the day header sticks for the whole day instead of unsticking after one screen; the standalone filters row is removed and the Filters trigger now lives in the sticky day header.

Closes #235

## Verification
- Open the List view for an edition spanning multiple festival days; scroll through a full day and confirm the day header stays docked below the top bar the whole time, handing over to the next day's header at the boundary.
- Confirm the standalone "Filters" row is gone and the Filters trigger (with badge/count) opens the same filter sheet from the sticky day header.
- Apply/clear day, time, stage, and vote filters from the sheet and confirm behavior is unchanged from before.
- `pnpm run typecheck`, `pnpm run lint`, and `pnpm test` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4xgXYPJMoUYDAb6UUn4wj)_