### PR TITLE
refactor(voting): rename useUserVotes/useVote hooks

### DIFF
--- a/src/api/voting/useUserVotesQuery.ts
+++ b/src/api/voting/useUserVotesQuery.ts
@@ -30,7 +30,7 @@ export function userVotesQuery(userId: string) {
   });
 }
 
-export function useUserVotes(userId: string | undefined) {
+export function useUserVotesQuery(userId: string | undefined) {
   return useQuery({
     ...userVotesQuery(userId!),
     enabled: !!userId,

--- a/src/api/voting/useVoteMutation.ts
+++ b/src/api/voting/useVoteMutation.ts
@@ -49,7 +49,7 @@ async function vote(variables: {
 }
 
 // Hook
-export function useVote() {
+export function useVoteMutation() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 

--- a/src/api/voting/useVoteMutation.ts
+++ b/src/api/voting/useVoteMutation.ts
@@ -48,7 +48,6 @@ async function vote(variables: {
   }
 }
 
-// Hook
 export function useVoteMutation() {
   const queryClient = useQueryClient();
   const { toast } = useToast();

--- a/src/pages/EditionView/tabs/ArtistsTab/SetCard/SetVotingButtons.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/SetCard/SetVotingButtons.tsx
@@ -1,12 +1,8 @@
 import { Button } from "@/components/ui/button";
-import {
-  VOTE_CONFIG,
-  VOTES_TYPES,
-  type VoteConfig,
-} from "@/lib/voteConfig";
+import { VOTE_CONFIG, VOTES_TYPES, type VoteConfig } from "@/lib/voteConfig";
 import { useFestivalSet } from "../FestivalSetContext";
-import { useUserVotes } from "@/api/voting/useUserVotes";
-import { useVote } from "@/api/voting/useVote";
+import { useUserVotesQuery } from "@/api/voting/useUserVotesQuery";
+import { useVoteMutation } from "@/api/voting/useVoteMutation";
 import { useAuth } from "@/contexts/AuthContext";
 import { useVoteCount } from "@/hooks/useVoteCount";
 
@@ -23,8 +19,8 @@ export function SetVotingButtons({
 
   const { set, onLockSort } = useFestivalSet();
   const { getVoteCount } = useVoteCount(set);
-  const userVotesQuery = useUserVotes(user?.id);
-  const voteMutation = useVote();
+  const userVotesQuery = useUserVotesQuery(user?.id);
+  const voteMutation = useVoteMutation();
 
   const userVoteForSet = userVotesQuery.data?.[set.id];
 

--- a/src/pages/EditionView/tabs/ScheduleTab/VoteButtons.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/VoteButtons.tsx
@@ -9,8 +9,8 @@ import { cn } from "@/lib/utils";
 import type { ScheduleSet } from "@/hooks/useScheduleData";
 import { useMemo } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUserVotes } from "@/api/voting/useUserVotes";
-import { useVote } from "@/api/voting/useVote";
+import { useUserVotesQuery } from "@/api/voting/useUserVotesQuery";
+import { useVoteMutation } from "@/api/voting/useVoteMutation";
 
 interface VoteButtonsProps {
   set: ScheduleSet;
@@ -18,8 +18,8 @@ interface VoteButtonsProps {
 
 export function VoteButtons({ set }: VoteButtonsProps) {
   const { user, showAuthDialog } = useAuth();
-  const userVotesQuery = useUserVotes(user?.id);
-  const voteMutation = useVote();
+  const userVotesQuery = useUserVotesQuery(user?.id);
+  const voteMutation = useVoteMutation();
 
   const userVote = userVotesQuery.data?.[set.id];
   const userVoteType = useMemo(() => {

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/Timeline.tsx
@@ -16,7 +16,7 @@ import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNotRevealedPlaceholder } from "../ScheduleNotRevealedPlaceholder";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUserVotes } from "@/api/voting/useUserVotes";
+import { useUserVotesQuery } from "@/api/voting/useUserVotesQuery";
 
 export function Timeline() {
   const { festival } = useFestivalEdition();
@@ -29,7 +29,7 @@ export function Timeline() {
     useEditionSetsQuery(edition.id);
   const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
   const { user } = useAuth();
-  const { data: userVotes } = useUserVotes(user?.id);
+  const { data: userVotes } = useUserVotesQuery(user?.id);
 
   const { scheduleDays } = useScheduleData({
     sets: editionSets,

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineOverview.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimelineOverview.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import type { RefObject } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUserVotes } from "@/api/voting/useUserVotes";
+import { useUserVotesQuery } from "@/api/voting/useUserVotesQuery";
 import { offsetToTime } from "@/lib/timelineCalculator";
 import type { TimelineData } from "@/lib/timelineCalculator";
 import type { ScheduleDay } from "@/hooks/useScheduleData";
@@ -45,7 +45,7 @@ export function TimelineOverview({
 }: TimelineOverviewProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const { user } = useAuth();
-  const { data: userVotes } = useUserVotes(user?.id);
+  const { data: userVotes } = useUserVotesQuery(user?.id);
 
   const viewportSize = useTimelineViewportSize(scrollContainerRef);
 
@@ -126,7 +126,10 @@ export function TimelineOverview({
     if (rect.width <= 0) return;
 
     const fraction = (event.clientX - rect.left) / rect.width;
-    const offset = fractionToOffset({ fraction, totalWidth: timelineData.totalWidth });
+    const offset = fractionToOffset({
+      fraction,
+      totalWidth: timelineData.totalWidth,
+    });
     onJump(offsetToTime(offset, timelineData.festivalStart));
   }
 }

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListSchedule.tsx
@@ -14,7 +14,7 @@ import { stagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 import { ScheduleNotRevealedPlaceholder } from "../ScheduleNotRevealedPlaceholder";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUserVotes } from "@/api/voting/useUserVotes";
+import { useUserVotesQuery } from "@/api/voting/useUserVotesQuery";
 
 interface TimeSlot {
   time: Date;
@@ -36,7 +36,7 @@ export function ListSchedule() {
     useEditionSetsQuery(edition.id);
   const { data: stages } = useSuspenseQuery(stagesByEditionQuery(edition.id));
   const { user } = useAuth();
-  const { data: userVotes } = useUserVotes(user?.id);
+  const { data: userVotes } = useUserVotesQuery(user?.id);
   const { scheduleDays } = useScheduleData({
     sets: editionSets,
     stages,

--- a/src/pages/ExploreSetPage/ExploreSetPage.tsx
+++ b/src/pages/ExploreSetPage/ExploreSetPage.tsx
@@ -6,8 +6,8 @@ import { ExplorePageHeader } from "./components/ExplorePageHeader";
 import { CardStackContainer } from "./components/CardStackContainer";
 import { VotingSection } from "./components/VotingSection";
 import { useAuth } from "@/contexts/AuthContext";
-import { useVote } from "@/api/voting/useVote";
-import { useUserVotes } from "@/api/voting/useUserVotes";
+import { useVoteMutation } from "@/api/voting/useVoteMutation";
+import { useUserVotesQuery } from "@/api/voting/useUserVotesQuery";
 import { useState } from "react";
 import { useExplorableSets } from "./useExplorableSets";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
@@ -16,8 +16,8 @@ export function ExploreSetPage() {
   const { edition } = useFestivalEdition();
   const navigate = useNavigate();
   const { user, showAuthDialog } = useAuth();
-  const voteMutation = useVote();
-  const { data: userVotes = {} } = useUserVotes(user?.id || "");
+  const voteMutation = useVoteMutation();
+  const { data: userVotes = {} } = useUserVotesQuery(user?.id || "");
 
   const explorableSetsQuery = useExplorableSets({
     editionId: edition?.id,

--- a/src/pages/SetDetails/SetVotingButtons.tsx
+++ b/src/pages/SetDetails/SetVotingButtons.tsx
@@ -1,8 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { FestivalSet } from "@/api/sets/types";
-import { useUserVotes } from "@/api/voting/useUserVotes";
-import { useVote } from "@/api/voting/useVote";
+import { useUserVotesQuery } from "@/api/voting/useUserVotesQuery";
+import { useVoteMutation } from "@/api/voting/useVoteMutation";
 import { useVoteCount } from "@/hooks/useVoteCount";
 import { VOTE_CONFIG, getVoteConfig } from "@/lib/voteConfig";
 
@@ -13,8 +13,8 @@ interface SetVotingButtonsProps {
 export function SetVotingButtons({ set }: SetVotingButtonsProps) {
   const { user, showAuthDialog } = useAuth();
   const { getVoteCount } = useVoteCount(set);
-  const userVotesQuery = useUserVotes(user?.id);
-  const voteMutation = useVote();
+  const userVotesQuery = useUserVotesQuery(user?.id);
+  const voteMutation = useVoteMutation();
 
   const setId = set.id;
   const userVoteForSet = userVotesQuery.data?.[setId];


### PR DESCRIPTION
Renames `useUserVotes` -> `useUserVotesQuery` and `useVote` -> `useVoteMutation` (files and all call sites) to follow the repo's Query/Mutation hook naming convention.
No behavior change.

Fixes #158

## Verification
- Vote on a set from the schedule tab; vote registers and persists after reload.
- Vote from Explore Set page and Set Details page; vote registers.
- `pnpm test` and `pnpm run lint` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zPmjZr8QrriCzLUgdGUt9)_