### PR TITLE
refactor(timeline): split TimeScale geometry from rendering

### DIFF
--- a/src/lib/timelineCalculator.test.ts
+++ b/src/lib/timelineCalculator.test.ts
@@ -3,12 +3,11 @@ import {
   calculateScheduleWindow,
   calculateTimelineData,
   offsetToTime,
+  PX_PER_MINUTE,
   timeToOffset,
 } from "./timelineCalculator";
 import type { ScheduleDay, ScheduleSet } from "@/hooks/useScheduleData";
 import { makeScheduleDay, makeStage } from "@/__tests__/fixtures";
-
-const PX_PER_MINUTE = 2;
 
 describe("timeToOffset", () => {
   it("returns 0 when moment equals origin", () => {
@@ -45,9 +44,7 @@ describe("offsetToTime", () => {
     const origin = new Date("2024-07-01T10:00:00Z");
     const offset = 60 * PX_PER_MINUTE; // 60 minutes
     const result = offsetToTime(offset, origin);
-    expect(result.getTime()).toBe(
-      origin.getTime() + 60 * 60 * 1000,
-    );
+    expect(result.getTime()).toBe(origin.getTime() + 60 * 60 * 1000);
   });
 
   it("is the inverse of timeToOffset for whole-minute moments", () => {
@@ -149,9 +146,7 @@ describe("calculateScheduleWindow", () => {
 
 describe("calculateTimelineData", () => {
   it("returns null when there are no schedule days", () => {
-    expect(
-      calculateTimelineData(new Date(), new Date(), [], []),
-    ).toBeNull();
+    expect(calculateTimelineData(new Date(), new Date(), [], [])).toBeNull();
   });
 
   it("returns null when festival dates are missing", () => {
@@ -232,10 +227,12 @@ describe("calculateTimelineData", () => {
       new Date("2024-07-01T11:59:59.999Z").getTime(),
     );
     // totalWidth spans the full rounded-up hour boundary (2 hours from 10:00 to 12:00)
-    expect(data!.totalWidth).toBe(timeToOffset(
-      new Date("2024-07-01T12:00:00Z"),
-      new Date("2024-07-01T10:00:00Z"),
-    ));
+    expect(data!.totalWidth).toBe(
+      timeToOffset(
+        new Date("2024-07-01T12:00:00Z"),
+        new Date("2024-07-01T10:00:00Z"),
+      ),
+    );
   });
 
   it("applies the 100px minimum width to short sets without affecting the scale", () => {
@@ -303,9 +300,7 @@ describe("calculateTimelineData", () => {
     );
 
     const lastSlot = data!.timeSlots[data!.timeSlots.length - 1];
-    expect(timeToOffset(lastSlot, data!.festivalStart)).toBe(
-      data!.totalWidth,
-    );
+    expect(timeToOffset(lastSlot, data!.festivalStart)).toBe(data!.totalWidth);
   });
 });
 
@@ -362,4 +357,3 @@ function makeDays(): ScheduleDay[] {
     ]),
   ];
 }
-

--- a/src/lib/timelineCalculator.ts
+++ b/src/lib/timelineCalculator.ts
@@ -3,8 +3,7 @@ import type { ScheduleSet, ScheduleDay } from "@/hooks/useScheduleData";
 import type { Stage } from "@/api/stages/types";
 import { sortStagesByOrder } from "@/lib/stageUtils";
 
-const PX_PER_MINUTE = 2;
-export const PX_PER_HOUR = PX_PER_MINUTE * 60;
+export const PX_PER_MINUTE = 2;
 
 export function timeToOffset(moment: Date, origin: Date): number {
   const minutes = (moment.getTime() - origin.getTime()) / (60 * 1000);

--- a/src/lib/timelineCalculator.ts
+++ b/src/lib/timelineCalculator.ts
@@ -4,6 +4,7 @@ import type { Stage } from "@/api/stages/types";
 import { sortStagesByOrder } from "@/lib/stageUtils";
 
 const PX_PER_MINUTE = 2;
+export const PX_PER_HOUR = PX_PER_MINUTE * 60;
 
 export function timeToOffset(moment: Date, origin: Date): number {
   const minutes = (moment.getTime() - origin.getTime()) / (60 * 1000);
@@ -204,8 +205,8 @@ function processStageGroups<T extends ScheduleSet>(
         allStageGroups[stage.id] = [];
       }
 
-      const enhancedSets = stage.sets.map((set): T =>
-        positionCalculator(set, earliestTime),
+      const enhancedSets = stage.sets.map(
+        (set): T => positionCalculator(set, earliestTime),
       );
 
       allStageGroups[stage.id].push(...enhancedSets);

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/DateBand.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/DateBand.tsx
@@ -1,6 +1,9 @@
 import { formatInTimeZone } from "date-fns-tz";
-import { DAY_GAP_PX, type DateLabelGeometry } from "./timeScaleGeometry";
-import type { DateChange } from "./timeScaleGeometry";
+import {
+  DAY_GAP_PX,
+  type DateChange,
+  type DateLabelGeometry,
+} from "./timeScaleGeometry";
 
 const dateFormat = "MMMM d";
 

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/DateBand.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/DateBand.tsx
@@ -1,0 +1,67 @@
+import { formatInTimeZone } from "date-fns-tz";
+import { DAY_GAP_PX, type DateLabelGeometry } from "./timeScaleGeometry";
+import type { DateChange } from "./timeScaleGeometry";
+
+const dateFormat = "MMMM d";
+
+interface DateBandProps {
+  dateChanges: DateChange[];
+  geometry: DateLabelGeometry;
+  totalWidth: number;
+  timezone: string;
+}
+
+export function DateBand({
+  dateChanges,
+  geometry,
+  totalWidth,
+  timezone,
+}: DateBandProps) {
+  const { currentDate, nextDate, currentDateStickyLeft, currentDateOpacity } =
+    geometry;
+
+  return (
+    <div className="relative h-8">
+      {dateChanges.map((dateChange, index) => {
+        const nextDateChange = dateChanges[index + 1];
+        const fullWidth = nextDateChange
+          ? nextDateChange.position - dateChange.position
+          : totalWidth - dateChange.position;
+        const width = fullWidth - DAY_GAP_PX;
+
+        return (
+          <div
+            key={`date-bg-${index}`}
+            className="absolute top-0 h-full bg-purple-900/60 border border-purple-400/30"
+            style={{
+              left: `${dateChange.position}px`,
+              width: `${width}px`,
+            }}
+          />
+        );
+      })}
+
+      <div
+        className="absolute top-0 z-10 flex h-full items-center px-3 text-sm font-medium text-purple-100 whitespace-nowrap"
+        style={{
+          left: `${currentDate.position + currentDateStickyLeft}px`,
+          opacity: currentDateOpacity,
+        }}
+      >
+        {formatInTimeZone(currentDate.date, timezone, dateFormat)}
+      </div>
+
+      {geometry.shouldShowUpcoming && nextDate && (
+        <div
+          className="absolute top-0 z-10 flex h-full items-center px-3 text-sm font-medium text-purple-50 whitespace-nowrap"
+          style={{
+            left: `${nextDate.position}px`,
+            opacity: geometry.nextDateOpacity,
+          }}
+        >
+          {formatInTimeZone(nextDate.date, timezone, dateFormat)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/HourMarkers.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/HourMarkers.tsx
@@ -1,0 +1,41 @@
+import { formatInTimeZone } from "date-fns-tz";
+import { timeToOffset } from "@/lib/timelineCalculator";
+
+interface HourMarkersProps {
+  timeSlots: Date[];
+  timezone: string;
+}
+
+export function HourMarkers({ timeSlots, timezone }: HourMarkersProps) {
+  return (
+    <div className="hour-markers relative h-10">
+      {timeSlots.map((timeSlot, index) => {
+        // The first/last marker's label would otherwise overhang past the
+        // scrollable range's true edge and get clipped there; growing it
+        // inward instead keeps the tick itself pinned to its real offset.
+        const edgeAlignment =
+          index === 0
+            ? "items-start"
+            : index === timeSlots.length - 1
+              ? "items-end"
+              : "items-center";
+
+        return (
+          <div
+            key={index}
+            className={`absolute flex flex-col ${edgeAlignment}`}
+            style={{
+              left: `${timeToOffset(timeSlot, timeSlots[0])}px`,
+              width: 0,
+            }}
+          >
+            <div className="text-sm font-medium text-purple-300 whitespace-nowrap">
+              {formatInTimeZone(timeSlot, timezone, "HH:mm")}
+            </div>
+            <div className="w-px h-4 bg-purple-400/30" />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/TimeScale.tsx
@@ -1,5 +1,9 @@
-import { formatInTimeZone } from "date-fns-tz";
-import { timeToOffset } from "@/lib/timelineCalculator";
+import {
+  computeDateChanges,
+  computeDateLabelGeometry,
+} from "./timeScaleGeometry";
+import { DateBand } from "./DateBand";
+import { HourMarkers } from "./HourMarkers";
 
 interface TimeScaleProps {
   timeSlots: Date[];
@@ -8,150 +12,28 @@ interface TimeScaleProps {
   scrollLeft: number;
 }
 
-const dateFormat = "MMMM d";
-
-// Width of the day-boundary gap between adjacent date backgrounds.
-const DAY_GAP_PX = 5;
-
-// Distance (px) from the next day boundary at which its label starts fading in.
-const UPCOMING_FADE_THRESHOLD_PX = 100;
-
-// `scrollLeft` keeps the current day's label pinned to the strip's left
-// edge while scrolling through that day, fading in the next day's label
-// as its boundary nears.
 export function TimeScale({
   timeSlots,
   totalWidth,
   timezone,
   scrollLeft,
 }: TimeScaleProps) {
-  const dateChanges = timeSlots.reduce(
-    (changes, timeSlot, index) => {
-      if (index === 0) {
-        changes.push({ date: timeSlot, position: 0 });
-        return changes;
-      }
-      const prevDate = formatInTimeZone(
-        timeSlots[index - 1],
-        timezone,
-        "yyyy-MM-dd",
-      );
-      const currentDate = formatInTimeZone(timeSlot, timezone, "yyyy-MM-dd");
-      if (prevDate !== currentDate) {
-        changes.push({
-          date: timeSlot,
-          position: timeToOffset(timeSlot, timeSlots[0]),
-        });
-      }
-      return changes;
-    },
-    [] as Array<{ date: Date; position: number }>,
-  );
-
-  const currentDateIndex = dateChanges.findLastIndex(
-    (change) => change.position <= scrollLeft,
-  );
-  const currentDate =
-    currentDateIndex >= 0 ? dateChanges[currentDateIndex] : dateChanges[0];
-  const nextDate =
-    currentDateIndex >= 0 && currentDateIndex < dateChanges.length - 1
-      ? dateChanges[currentDateIndex + 1]
-      : null;
-
-  const currentDayEndPosition = nextDate
-    ? nextDate.position - DAY_GAP_PX
-    : totalWidth;
-  const currentDayWidth = currentDayEndPosition - currentDate.position;
-  const distanceToNextDay = nextDate
-    ? nextDate.position - scrollLeft
-    : Infinity;
-  const shouldShowUpcoming =
-    nextDate !== null && distanceToNextDay <= UPCOMING_FADE_THRESHOLD_PX;
-
-  // Pinned label stays within its own day block: not before the day starts,
-  // not past the day's end (leaving room for the label's own width).
-  const currentDateStickyLeft = Math.min(
-    Math.max(0, scrollLeft - currentDate.position),
-    Math.max(0, currentDayWidth - 120),
+  const dateChanges = computeDateChanges(timeSlots, timezone);
+  const geometry = computeDateLabelGeometry(
+    dateChanges,
+    scrollLeft,
+    totalWidth,
   );
 
   return (
     <div className="relative" style={{ minWidth: totalWidth }}>
-      <div className="relative h-8">
-        {dateChanges.map((dateChange, index) => {
-          const nextDateChange = dateChanges[index + 1];
-          const fullWidth = nextDateChange
-            ? nextDateChange.position - dateChange.position
-            : totalWidth - dateChange.position;
-          const width = fullWidth - DAY_GAP_PX;
-
-          return (
-            <div
-              key={`date-bg-${index}`}
-              className="absolute top-0 h-full bg-purple-900/60 border border-purple-400/30"
-              style={{
-                left: `${dateChange.position}px`,
-                width: `${width}px`,
-              }}
-            />
-          );
-        })}
-
-        <div
-          className="absolute top-0 z-10 flex h-full items-center px-3 text-sm font-medium text-purple-100 whitespace-nowrap"
-          style={{
-            left: `${currentDate.position + currentDateStickyLeft}px`,
-            opacity: scrollLeft - currentDate.position >= 0 ? 1 : 0,
-          }}
-        >
-          {formatInTimeZone(currentDate.date, timezone, dateFormat)}
-        </div>
-
-        {shouldShowUpcoming && nextDate && (
-          <div
-            className="absolute top-0 z-10 flex h-full items-center px-3 text-sm font-medium text-purple-50 whitespace-nowrap"
-            style={{
-              left: `${nextDate.position}px`,
-              opacity: Math.min(
-                1,
-                (UPCOMING_FADE_THRESHOLD_PX - distanceToNextDay) / 50,
-              ),
-            }}
-          >
-            {formatInTimeZone(nextDate.date, timezone, dateFormat)}
-          </div>
-        )}
-      </div>
-
-      <div className="hour-markers relative h-10">
-        {timeSlots.map((timeSlot, index) => {
-          // The first/last marker's label would otherwise overhang past the
-          // scrollable range's true edge and get clipped there; growing it
-          // inward instead keeps the tick itself pinned to its real offset.
-          const edgeAlignment =
-            index === 0
-              ? "items-start"
-              : index === timeSlots.length - 1
-                ? "items-end"
-                : "items-center";
-
-          return (
-            <div
-              key={index}
-              className={`absolute flex flex-col ${edgeAlignment}`}
-              style={{
-                left: `${timeToOffset(timeSlot, timeSlots[0])}px`,
-                width: 0,
-              }}
-            >
-              <div className="text-sm font-medium text-purple-300 whitespace-nowrap">
-                {formatInTimeZone(timeSlot, timezone, "HH:mm")}
-              </div>
-              <div className="w-px h-4 bg-purple-400/30" />
-            </div>
-          );
-        })}
-      </div>
+      <DateBand
+        dateChanges={dateChanges}
+        geometry={geometry}
+        totalWidth={totalWidth}
+        timezone={timezone}
+      />
+      <HourMarkers timeSlots={timeSlots} timezone={timezone} />
     </div>
   );
 }

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { PX_PER_HOUR } from "@/lib/timelineCalculator";
+import { PX_PER_MINUTE } from "@/lib/timelineCalculator";
 import {
   computeDateChanges,
   computeDateLabelGeometry,
@@ -9,7 +9,7 @@ import {
 } from "./timeScaleGeometry";
 
 const timezone = "UTC";
-const ONE_DAY_PX = 24 * PX_PER_HOUR;
+const ONE_DAY_PX = 24 * 60 * PX_PER_MINUTE;
 
 describe("computeDateChanges", () => {
   it("returns a single entry at position 0 for a single-day slot list", () => {

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
@@ -49,8 +49,8 @@ describe("computeDateChanges", () => {
     const changesUtc = computeDateChanges(timeSlots, "UTC");
     expect(changesUtc).toHaveLength(1);
 
-    const changesUtcPlus1 = computeDateChanges(timeSlots, "Europe/Berlin");
-    expect(changesUtcPlus1).toHaveLength(2);
+    const changesBerlinSummer = computeDateChanges(timeSlots, "Europe/Berlin");
+    expect(changesBerlinSummer).toHaveLength(2);
   });
 });
 

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { PX_PER_HOUR } from "@/lib/timelineCalculator";
 import {
   computeDateChanges,
   computeDateLabelGeometry,
+  DATE_LABEL_WIDTH_PX,
+  DAY_GAP_PX,
+  UPCOMING_FADE_THRESHOLD_PX,
 } from "./timeScaleGeometry";
 
 const timezone = "UTC";
+const ONE_DAY_PX = 24 * PX_PER_HOUR;
 
 describe("computeDateChanges", () => {
   it("returns a single entry at position 0 for a single-day slot list", () => {
@@ -57,9 +62,9 @@ describe("computeDateChanges", () => {
 describe("computeDateLabelGeometry", () => {
   const dateChanges = [
     { date: new Date("2024-07-01T10:00:00Z"), position: 0 },
-    { date: new Date("2024-07-02T10:00:00Z"), position: 2880 }, // 24h * 120px/h
+    { date: new Date("2024-07-02T10:00:00Z"), position: ONE_DAY_PX },
   ];
-  const totalWidth = 5760;
+  const totalWidth = 2 * ONE_DAY_PX;
 
   it("pins the first day's label at the start when scroll is 0", () => {
     const geometry = computeDateLabelGeometry(dateChanges, 0, totalWidth);
@@ -71,30 +76,50 @@ describe("computeDateLabelGeometry", () => {
   });
 
   it("keeps the pinned label clamped within its own day block while scrolling", () => {
-    const geometry = computeDateLabelGeometry(dateChanges, 1000, totalWidth);
+    const scrollLeft = ONE_DAY_PX / 2;
+    const geometry = computeDateLabelGeometry(
+      dateChanges,
+      scrollLeft,
+      totalWidth,
+    );
 
     expect(geometry.currentDate).toEqual(dateChanges[0]);
-    expect(geometry.currentDateStickyLeft).toBe(1000);
+    expect(geometry.currentDateStickyLeft).toBe(scrollLeft);
   });
 
   it("clamps the sticky offset so the label never overruns the day's end", () => {
-    // Scrolled almost to the next day boundary (2880 - 5 gap = 2875 end).
-    const geometry = computeDateLabelGeometry(dateChanges, 2870, totalWidth);
+    // Scrolled almost to the next day boundary.
+    const scrollLeft = ONE_DAY_PX - 10;
+    const geometry = computeDateLabelGeometry(
+      dateChanges,
+      scrollLeft,
+      totalWidth,
+    );
 
-    // currentDayWidth = 2875, clamp max = currentDayWidth - 120 = 2755
-    expect(geometry.currentDateStickyLeft).toBe(2755);
+    const currentDayWidth = ONE_DAY_PX - DAY_GAP_PX;
+    const expectedStickyLeft = currentDayWidth - DATE_LABEL_WIDTH_PX;
+    expect(geometry.currentDateStickyLeft).toBe(expectedStickyLeft);
   });
 
   it("switches to the next day once scrolled past its boundary", () => {
-    const geometry = computeDateLabelGeometry(dateChanges, 2880, totalWidth);
+    const geometry = computeDateLabelGeometry(
+      dateChanges,
+      ONE_DAY_PX,
+      totalWidth,
+    );
 
     expect(geometry.currentDate).toEqual(dateChanges[1]);
     expect(geometry.nextDate).toBeNull();
   });
 
   it("fades in the next day's label within the fade threshold", () => {
-    // 2880 - 2830 = 50px from the boundary, within the 100px threshold.
-    const geometry = computeDateLabelGeometry(dateChanges, 2830, totalWidth);
+    const distanceFromBoundary = UPCOMING_FADE_THRESHOLD_PX / 2;
+    const scrollLeft = ONE_DAY_PX - distanceFromBoundary;
+    const geometry = computeDateLabelGeometry(
+      dateChanges,
+      scrollLeft,
+      totalWidth,
+    );
 
     expect(geometry.shouldShowUpcoming).toBe(true);
     expect(geometry.nextDate).toEqual(dateChanges[1]);
@@ -102,7 +127,12 @@ describe("computeDateLabelGeometry", () => {
   });
 
   it("does not show the upcoming label outside the fade threshold", () => {
-    const geometry = computeDateLabelGeometry(dateChanges, 2000, totalWidth);
+    const scrollLeft = ONE_DAY_PX - UPCOMING_FADE_THRESHOLD_PX - 1;
+    const geometry = computeDateLabelGeometry(
+      dateChanges,
+      scrollLeft,
+      totalWidth,
+    );
 
     expect(geometry.shouldShowUpcoming).toBe(false);
   });

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeDateChanges,
+  computeDateLabelGeometry,
+} from "./timeScaleGeometry";
+
+const timezone = "UTC";
+
+describe("computeDateChanges", () => {
+  it("returns a single entry at position 0 for a single-day slot list", () => {
+    const timeSlots = [
+      new Date("2024-07-01T10:00:00Z"),
+      new Date("2024-07-01T11:00:00Z"),
+      new Date("2024-07-01T12:00:00Z"),
+    ];
+
+    const changes = computeDateChanges(timeSlots, timezone);
+
+    expect(changes).toEqual([{ date: timeSlots[0], position: 0 }]);
+  });
+
+  it("adds an entry when the date (in the given timezone) changes", () => {
+    const timeSlots = [
+      new Date("2024-07-01T22:00:00Z"),
+      new Date("2024-07-01T23:00:00Z"),
+      new Date("2024-07-02T00:00:00Z"),
+      new Date("2024-07-02T01:00:00Z"),
+    ];
+
+    const changes = computeDateChanges(timeSlots, timezone);
+
+    expect(changes).toHaveLength(2);
+    expect(changes[0]).toEqual({ date: timeSlots[0], position: 0 });
+    expect(changes[1].date).toBe(timeSlots[2]);
+    expect(changes[1].position).toBeGreaterThan(0);
+  });
+
+  it("returns an empty array for an empty slot list", () => {
+    expect(computeDateChanges([], timezone)).toEqual([]);
+  });
+
+  it("respects the given timezone when detecting the day boundary", () => {
+    // 21:30 UTC on 07-01 is already 07-02 in a UTC+2 (Berlin summer) zone.
+    const timeSlots = [
+      new Date("2024-07-01T21:00:00Z"),
+      new Date("2024-07-01T22:00:00Z"),
+    ];
+
+    const changesUtc = computeDateChanges(timeSlots, "UTC");
+    expect(changesUtc).toHaveLength(1);
+
+    const changesUtcPlus1 = computeDateChanges(timeSlots, "Europe/Berlin");
+    expect(changesUtcPlus1).toHaveLength(2);
+  });
+});
+
+describe("computeDateLabelGeometry", () => {
+  const dateChanges = [
+    { date: new Date("2024-07-01T10:00:00Z"), position: 0 },
+    { date: new Date("2024-07-02T10:00:00Z"), position: 2880 }, // 24h * 120px/h
+  ];
+  const totalWidth = 5760;
+
+  it("pins the first day's label at the start when scroll is 0", () => {
+    const geometry = computeDateLabelGeometry(dateChanges, 0, totalWidth);
+
+    expect(geometry.currentDate).toEqual(dateChanges[0]);
+    expect(geometry.currentDateStickyLeft).toBe(0);
+    expect(geometry.currentDateOpacity).toBe(1);
+    expect(geometry.shouldShowUpcoming).toBe(false);
+  });
+
+  it("keeps the pinned label clamped within its own day block while scrolling", () => {
+    const geometry = computeDateLabelGeometry(dateChanges, 1000, totalWidth);
+
+    expect(geometry.currentDate).toEqual(dateChanges[0]);
+    expect(geometry.currentDateStickyLeft).toBe(1000);
+  });
+
+  it("clamps the sticky offset so the label never overruns the day's end", () => {
+    // Scrolled almost to the next day boundary (2880 - 5 gap = 2875 end).
+    const geometry = computeDateLabelGeometry(dateChanges, 2870, totalWidth);
+
+    // currentDayWidth = 2875, clamp max = currentDayWidth - 120 = 2755
+    expect(geometry.currentDateStickyLeft).toBe(2755);
+  });
+
+  it("switches to the next day once scrolled past its boundary", () => {
+    const geometry = computeDateLabelGeometry(dateChanges, 2880, totalWidth);
+
+    expect(geometry.currentDate).toEqual(dateChanges[1]);
+    expect(geometry.nextDate).toBeNull();
+  });
+
+  it("fades in the next day's label within the fade threshold", () => {
+    // 2880 - 2830 = 50px from the boundary, within the 100px threshold.
+    const geometry = computeDateLabelGeometry(dateChanges, 2830, totalWidth);
+
+    expect(geometry.shouldShowUpcoming).toBe(true);
+    expect(geometry.nextDate).toEqual(dateChanges[1]);
+    expect(geometry.nextDateOpacity).toBeCloseTo(1, 5);
+  });
+
+  it("does not show the upcoming label outside the fade threshold", () => {
+    const geometry = computeDateLabelGeometry(dateChanges, 2000, totalWidth);
+
+    expect(geometry.shouldShowUpcoming).toBe(false);
+  });
+
+  it("uses the total width as the current day's end when there is no next day", () => {
+    const singleDayChanges = [dateChanges[0]];
+    const geometry = computeDateLabelGeometry(
+      singleDayChanges,
+      100,
+      totalWidth,
+    );
+
+    expect(geometry.nextDate).toBeNull();
+    expect(geometry.currentDayEndPosition).toBe(totalWidth);
+  });
+});

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
@@ -50,6 +50,7 @@ export interface DateLabelGeometry {
   nextDateOpacity: number;
 }
 
+// Computes the pinned/fading date-label positions for the current scroll offset.
 // `scrollLeft` keeps the current day's label pinned to the strip's left
 // edge while scrolling through that day, fading in the next day's label
 // as its boundary nears.

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
@@ -1,0 +1,96 @@
+import { formatInTimeZone } from "date-fns-tz";
+import { timeToOffset } from "@/lib/timelineCalculator";
+
+// Width of the day-boundary gap between adjacent date backgrounds.
+export const DAY_GAP_PX = 5;
+
+// Distance (px) from the next day boundary at which its label starts fading in.
+export const UPCOMING_FADE_THRESHOLD_PX = 100;
+
+export interface DateChange {
+  date: Date;
+  position: number;
+}
+
+export function computeDateChanges(
+  timeSlots: Date[],
+  timezone: string,
+): DateChange[] {
+  return timeSlots.reduce((changes, timeSlot, index) => {
+    if (index === 0) {
+      changes.push({ date: timeSlot, position: 0 });
+      return changes;
+    }
+    const prevDate = formatInTimeZone(
+      timeSlots[index - 1],
+      timezone,
+      "yyyy-MM-dd",
+    );
+    const currentDate = formatInTimeZone(timeSlot, timezone, "yyyy-MM-dd");
+    if (prevDate !== currentDate) {
+      changes.push({
+        date: timeSlot,
+        position: timeToOffset(timeSlot, timeSlots[0]),
+      });
+    }
+    return changes;
+  }, [] as DateChange[]);
+}
+
+export interface DateLabelGeometry {
+  currentDate: DateChange;
+  nextDate: DateChange | null;
+  currentDayEndPosition: number;
+  currentDateStickyLeft: number;
+  currentDateOpacity: number;
+  shouldShowUpcoming: boolean;
+  nextDateOpacity: number;
+}
+
+// `scrollLeft` keeps the current day's label pinned to the strip's left
+// edge while scrolling through that day, fading in the next day's label
+// as its boundary nears.
+export function computeDateLabelGeometry(
+  dateChanges: DateChange[],
+  scrollLeft: number,
+  totalWidth: number,
+): DateLabelGeometry {
+  const currentDateIndex = dateChanges.findLastIndex(
+    (change) => change.position <= scrollLeft,
+  );
+  const currentDate =
+    currentDateIndex >= 0 ? dateChanges[currentDateIndex] : dateChanges[0];
+  const nextDate =
+    currentDateIndex >= 0 && currentDateIndex < dateChanges.length - 1
+      ? dateChanges[currentDateIndex + 1]
+      : null;
+
+  const currentDayEndPosition = nextDate
+    ? nextDate.position - DAY_GAP_PX
+    : totalWidth;
+  const currentDayWidth = currentDayEndPosition - currentDate.position;
+  const distanceToNextDay = nextDate
+    ? nextDate.position - scrollLeft
+    : Infinity;
+  const shouldShowUpcoming =
+    nextDate !== null && distanceToNextDay <= UPCOMING_FADE_THRESHOLD_PX;
+
+  // Pinned label stays within its own day block: not before the day starts,
+  // not past the day's end (leaving room for the label's own width).
+  const currentDateStickyLeft = Math.min(
+    Math.max(0, scrollLeft - currentDate.position),
+    Math.max(0, currentDayWidth - 120),
+  );
+
+  return {
+    currentDate,
+    nextDate,
+    currentDayEndPosition,
+    currentDateStickyLeft,
+    currentDateOpacity: scrollLeft - currentDate.position >= 0 ? 1 : 0,
+    shouldShowUpcoming,
+    nextDateOpacity: shouldShowUpcoming
+      ? Math.min(1, (UPCOMING_FADE_THRESHOLD_PX - distanceToNextDay) / 50)
+      : 0,
+  };
+}

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
@@ -1,13 +1,10 @@
 import { formatInTimeZone } from "date-fns-tz";
 import { timeToOffset } from "@/lib/timelineCalculator";
 
-// Width of the day-boundary gap between adjacent date backgrounds.
 export const DAY_GAP_PX = 5;
 
-// Distance (px) from the next day boundary at which its label starts fading in.
 export const UPCOMING_FADE_THRESHOLD_PX = 100;
 
-// Width reserved for the pinned date label so it never overruns the day's end.
 export const DATE_LABEL_WIDTH_PX = 120;
 
 export interface DateChange {
@@ -50,10 +47,12 @@ export interface DateLabelGeometry {
   nextDateOpacity: number;
 }
 
-// Computes the pinned/fading date-label positions for the current scroll offset.
-// `scrollLeft` keeps the current day's label pinned to the strip's left
-// edge while scrolling through that day, fading in the next day's label
-// as its boundary nears.
+/**
+ * Computes the pinned/fading date-label positions for the current scroll offset.
+ * @param scrollLeft Keeps the current day's label pinned to the strip's left
+ * edge while scrolling through that day, fading in the next day's label
+ * as its boundary nears.
+ */
 export function computeDateLabelGeometry(
   dateChanges: DateChange[],
   scrollLeft: number,

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/timeScaleGeometry.ts
@@ -7,6 +7,9 @@ export const DAY_GAP_PX = 5;
 // Distance (px) from the next day boundary at which its label starts fading in.
 export const UPCOMING_FADE_THRESHOLD_PX = 100;
 
+// Width reserved for the pinned date label so it never overruns the day's end.
+export const DATE_LABEL_WIDTH_PX = 120;
+
 export interface DateChange {
   date: Date;
   position: number;
@@ -79,7 +82,7 @@ export function computeDateLabelGeometry(
   // not past the day's end (leaving room for the label's own width).
   const currentDateStickyLeft = Math.min(
     Math.max(0, scrollLeft - currentDate.position),
-    Math.max(0, currentDayWidth - 120),
+    Math.max(0, currentDayWidth - DATE_LABEL_WIDTH_PX),
   );
 
   return {


### PR DESCRIPTION
Splits `TimeScale.tsx` into pure, unit-tested helpers (`computeDateChanges`, `computeDateLabelGeometry`) plus two presentational subcomponents (`DateBand`, `HourMarkers`), composed unchanged by `TimeScale`. No props or visual changes.

Closes #244

## Verification
- Load the schedule timeline; date band, pinned date label, fading next-day label, and hour markers render identically to before.
- Scroll horizontally through a multi-day festival; the pinned label stays clamped within its day and the next day's label fades in near the boundary.
- `pnpm test` (483 tests) and `pnpm run lint` pass; `tsc --noEmit` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zPmjZr8QrriCzLUgdGUt9)_