### PR TITLE
fix(schedule): drop dead loading/error fields from useScheduleData

### DIFF
--- a/src/hooks/useScheduleData.ts
+++ b/src/hooks/useScheduleData.ts
@@ -57,9 +57,6 @@ export function useScheduleData({
   use24Hour = false,
   timezone,
 }: UseScheduleDataOptions) {
-  const loading = false;
-  const error = null;
-
   const scheduleDays = useMemo(() => {
     if (!sets || !stages || !Array.isArray(sets) || sets.length === 0) {
       return [];
@@ -76,26 +73,32 @@ export function useScheduleData({
       });
 
     // Parse and enhance set data
-    const enhancedSets: EnhancedSet[] = performingSets.map(({ set, dayKey }) => {
-      const startTime = set.time_start ? new Date(set.time_start) : undefined;
-      const endTime = set.time_end ? new Date(set.time_end) : undefined;
+    const enhancedSets: EnhancedSet[] = performingSets.map(
+      ({ set, dayKey }) => {
+        const startTime = set.time_start ? new Date(set.time_start) : undefined;
+        const endTime = set.time_end ? new Date(set.time_end) : undefined;
 
-      return {
-        id: set.id,
-        name: set.name,
-        slug: set.slug,
-        stageId: set.stage_id || "",
-        startTime,
-        endTime,
-        votes: set.votes || [],
-        formattedTimeRange: formatDateTime(set.time_start, use24Hour, timezone),
-        dayKey,
-        artists: (set.artists || []).map((artist) => ({
-          id: artist.id,
-          name: artist.name,
-        })),
-      };
-    });
+        return {
+          id: set.id,
+          name: set.name,
+          slug: set.slug,
+          stageId: set.stage_id || "",
+          startTime,
+          endTime,
+          votes: set.votes || [],
+          formattedTimeRange: formatDateTime(
+            set.time_start,
+            use24Hour,
+            timezone,
+          ),
+          dayKey,
+          artists: (set.artists || []).map((artist) => ({
+            id: artist.id,
+            name: artist.name,
+          })),
+        };
+      },
+    );
 
     // Group sets by festival calendar day
     const dayGroups = enhancedSets.reduce(
@@ -175,7 +178,5 @@ export function useScheduleData({
   return {
     scheduleDays,
     allStages,
-    loading,
-    error,
   };
 }

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -31,7 +31,7 @@ export function Timeline() {
   const { user } = useAuth();
   const { data: userVotes } = useUserVotes(user?.id);
 
-  const { scheduleDays, loading, error } = useScheduleData({
+  const { scheduleDays } = useScheduleData({
     sets: editionSets,
     stages,
     timezone: festival.timezone,
@@ -83,18 +83,10 @@ export function Timeline() {
     festival.timezone,
   ]);
 
-  if (loading || setsLoading) {
+  if (setsLoading) {
     return (
       <div className="text-center text-purple-300 py-12">
         <p>Loading horizontal timeline...</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="text-center text-purple-300 py-12">
-        <p>Error loading schedule.</p>
       </div>
     );
   }

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
@@ -37,7 +37,7 @@ export function ListSchedule() {
   const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
   const { user } = useAuth();
   const { data: userVotes } = useUserVotes(user?.id);
-  const { scheduleDays, loading, error } = useScheduleData({
+  const { scheduleDays } = useScheduleData({
     sets: editionSets,
     stages,
     timezone: festival.timezone,
@@ -139,18 +139,10 @@ export function ListSchedule() {
     festival.timezone,
   ]);
 
-  if (loading || setsLoading) {
+  if (setsLoading) {
     return (
       <div className="text-center text-purple-300 py-12">
         <p>Loading schedule...</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="text-center text-purple-300 py-12">
-        <p>Error loading schedule.</p>
       </div>
     );
   }


### PR DESCRIPTION
Removes the hardcoded `loading`/`error` fields from `useScheduleData` (never varied) and the dead branches that checked them in `Timeline` and `ListSchedule`. Real loading state still comes from `setsLoading`.

Fixes #169

## Verification
- Open the timeline schedule view; sets/stages render as before, no visual change on the happy path.
- Open the list schedule view; sets/stages render as before, no visual change on the happy path.
- Confirm neither view references `loading`/`error` from `useScheduleData` anymore (typecheck passes).

---
_Generated by [Claude Code](https://claude.ai/code/session_016zPmjZr8QrriCzLUgdGUt9)_