### PR TITLE
feat(festival-info): let admins set link type, widen Info tab

### DIFF
--- a/src/api/custom-links/types.ts
+++ b/src/api/custom-links/types.ts
@@ -1,6 +1,11 @@
-import type { Tables } from "@/integrations/supabase/types";
+import type { Enums, Tables } from "@/integrations/supabase/types";
 
 export type CustomLink = Tables<"custom_links">;
+export type LinkType = Enums<"link_type">;
+
+export function hasLinkOfType(links: CustomLink[], types: LinkType[]): boolean {
+  return links.some((link) => types.includes(link.link_type));
+}
 
 export const customLinksKeys = {
   all: ["customLinks"] as const,

--- a/src/api/custom-links/useCustomLinksMutation.ts
+++ b/src/api/custom-links/useCustomLinksMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
-import { customLinksKeys } from "./types";
+import { customLinksKeys, LinkType } from "./types";
 
 interface BulkUpdateCustomLinksData {
   festivalId: string;
@@ -10,6 +10,7 @@ interface BulkUpdateCustomLinksData {
     title: string;
     url: string;
     display_order: number;
+    link_type: LinkType;
   }>;
 }
 
@@ -48,6 +49,7 @@ async function bulkUpdateCustomLinks({
       title: link.title,
       url: link.url,
       display_order: index,
+      link_type: link.link_type,
     };
 
     if (link.id) {

--- a/src/pages/EditionView/TabNavigation/TabNavigation.tsx
+++ b/src/pages/EditionView/TabNavigation/TabNavigation.tsx
@@ -1,6 +1,7 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { festivalInfoQuery } from "@/api/festival-info/useFestivalInfo";
+import { customLinksQuery } from "@/api/custom-links/useCustomLinks";
 import { useFestivalPhase } from "@/hooks/useFestivalPhase";
 import { DesktopTabButton } from "./DesktopTabButton";
 import { MobileTabButton } from "./MobileTabButton";
@@ -20,6 +21,7 @@ export function MainTabNavigation() {
   const { data: festivalInfo } = useSuspenseQuery(
     festivalInfoQuery(festival.id),
   );
+  const { data: customLinks } = useSuspenseQuery(customLinksQuery(festival.id));
   const { phase } = useFestivalPhase();
   const hideBottomBar = useHideOnScrollDown();
 
@@ -28,7 +30,7 @@ export function MainTabNavigation() {
       if (typeof config.enabled === "boolean") {
         return config.enabled;
       }
-      return config.enabled(festivalInfo);
+      return config.enabled({ festivalInfo, customLinks });
     })
     .map((config) => {
       if (config.key !== "sets") return config;

--- a/src/pages/EditionView/TabNavigation/config.ts
+++ b/src/pages/EditionView/TabNavigation/config.ts
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { TabConfig } from "./types";
 import { ScheduleTabIndicator } from "./ScheduleTabIndicator";
+import { infoTabEnabled } from "./infoTabEnabled";
 
 export const config: TabConfig[] = [
   {
@@ -37,21 +38,21 @@ export const config: TabConfig[] = [
     icon: MapIcon,
     label: "Map",
     shortLabel: "Map",
-    enabled: (festivalInfo) => !!festivalInfo?.map_image_url,
+    enabled: ({ festivalInfo }) => !!festivalInfo?.map_image_url,
   },
   {
     key: "info",
     icon: InfoIcon,
     label: "Info",
     shortLabel: "Info",
-    enabled: (festivalInfo) => !!festivalInfo?.info_text,
+    enabled: infoTabEnabled,
   },
   {
     key: "social",
     icon: MessageSquareIcon,
     label: "Social",
     shortLabel: "Social",
-    enabled: (festivalInfo) =>
+    enabled: ({ festivalInfo }) =>
       !!(festivalInfo?.facebook_url || festivalInfo?.instagram_url),
   },
 ];

--- a/src/pages/EditionView/TabNavigation/infoTabEnabled.test.ts
+++ b/src/pages/EditionView/TabNavigation/infoTabEnabled.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { infoTabEnabled } from "./infoTabEnabled";
+import { CustomLink } from "@/api/custom-links/types";
+
+function makeLink(overrides: Partial<CustomLink> = {}): CustomLink {
+  return {
+    id: "1",
+    festival_id: "f1",
+    title: "Link",
+    url: "https://example.com",
+    display_order: 0,
+    link_type: "custom",
+    created_at: null,
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+describe("infoTabEnabled", () => {
+  it("is enabled when info_text is present", () => {
+    expect(
+      infoTabEnabled({ festivalInfo: { info_text: "hello" } as never }),
+    ).toBe(true);
+  });
+
+  it("is enabled when a tickets link exists", () => {
+    expect(
+      infoTabEnabled({
+        customLinks: [makeLink({ link_type: "tickets" })],
+      }),
+    ).toBe(true);
+  });
+
+  it("is enabled when a website link exists", () => {
+    expect(
+      infoTabEnabled({
+        customLinks: [makeLink({ link_type: "website" })],
+      }),
+    ).toBe(true);
+  });
+
+  it("is disabled for a custom link that is not tickets or website", () => {
+    expect(
+      infoTabEnabled({
+        customLinks: [makeLink({ link_type: "custom" })],
+      }),
+    ).toBe(false);
+  });
+
+  it("is disabled when there is no info text, no social links, and no custom links", () => {
+    expect(infoTabEnabled({})).toBe(false);
+  });
+});

--- a/src/pages/EditionView/TabNavigation/infoTabEnabled.ts
+++ b/src/pages/EditionView/TabNavigation/infoTabEnabled.ts
@@ -1,0 +1,12 @@
+import { hasLinkOfType } from "@/api/custom-links/types";
+import { TabEnablementContext } from "./types";
+
+export function infoTabEnabled({
+  festivalInfo,
+  customLinks = [],
+}: TabEnablementContext): boolean {
+  return (
+    !!festivalInfo?.info_text ||
+    hasLinkOfType(customLinks, ["tickets", "website"])
+  );
+}

--- a/src/pages/EditionView/TabNavigation/types.ts
+++ b/src/pages/EditionView/TabNavigation/types.ts
@@ -1,4 +1,5 @@
 import { FestivalInfo } from "@/api/festival-info/types";
+import { CustomLink } from "@/api/custom-links/types";
 import { LucideIcon } from "lucide-react";
 import { ComponentType } from "react";
 
@@ -10,12 +11,17 @@ export type MainTab =
   | "social"
   | "explore";
 
+export interface TabEnablementContext {
+  festivalInfo?: FestivalInfo | null;
+  customLinks?: CustomLink[];
+}
+
 export type TabConfig = {
   key: MainTab;
   icon: LucideIcon;
   label: string;
   shortLabel: string;
-  enabled: boolean | ((festivalInfo?: FestivalInfo | null) => boolean);
+  enabled: boolean | ((context: TabEnablementContext) => boolean);
   Indicator?: ComponentType;
 };
 

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalLinksField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalLinksField.tsx
@@ -1,16 +1,29 @@
-import { useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { ExternalLink, Plus, Trash2 } from "lucide-react";
 import { EditableField } from "./shared/EditableField";
 import { EditContainer } from "./shared/EditContainer";
-import { CustomLink } from "@/api/custom-links/types";
+import { CustomLink, LinkType } from "@/api/custom-links/types";
 import { useBulkUpdateCustomLinksMutation } from "@/api/custom-links/useCustomLinksMutation";
 
 interface FestivalLinksFieldProps {
   festivalId: string;
   customLinks: CustomLink[];
 }
+
+const LINK_TYPE_LABELS: Record<LinkType, string> = {
+  website: "Website",
+  tickets: "Tickets",
+  custom: "Custom",
+};
 
 export function FestivalLinksField({
   festivalId,
@@ -50,7 +63,11 @@ interface EditingLink {
   id?: string;
   title: string;
   url: string;
-  display_order?: number;
+  link_type: LinkType;
+}
+
+interface LinksFormData {
+  links: EditingLink[];
 }
 
 function LinksFieldForm({
@@ -64,90 +81,74 @@ function LinksFieldForm({
   onCancel: () => void;
   onSave: () => void;
 }) {
-  const [editingLinks, setEditingLinks] = useState<EditingLink[]>([]);
   const mutation = useBulkUpdateCustomLinksMutation();
 
-  function handleEdit() {
-    setEditingLinks(
-      customLinks.length > 0
-        ? customLinks.map((link) => ({
-            id: link.id,
-            title: link.title,
-            url: link.url,
-            display_order: link.display_order || undefined,
-          }))
-        : [{ title: "", url: "", display_order: 0 }],
-    );
-  }
+  const form = useForm<LinksFormData>({
+    defaultValues: {
+      links:
+        customLinks.length > 0
+          ? customLinks.map((link) => ({
+              id: link.id,
+              title: link.title,
+              url: link.url,
+              link_type: link.link_type,
+            }))
+          : [{ title: "", url: "", link_type: "custom" }],
+    },
+  });
 
-  function addCustomLink() {
-    setEditingLinks([
-      ...editingLinks,
-      { title: "", url: "", display_order: editingLinks.length },
-    ]);
-  }
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "links",
+  });
 
-  function removeCustomLink(index: number) {
-    setEditingLinks(editingLinks.filter((_, i) => i !== index));
-  }
-
-  function updateCustomLink(
-    index: number,
-    field: "title" | "url",
-    value: string,
-  ) {
-    const updatedLinks = [...editingLinks];
-    updatedLinks[index] = { ...updatedLinks[index], [field]: value };
-    setEditingLinks(updatedLinks);
-  }
-
-  function handleSave() {
-    const validLinks = editingLinks
-      .filter((link) => link.title.trim() && link.url.trim())
-      .map((link, index) => ({
-        ...link,
-        display_order: index,
-      }));
-
-    mutation.mutate({ festivalId, links: validLinks }, { onSuccess: onSave });
-  }
-
-  if (editingLinks.length === 0) {
-    handleEdit();
-  }
+  const handleSubmit = form.handleSubmit(handleSave);
 
   return (
     <EditContainer
-      onSave={handleSave}
+      onSave={handleSubmit}
       onCancel={onCancel}
       isLoading={mutation.isPending}
       helpText="Only links with both title and URL filled will be saved"
     >
       <div className="space-y-4">
-        {editingLinks.map((link, index) => (
+        {fields.map((field, index) => (
           <div
-            key={link.id || `new-${index}`}
+            key={field.id}
             className="flex items-center gap-2 p-3 border rounded-lg bg-background"
           >
-            <div className="grid grid-cols-2 gap-2 flex-1">
+            <div className="grid grid-cols-3 gap-2 flex-1">
               <Input
                 placeholder="Link title (e.g., Tickets)"
-                value={link.title}
-                onChange={(e) =>
-                  updateCustomLink(index, "title", e.target.value)
-                }
+                {...form.register(`links.${index}.title`)}
               />
               <Input
                 placeholder="URL (e.g., https://...)"
-                value={link.url}
-                onChange={(e) => updateCustomLink(index, "url", e.target.value)}
+                {...form.register(`links.${index}.url`)}
               />
+              <Select
+                value={form.watch(`links.${index}.link_type`)}
+                onValueChange={(value: LinkType) =>
+                  form.setValue(`links.${index}.link_type`, value)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(LINK_TYPE_LABELS).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <Button
-              onClick={() => removeCustomLink(index)}
+              onClick={() => remove(index)}
               variant="outline"
               size="sm"
-              disabled={editingLinks.length === 1}
+              disabled={fields.length === 1}
             >
               <Trash2 className="h-4 w-4" />
             </Button>
@@ -156,11 +157,26 @@ function LinksFieldForm({
       </div>
 
       <div className="flex items-center justify-between">
-        <Button onClick={addCustomLink} variant="outline" size="sm">
+        <Button
+          onClick={() => append({ title: "", url: "", link_type: "custom" })}
+          variant="outline"
+          size="sm"
+        >
           <Plus className="h-4 w-4 mr-2" />
           Add Link
         </Button>
       </div>
     </EditContainer>
   );
+
+  function handleSave(data: LinksFormData) {
+    const validLinks = data.links
+      .filter((link) => link.title.trim() && link.url.trim())
+      .map((link, index) => ({
+        ...link,
+        display_order: index,
+      }));
+
+    mutation.mutate({ festivalId, links: validLinks }, { onSuccess: onSave });
+  }
 }


### PR DESCRIPTION
Adds a link-type select (website/tickets/custom) to the admin custom links form, and the Info tab now also shows whenever a tickets/website link exists (not just when info text is set).

## Verification
- In admin, edit a festival's custom links, set one to "Tickets", save, reload — type persists.
- View a festival edition with no info text but a tickets/website custom link — Info tab appears and shows the link in the generic Links list.
- View a festival edition with no info text, no social links, and no custom links — Info tab stays hidden.
- View a festival edition with only a "custom"-typed link and no info text — Info tab stays hidden.

Closes #228

---
_Generated by [Claude Code](https://claude.ai/code/session_016zPmjZr8QrriCzLUgdGUt9)_