### PR TITLE
fix(components): replace confirm() with AlertDialog

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,48 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/ConfirmDialogHost.tsx
+++ b/src/components/ConfirmDialogHost.tsx
@@ -1,0 +1,17 @@
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { respondConfirm, useConfirm } from "@/hooks/use-confirm";
+
+export function ConfirmDialogHost() {
+  const { request } = useConfirm();
+
+  return (
+    <ConfirmDialog
+      open={request !== null}
+      onOpenChange={(open) => !open && respondConfirm(false)}
+      title={request?.title ?? ""}
+      description={request?.description ?? ""}
+      confirmLabel={request?.confirmLabel ?? ""}
+      onConfirm={() => respondConfirm(true)}
+    />
+  );
+}

--- a/src/hooks/use-confirm.ts
+++ b/src/hooks/use-confirm.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+interface ConfirmOptions {
+  title: string;
+  description: string;
+  confirmLabel: string;
+}
+
+interface ConfirmRequest extends ConfirmOptions {
+  resolve: (confirmed: boolean) => void;
+}
+
+interface State {
+  request: ConfirmRequest | null;
+}
+
+let memoryState: State = { request: null };
+const listeners: Array<(state: State) => void> = [];
+
+function dispatch(state: State) {
+  memoryState = state;
+  listeners.forEach((listener) => listener(memoryState));
+}
+
+function confirm(options: ConfirmOptions) {
+  return new Promise<boolean>((resolve) => {
+    memoryState.request?.resolve(false);
+    dispatch({ request: { ...options, resolve } });
+  });
+}
+
+function respondConfirm(confirmed: boolean) {
+  memoryState.request?.resolve(confirmed);
+  dispatch({ request: null });
+}
+
+function useConfirm() {
+  const [state, setState] = useState<State>(memoryState);
+
+  useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, []);
+
+  return state;
+}
+
+export { useConfirm, confirm, respondConfirm };

--- a/src/pages/SetDetails/notes/SetNoteItem.tsx
+++ b/src/pages/SetDetails/notes/SetNoteItem.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { confirm } from "@/hooks/use-confirm";
 import { SetNote } from "@/api/artist-notes/types";
 import { useDeleteNoteMutation } from "@/api/artist-notes/useDeleteNoteMutation";
 import { Trash2Icon } from "lucide-react";
@@ -22,7 +23,7 @@ export function SetNoteItem({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => handleDelete(note.id)}
+            onClick={handleDelete}
             className="border-red-400/50 text-red-400 hover:bg-red-400 hover:text-white"
             disabled={deleteNoteMutation.isPending}
           >
@@ -39,9 +40,15 @@ export function SetNoteItem({
     </div>
   );
 
-  async function handleDelete(noteId: string) {
-    if (window.confirm("Are you sure you want to delete this note?")) {
-      deleteNoteMutation.mutate(noteId, {});
-    }
+  async function handleDelete() {
+    const confirmed = await confirm({
+      title: "Delete this note?",
+      description:
+        "Are you sure you want to delete this note? This action cannot be undone.",
+      confirmLabel: "Delete",
+    });
+    if (!confirmed) return;
+
+    deleteNoteMutation.mutate(note.id);
   }
 }

--- a/src/pages/admin/festivals/FestivalEditionManagement.tsx
+++ b/src/pages/admin/festivals/FestivalEditionManagement.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { confirm } from "@/hooks/use-confirm";
 import {
   Dialog,
   DialogContent,
@@ -223,14 +224,13 @@ export function FestivalEditionManagement({
     }
   }
 
-  async function handleDelete(edition: FestivalEdition) {
-    if (
-      !confirm(
-        `Are you sure you want to delete "${edition.name}"? This will also delete all associated stages and sets.`,
-      )
-    ) {
-      return;
-    }
+  async function handleDeleteRequest(edition: FestivalEdition) {
+    const confirmed = await confirm({
+      title: "Delete this edition?",
+      description: `Are you sure you want to delete "${edition.name}"? This will also delete all associated stages and sets.`,
+      confirmLabel: "Delete",
+    });
+    if (!confirmed) return;
 
     deleteEditionMutation.mutate(edition.id);
   }
@@ -432,7 +432,7 @@ export function FestivalEditionManagement({
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          handleDelete(edition);
+                          handleDeleteRequest(edition);
                         }}
                         className="text-destructive hover:text-destructive"
                       >

--- a/src/pages/admin/festivals/FestivalManagementTable.tsx
+++ b/src/pages/admin/festivals/FestivalManagementTable.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
+import { confirm } from "@/hooks/use-confirm";
 import { Edit2, Trash2, Image as ImageIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FestivalLogoDialog } from "./FestivalLogoDialog";
@@ -32,14 +33,13 @@ export function FestivalManagementTable({
   const [selectedFestivalForLogo, setSelectedFestivalForLogo] =
     useState<Festival | null>(null);
 
-  function handleDelete(festival: Festival) {
-    if (
-      !confirm(
-        `Are you sure you want to delete "${festival.name}"? This will also delete all associated editions, stages, and sets.`,
-      )
-    ) {
-      return;
-    }
+  async function handleDeleteRequest(festival: Festival) {
+    const confirmed = await confirm({
+      title: "Delete this festival?",
+      description: `Are you sure you want to delete "${festival.name}"? This will also delete all associated editions, stages, and sets.`,
+      confirmLabel: "Delete",
+    });
+    if (!confirmed) return;
 
     deleteFestivalMutation.mutate(festival.id);
   }
@@ -116,7 +116,7 @@ export function FestivalManagementTable({
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      handleDelete(festival);
+                      handleDeleteRequest(festival);
                     }}
                     className="text-destructive hover:text-destructive"
                     title="Delete festival"

--- a/src/pages/admin/festivals/SetsManagement/SetManagement.tsx
+++ b/src/pages/admin/festivals/SetsManagement/SetManagement.tsx
@@ -3,6 +3,7 @@ import { useParams } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { confirm } from "@/hooks/use-confirm";
 import { Loader2, Plus, Music } from "lucide-react";
 import { FestivalSet } from "@/api/sets/types";
 import { useSetsByEditionQuery } from "@/api/sets/useSetsByEdition";
@@ -40,14 +41,13 @@ export function SetManagement() {
     setIsDialogOpen(true);
   }
 
-  async function handleDelete(set: FestivalSet) {
-    if (
-      !confirm(
-        `Are you sure you want to delete "${set.name}"? This will also delete all votes for this set.`,
-      )
-    ) {
-      return;
-    }
+  async function handleDeleteRequest(set: FestivalSet) {
+    const confirmed = await confirm({
+      title: "Delete this set?",
+      description: `Are you sure you want to delete "${set.name}"? This will also delete all votes for this set.`,
+      confirmLabel: "Delete",
+    });
+    if (!confirmed) return;
 
     deleteSetMutation.mutate(set.id);
   }
@@ -91,7 +91,7 @@ export function SetManagement() {
         <SetsTable
           sets={setsQuery.data || []}
           onEdit={handleEdit}
-          onDelete={handleDelete}
+          onDelete={handleDeleteRequest}
           editionId={editionQuery.data.id}
           timezone={festival.timezone}
         />

--- a/src/pages/admin/festivals/StageManagement.tsx
+++ b/src/pages/admin/festivals/StageManagement.tsx
@@ -5,6 +5,7 @@ import { useStagesByEditionQuery } from "@/api/stages/useStagesByEdition";
 import { useDeleteStageMutation } from "@/api/stages/useDeleteStage";
 import type { Stage } from "@/api/stages/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { confirm } from "@/hooks/use-confirm";
 import { Loader2, MapPin } from "lucide-react";
 import { StagesTable } from "./StageManagement/StagesTable";
 import { CreateStageDialog } from "./StageManagement/CreateStageDialog";
@@ -43,14 +44,13 @@ export function StageManagement(_props: StageManagementProps) {
     setEditingStage(null);
   }
 
-  async function handleDelete(stage: Stage) {
-    if (
-      !confirm(
-        `Are you sure you want to delete "${stage.name}"? This will also affect all sets assigned to this stage.`,
-      )
-    ) {
-      return;
-    }
+  async function handleDeleteRequest(stage: Stage) {
+    const confirmed = await confirm({
+      title: "Delete this stage?",
+      description: `Are you sure you want to delete "${stage.name}"? This will also affect all sets assigned to this stage.`,
+      confirmLabel: "Delete",
+    });
+    if (!confirmed) return;
 
     deleteStageMutation.mutate(stage.id);
   }
@@ -85,7 +85,7 @@ export function StageManagement(_props: StageManagementProps) {
         <StagesTable
           stages={filteredStages}
           onEdit={handleEdit}
-          onDelete={handleDelete}
+          onDelete={handleDeleteRequest}
         />
 
         <EditStageDialog

--- a/src/pages/groups/GroupDetail.tsx
+++ b/src/pages/groups/GroupDetail.tsx
@@ -15,6 +15,7 @@ import { Users, UserMinus, Crown } from "lucide-react";
 import { InviteManagement } from "./GroupDetail/InviteManagement";
 import { AddMemberForm } from "./GroupDetail/AddMemberForm";
 import { Button } from "@/components/ui/button";
+import { confirm } from "@/hooks/use-confirm";
 import { groupBySlugQuery } from "@/api/groups/useGroupBySlug";
 import { groupMembersQuery } from "@/api/groups/useGroupMembers";
 import { useRemoveMemberMutation } from "@/api/groups/useRemoveMember";
@@ -48,7 +49,7 @@ function GroupDetail() {
 
 function GroupDetailContent({ user }: { user: User }) {
   const { groupSlug } = useParams({ from: "/groups/$groupSlug" });
-  const [removingMember, setRemovingMember] = useState<string | null>(null);
+  const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
 
   const { data: group } = useSuspenseQuery(
     groupBySlugQuery(groupSlug, user.id),
@@ -163,9 +164,12 @@ function GroupDetailContent({ user }: { user: User }) {
                             variant="destructive"
                             size="sm"
                             onClick={() =>
-                              handleRemoveMember(member.id, member.user_id)
+                              handleRemoveMemberRequest(
+                                member.id,
+                                member.user_id,
+                              )
                             }
-                            disabled={removingMember === member.id}
+                            disabled={removingMemberId === member.id}
                           >
                             <UserMinus className="h-4 w-4" />
                           </Button>
@@ -194,23 +198,23 @@ function GroupDetailContent({ user }: { user: User }) {
     </div>
   );
 
-  async function handleRemoveMember(memberId: string, memberUserId: string) {
-    if (
-      window.confirm(
+  async function handleRemoveMemberRequest(
+    memberId: string,
+    memberUserId: string,
+  ) {
+    const confirmed = await confirm({
+      title: "Remove this member?",
+      description:
         "Are you sure you want to remove this member from the group?",
-      )
-    ) {
-      setRemovingMember(memberId);
-      try {
-        await removeMemberMutation.mutateAsync({
-          userId: memberUserId,
-          currentUserId: user.id,
-        });
-        // The mutation automatically invalidates queries and shows toast
-      } finally {
-        setRemovingMember(null);
-      }
-    }
+      confirmLabel: "Remove",
+    });
+    if (!confirmed) return;
+
+    setRemovingMemberId(memberId);
+    removeMemberMutation.mutate(
+      { userId: memberUserId, currentUserId: user.id },
+      { onSettled: () => setRemovingMemberId(null) },
+    );
   }
 }
 

--- a/src/pages/groups/GroupDetail/InviteManagement.tsx
+++ b/src/pages/groups/GroupDetail/InviteManagement.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { confirm } from "@/hooks/use-confirm";
 import { Link, Copy, Trash2, Calendar, Users } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -80,8 +81,15 @@ export function InviteManagement({
     }
   }
 
-  function deleteInvite(inviteId: string) {
-    if (!window.confirm("Are you sure you want to delete this invite?")) return;
+  async function handleDeleteInviteRequest(inviteId: string) {
+    const confirmed = await confirm({
+      title: "Delete this invite?",
+      description:
+        "Are you sure you want to delete this invite? This action cannot be undone.",
+      confirmLabel: "Delete",
+    });
+    if (!confirmed) return;
+
     deleteInviteMutation.mutate(inviteId);
   }
 
@@ -201,7 +209,7 @@ export function InviteManagement({
                       <Button
                         variant="destructive"
                         size="sm"
-                        onClick={() => deleteInvite(invite.id)}
+                        onClick={() => handleDeleteInviteRequest(invite.id)}
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>

--- a/src/pages/groups/Groups/GroupCard.tsx
+++ b/src/pages/groups/Groups/GroupCard.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { confirm } from "@/hooks/use-confirm";
 import {
   Card,
   CardHeader,
@@ -85,7 +86,7 @@ export function GroupCard({
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    handleLeaveGroup();
+                    handleLeaveGroupRequest();
                   }}
                   className="bg-white/10 border-purple-400/30 text-white hover:bg-white/20"
                 >
@@ -107,9 +108,15 @@ export function GroupCard({
     </Link>
   );
 
-  async function handleLeaveGroup() {
-    if (window.confirm("Are you sure you want to leave this group?")) {
-      leaveGroupMutation.mutate({ groupId: group.id, userId: user?.id || "" });
-    }
+  async function handleLeaveGroupRequest() {
+    const confirmed = await confirm({
+      title: "Leave this group?",
+      description:
+        "Are you sure you want to leave this group? You will lose access to its votes and notes.",
+      confirmLabel: "Leave",
+    });
+    if (!confirmed) return;
+
+    leaveGroupMutation.mutate({ groupId: group.id, userId: user?.id || "" });
   }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
+import { ConfirmDialogHost } from "@/components/ConfirmDialogHost";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { CookieConsentBanner } from "@/components/layout/legal/CookieConsentBanner";
 import { OfflineIndicator } from "@/components/ui/OfflineIndicator";
@@ -60,6 +61,7 @@ function RootComponent() {
       <TooltipProvider>
         <Toaster />
         <Sonner />
+        <ConfirmDialogHost />
         <AppUpdatePrompt />
         <CookieConsentBanner />
         <AuthProvider>


### PR DESCRIPTION
Adds a shared ConfirmDialog and a `confirm(options): Promise<boolean>` helper (singleton store + `<ConfirmDialogHost />` mounted at the app root, modeled on the existing `useToast`/`<Toaster />` pattern), and swaps all 8 destructive-action `window.confirm()`/`confirm()` sites for it.
Cancel/dismiss resolves `false` and leaves data unchanged; confirming resolves `true` and the caller runs its mutation via `mutation.mutate(...)`, using the mutation's own `isPending` for loading state on the trigger button.

Closes #160

## Verification
- Delete a set note: dialog appears with note-specific copy; Cancel leaves it; Delete removes it.
- Delete a group invite in InviteManagement: dialog appears; confirm removes the invite.
- Remove a member from a group as the group creator: dialog appears; confirm removes the member, and only that member's button shows a disabled/loading state while removal is in flight.
- Leave a group as a non-creator member: dialog appears; confirm leaves the group.
- Delete a festival, stage, edition, and set in admin: each dialog shows action-specific copy; confirm removes the item.
- Confirm no `confirm(`/`window.confirm(` occurrences remain under `src/` (grep clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_016zPmjZr8QrriCzLUgdGUt9)_