### PR TITLE
refactor(queries): switch to useSuspenseQuery

### DIFF
--- a/src/api/festivals/useFestivals.ts
+++ b/src/api/festivals/useFestivals.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
 import { isTimeoutError, withTimeout } from "@/lib/timeout";
@@ -38,8 +38,4 @@ export function festivalsQuery({
     queryFn: ({ signal }) =>
       fetchFestivals({ all, signal: withTimeout(signal, timeoutMs) }),
   });
-}
-
-export function useFestivalsQuery({ all }: { all?: boolean } = {}) {
-  return useSuspenseQuery(festivalsQuery({ all }));
 }

--- a/src/api/festivals/useFestivals.ts
+++ b/src/api/festivals/useFestivals.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Festival, festivalsKeys } from "./types";
 import { isTimeoutError, withTimeout } from "@/lib/timeout";
@@ -41,5 +41,5 @@ export function festivalsQuery({
 }
 
 export function useFestivalsQuery({ all }: { all?: boolean } = {}) {
-  return useQuery(festivalsQuery({ all }));
+  return useSuspenseQuery(festivalsQuery({ all }));
 }

--- a/src/api/genres/useGenres.ts
+++ b/src/api/genres/useGenres.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Genre, genresKeys } from "./types";
 
@@ -21,8 +21,4 @@ export function genresQuery() {
     queryFn: fetchGenres,
     staleTime: 10 * 60 * 1000,
   });
-}
-
-export function useGenresQuery() {
-  return useSuspenseQuery(genresQuery());
 }

--- a/src/api/genres/useGenres.ts
+++ b/src/api/genres/useGenres.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Genre, genresKeys } from "./types";
 
@@ -24,5 +24,5 @@ export function genresQuery() {
 }
 
 export function useGenresQuery() {
-  return useQuery(genresQuery());
+  return useSuspenseQuery(genresQuery());
 }

--- a/src/api/groups/useGroupMembers.ts
+++ b/src/api/groups/useGroupMembers.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import type { GroupMember } from "./types";
 import { groupsKeys } from "./types";
@@ -48,11 +48,4 @@ export function groupMembersQuery(groupId: string) {
     queryKey: groupsKeys.members(groupId),
     queryFn: () => fetchGroupMembers(groupId),
   });
-}
-
-// Hook
-// Only call with a known groupId - callers should gate rendering on its presence
-// rather than passing an empty string, since this suspends until data resolves.
-export function useGroupMembersQuery(groupId: string) {
-  return useSuspenseQuery(groupMembersQuery(groupId));
 }

--- a/src/api/groups/useGroupMembers.ts
+++ b/src/api/groups/useGroupMembers.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import type { GroupMember } from "./types";
 import { groupsKeys } from "./types";
@@ -51,9 +51,8 @@ export function groupMembersQuery(groupId: string) {
 }
 
 // Hook
+// Only call with a known groupId - callers should gate rendering on its presence
+// rather than passing an empty string, since this suspends until data resolves.
 export function useGroupMembersQuery(groupId: string) {
-  return useQuery({
-    ...groupMembersQuery(groupId),
-    enabled: !!groupId,
-  });
+  return useSuspenseQuery(groupMembersQuery(groupId));
 }

--- a/src/api/groups/useUserGroups.ts
+++ b/src/api/groups/useUserGroups.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import type { Group } from "./types";
 import { groupsKeys } from "./types";
@@ -124,14 +124,4 @@ export function userGroupsQuery(
     queryKey: groupsKeys.user(userId, params),
     queryFn: () => fetchUserGroups(userId, params),
   });
-}
-
-// Only call with a known userId - callers should gate rendering on the user
-// being signed in rather than passing it as optional, since this suspends
-// until data resolves.
-export function useUserGroupsQuery(
-  userId: string,
-  params: { all?: boolean } = {},
-) {
-  return useSuspenseQuery(userGroupsQuery(userId, params));
 }

--- a/src/api/groups/useUserGroups.ts
+++ b/src/api/groups/useUserGroups.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import type { Group } from "./types";
 import { groupsKeys } from "./types";
@@ -126,12 +126,12 @@ export function userGroupsQuery(
   });
 }
 
+// Only call with a known userId - callers should gate rendering on the user
+// being signed in rather than passing it as optional, since this suspends
+// until data resolves.
 export function useUserGroupsQuery(
-  userId: string | undefined,
+  userId: string,
   params: { all?: boolean } = {},
 ) {
-  return useQuery({
-    ...userGroupsQuery(userId!, params),
-    enabled: !!userId,
-  });
+  return useSuspenseQuery(userGroupsQuery(userId, params));
 }

--- a/src/components/GenreBadge.test.tsx
+++ b/src/components/GenreBadge.test.tsx
@@ -1,14 +1,17 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import * as reactQuery from "@tanstack/react-query";
 import type { UseSuspenseQueryResult } from "@tanstack/react-query";
 import { GenreBadge } from "./GenreBadge";
-import * as useGenresModule from "@/api/genres/useGenres";
 import type { Genre } from "@/api/genres/types";
 
-vi.mock("@/api/genres/useGenres");
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof reactQuery>()),
+  useSuspenseQuery: vi.fn(),
+}));
 
 function mockGenresQuery(data: Genre[]) {
-  vi.spyOn(useGenresModule, "useGenresQuery").mockReturnValue({
+  vi.mocked(reactQuery.useSuspenseQuery).mockReturnValue({
     data,
   } as unknown as UseSuspenseQueryResult<Genre[], Error>);
 }

--- a/src/components/GenreBadge.test.tsx
+++ b/src/components/GenreBadge.test.tsx
@@ -1,22 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { UseQueryResult } from "@tanstack/react-query";
+import type { UseSuspenseQueryResult } from "@tanstack/react-query";
 import { GenreBadge } from "./GenreBadge";
 import * as useGenresModule from "@/api/genres/useGenres";
 import type { Genre } from "@/api/genres/types";
 
 vi.mock("@/api/genres/useGenres");
 
-function mockGenresQuery(result: {
-  data?: Genre[];
-  isLoading?: boolean;
-  error?: Error | null;
-}) {
+function mockGenresQuery(data: Genre[]) {
   vi.spyOn(useGenresModule, "useGenresQuery").mockReturnValue({
-    data: result.data ?? [],
-    isLoading: result.isLoading ?? false,
-    error: result.error ?? null,
-  } as unknown as UseQueryResult<Genre[], Error>);
+    data,
+  } as unknown as UseSuspenseQueryResult<Genre[], Error>);
 }
 
 describe("GenreBadge", () => {
@@ -25,45 +19,27 @@ describe("GenreBadge", () => {
   });
 
   it("renders genre name when genre is found", () => {
-    mockGenresQuery({
-      data: [
-        { id: "1", name: "Rock" },
-        { id: "2", name: "Pop" },
-      ],
-    });
+    mockGenresQuery([
+      { id: "1", name: "Rock" },
+      { id: "2", name: "Pop" },
+    ]);
 
     render(<GenreBadge genreId="1" />);
     expect(screen.getByText("Rock")).toBeInTheDocument();
   });
 
-  it("renders null when loading", () => {
-    mockGenresQuery({ isLoading: true });
-
-    const { container } = render(<GenreBadge genreId="1" />);
-    expect(container.firstChild).toBeNull();
-  });
-
-  it("renders null when error", () => {
-    mockGenresQuery({ error: new Error("Failed to load") });
-
-    const { container } = render(<GenreBadge genreId="1" />);
-    expect(container.firstChild).toBeNull();
-  });
-
   it("renders null when genre is not found", () => {
-    mockGenresQuery({
-      data: [
-        { id: "1", name: "Rock" },
-        { id: "2", name: "Pop" },
-      ],
-    });
+    mockGenresQuery([
+      { id: "1", name: "Rock" },
+      { id: "2", name: "Pop" },
+    ]);
 
     const { container } = render(<GenreBadge genreId="999" />);
     expect(container.firstChild).toBeNull();
   });
 
   it("renders with default size", () => {
-    mockGenresQuery({ data: [{ id: "1", name: "Rock" }] });
+    mockGenresQuery([{ id: "1", name: "Rock" }]);
 
     const { container } = render(<GenreBadge genreId="1" />);
     const badge = container.querySelector("div");
@@ -71,7 +47,7 @@ describe("GenreBadge", () => {
   });
 
   it("renders with small size", () => {
-    mockGenresQuery({ data: [{ id: "1", name: "Rock" }] });
+    mockGenresQuery([{ id: "1", name: "Rock" }]);
 
     const { container } = render(<GenreBadge genreId="1" size="sm" />);
     const badge = container.querySelector("div");
@@ -79,7 +55,7 @@ describe("GenreBadge", () => {
   });
 
   it("has correct styling classes", () => {
-    mockGenresQuery({ data: [{ id: "1", name: "Rock" }] });
+    mockGenresQuery([{ id: "1", name: "Rock" }]);
 
     const { container } = render(<GenreBadge genreId="1" />);
     const badge = container.querySelector("div");
@@ -87,13 +63,11 @@ describe("GenreBadge", () => {
   });
 
   it("finds correct genre from multiple genres", () => {
-    mockGenresQuery({
-      data: [
-        { id: "1", name: "Rock" },
-        { id: "2", name: "Pop" },
-        { id: "3", name: "Jazz" },
-      ],
-    });
+    mockGenresQuery([
+      { id: "1", name: "Rock" },
+      { id: "2", name: "Pop" },
+      { id: "3", name: "Jazz" },
+    ]);
 
     render(<GenreBadge genreId="2" />);
     expect(screen.getByText("Pop")).toBeInTheDocument();
@@ -102,7 +76,7 @@ describe("GenreBadge", () => {
   });
 
   it("renders when genres list is empty", () => {
-    mockGenresQuery({ data: [] });
+    mockGenresQuery([]);
 
     const { container } = render(<GenreBadge genreId="1" />);
     expect(container.firstChild).toBeNull();

--- a/src/components/GenreBadge.tsx
+++ b/src/components/GenreBadge.tsx
@@ -7,9 +7,7 @@ interface GenreBadgeProps {
 }
 
 export function GenreBadge({ genreId, size = "default" }: GenreBadgeProps) {
-  const { data: genres = [], isLoading, error } = useGenresQuery();
-
-  if (isLoading || error) return null;
+  const { data: genres } = useGenresQuery();
 
   const genre = genres.find((g) => g.id === genreId);
   if (!genre) return null;

--- a/src/components/GenreBadge.tsx
+++ b/src/components/GenreBadge.tsx
@@ -1,5 +1,6 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
-import { useGenresQuery } from "@/api/genres/useGenres";
+import { genresQuery } from "@/api/genres/useGenres";
 
 interface GenreBadgeProps {
   genreId: string;
@@ -7,7 +8,7 @@ interface GenreBadgeProps {
 }
 
 export function GenreBadge({ genreId, size = "default" }: GenreBadgeProps) {
-  const { data: genres } = useGenresQuery();
+  const { data: genres } = useSuspenseQuery(genresQuery());
 
   const genre = genres.find((g) => g.id === genreId);
   if (!genre) return null;

--- a/src/components/layout/AppHeader/GroupsIndicator.tsx
+++ b/src/components/layout/AppHeader/GroupsIndicator.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { Link } from "@tanstack/react-router";
 import { UserPlus, Users } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -11,22 +12,35 @@ const groupsButtonClassName =
 
 export function GroupsIndicator({ isMobile }: { isMobile: boolean }) {
   const { user } = useAuth();
-  const { activeGroup, hasGroups, isLoading } = useActiveGroup();
 
   if (!user) {
     return null;
   }
 
-  if (isLoading) {
-    return (
-      <Skeleton
-        className={cn(
-          "bg-purple-400/20",
-          isMobile ? "h-9 w-9 rounded-md" : "h-10 w-32 rounded-md",
-        )}
-      />
-    );
-  }
+  return (
+    <Suspense
+      fallback={
+        <Skeleton
+          className={cn(
+            "bg-purple-400/20",
+            isMobile ? "h-9 w-9 rounded-md" : "h-10 w-32 rounded-md",
+          )}
+        />
+      }
+    >
+      <GroupsIndicatorContent isMobile={isMobile} userId={user.id} />
+    </Suspense>
+  );
+}
+
+function GroupsIndicatorContent({
+  isMobile,
+  userId,
+}: {
+  isMobile: boolean;
+  userId: string;
+}) {
+  const { activeGroup, hasGroups } = useActiveGroup(userId);
 
   return (
     <Link to="/groups">
@@ -35,7 +49,11 @@ export function GroupsIndicator({ isMobile }: { isMobile: boolean }) {
           variant="outline"
           size={isMobile ? "sm" : "default"}
           className={groupsButtonClassName}
-          tooltip={activeGroup ? `Active group: ${activeGroup.name}` : "View Your Groups"}
+          tooltip={
+            activeGroup
+              ? `Active group: ${activeGroup.name}`
+              : "View Your Groups"
+          }
           isMobile={isMobile}
           aria-label={isMobile ? activeGroup?.name || "Groups" : undefined}
         >

--- a/src/hooks/useActiveGroup.ts
+++ b/src/hooks/useActiveGroup.ts
@@ -11,9 +11,6 @@ interface ActiveGroupState {
   hasGroups: boolean;
 }
 
-// Only call for a signed-in user - callers should gate rendering on that
-// rather than passing an optional userId, since this suspends until data
-// resolves.
 export function useActiveGroup(userId: string): ActiveGroupState {
   const { profile } = useAuth();
   const { data: groups } = useSuspenseQuery(userGroupsQuery(userId));

--- a/src/hooks/useActiveGroup.ts
+++ b/src/hooks/useActiveGroup.ts
@@ -1,5 +1,6 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUserGroupsQuery } from "@/api/groups/useUserGroups";
+import { userGroupsQuery } from "@/api/groups/useUserGroups";
 import { resolveActiveGroupId } from "@/lib/activeGroup";
 import type { Group } from "@/api/groups/types";
 
@@ -15,7 +16,7 @@ interface ActiveGroupState {
 // resolves.
 export function useActiveGroup(userId: string): ActiveGroupState {
   const { profile } = useAuth();
-  const { data: groups } = useUserGroupsQuery(userId);
+  const { data: groups } = useSuspenseQuery(userGroupsQuery(userId));
 
   const activeGroupId = resolveActiveGroupId({
     profileActiveGroupId: profile?.active_group_id,

--- a/src/hooks/useActiveGroup.ts
+++ b/src/hooks/useActiveGroup.ts
@@ -8,13 +8,14 @@ interface ActiveGroupState {
   activeGroup: Group | undefined;
   groups: Group[];
   hasGroups: boolean;
-  isLoading: boolean;
 }
 
-export function useActiveGroup(): ActiveGroupState {
-  const { user, profile } = useAuth();
-  const groupsQuery = useUserGroupsQuery(user?.id);
-  const groups = groupsQuery.data ?? [];
+// Only call for a signed-in user - callers should gate rendering on that
+// rather than passing an optional userId, since this suspends until data
+// resolves.
+export function useActiveGroup(userId: string): ActiveGroupState {
+  const { profile } = useAuth();
+  const { data: groups } = useUserGroupsQuery(userId);
 
   const activeGroupId = resolveActiveGroupId({
     profileActiveGroupId: profile?.active_group_id,
@@ -26,6 +27,5 @@ export function useActiveGroup(): ActiveGroupState {
     activeGroup: groups.find((group) => group.id === activeGroupId),
     groups,
     hasGroups: groups.length > 0,
-    isLoading: groupsQuery.isLoading,
   };
 }

--- a/src/pages/EditionView/tabs/ArtistsTab/ArtistsTab.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/ArtistsTab.tsx
@@ -1,10 +1,16 @@
+import { useMemo } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { FilterSortControls } from "./filters/FilterSortControls";
 import { useSetFiltering } from "./useSetFiltering";
-import { useUrlState } from "@/hooks/useUrlState";
+import { useUrlState, type FilterSortState } from "@/hooks/useUrlState";
 import { SetsPanel } from "./SetsPanel";
 import { useSetsByEditionQuery } from "@/api/sets/useSetsByEdition";
+import { groupMembersQuery } from "@/api/groups/useGroupMembers";
 import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
+import type { FestivalSet } from "@/api/sets/types";
+
+const EMPTY_GROUP_MEMBER_IDS = new Set<string>();
 
 export function ArtistsTab() {
   const { state: urlState, updateUrlState, clearFilters } = useUrlState();
@@ -13,10 +19,6 @@ export function ArtistsTab() {
   // Fetch sets for the current edition
   const { data: sets = [], isLoading: setsLoading } = useSetsByEditionQuery(
     edition?.id,
-  );
-  const { filteredAndSortedSets, lockCurrentOrder } = useSetFiltering(
-    sets || [],
-    urlState,
   );
 
   if (setsLoading) {
@@ -42,13 +44,91 @@ export function ArtistsTab() {
         />
 
         <div className="mt-8">
-          <SetsPanel
-            sets={filteredAndSortedSets}
-            use24Hour={urlState.use24Hour}
-            onLockSort={() => lockCurrentOrder(updateUrlState)}
+          <FilteredSetsPanel
+            sets={sets}
+            urlState={urlState}
+            updateUrlState={updateUrlState}
           />
         </div>
       </div>
     </>
+  );
+}
+
+interface FilteredSetsPanelProps {
+  sets: FestivalSet[];
+  urlState: FilterSortState;
+  updateUrlState: (updates: Partial<FilterSortState>) => void;
+}
+
+// Gates whether the group-members query is mounted at all, so selecting a
+// group filter for the first time suspends this section rather than
+// requiring a separate loading state.
+function FilteredSetsPanel({
+  sets,
+  urlState,
+  updateUrlState,
+}: FilteredSetsPanelProps) {
+  if (urlState.groupId) {
+    return (
+      <GroupFilteredSetsPanel
+        sets={sets}
+        urlState={urlState}
+        updateUrlState={updateUrlState}
+        groupId={urlState.groupId}
+      />
+    );
+  }
+
+  return (
+    <SetsPanelContent
+      sets={sets}
+      urlState={urlState}
+      updateUrlState={updateUrlState}
+      groupMemberIds={EMPTY_GROUP_MEMBER_IDS}
+    />
+  );
+}
+
+function GroupFilteredSetsPanel({
+  sets,
+  urlState,
+  updateUrlState,
+  groupId,
+}: FilteredSetsPanelProps & { groupId: string }) {
+  const { data: members } = useSuspenseQuery(groupMembersQuery(groupId));
+  const groupMemberIds = useMemo(
+    () => new Set(members.map((member) => member.id)),
+    [members],
+  );
+
+  return (
+    <SetsPanelContent
+      sets={sets}
+      urlState={urlState}
+      updateUrlState={updateUrlState}
+      groupMemberIds={groupMemberIds}
+    />
+  );
+}
+
+function SetsPanelContent({
+  sets,
+  urlState,
+  updateUrlState,
+  groupMemberIds,
+}: FilteredSetsPanelProps & { groupMemberIds: Set<string> }) {
+  const { filteredAndSortedSets, lockCurrentOrder } = useSetFiltering(
+    sets,
+    urlState,
+    groupMemberIds,
+  );
+
+  return (
+    <SetsPanel
+      sets={filteredAndSortedSets}
+      use24Hour={urlState.use24Hour}
+      onLockSort={() => lockCurrentOrder(updateUrlState)}
+    />
   );
 }

--- a/src/pages/EditionView/tabs/ArtistsTab/ArtistsTab.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/ArtistsTab.tsx
@@ -10,8 +10,6 @@ import { useFestivalEdition } from "@/contexts/FestivalEditionContext";
 import { PageTitle } from "@/components/PageTitle/PageTitle";
 import type { FestivalSet } from "@/api/sets/types";
 
-const EMPTY_GROUP_MEMBER_IDS = new Set<string>();
-
 export function ArtistsTab() {
   const { state: urlState, updateUrlState, clearFilters } = useUrlState();
   const { edition, festival } = useFestivalEdition();
@@ -85,7 +83,6 @@ function FilteredSetsPanel({
       sets={sets}
       urlState={urlState}
       updateUrlState={updateUrlState}
-      groupMemberIds={EMPTY_GROUP_MEMBER_IDS}
     />
   );
 }
@@ -116,8 +113,8 @@ function SetsPanelContent({
   sets,
   urlState,
   updateUrlState,
-  groupMemberIds,
-}: FilteredSetsPanelProps & { groupMemberIds: Set<string> }) {
+  groupMemberIds = new Set<string>(),
+}: FilteredSetsPanelProps & { groupMemberIds?: Set<string> }) {
   const { filteredAndSortedSets, lockCurrentOrder } = useSetFiltering(
     sets,
     urlState,

--- a/src/pages/EditionView/tabs/ArtistsTab/filters/GroupFilterDropdown.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/filters/GroupFilterDropdown.tsx
@@ -19,13 +19,32 @@ export function GroupFilterDropdown({
   onGroupChange,
 }: GroupFilterDropdownProps) {
   const { user } = useAuth();
-  const { data: groups = [] } = useUserGroupsQuery(user?.id);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <GroupFilterDropdownContent
+      userId={user.id}
+      selectedGroupId={selectedGroupId}
+      onGroupChange={onGroupChange}
+    />
+  );
+}
+
+function GroupFilterDropdownContent({
+  userId,
+  selectedGroupId,
+  onGroupChange,
+}: GroupFilterDropdownProps & { userId: string }) {
+  const { data: groups } = useUserGroupsQuery(userId);
 
   const hasActiveGroupFilter = selectedGroupId;
   const currentGroup = groups.find((g) => g.id === selectedGroupId);
   const groupDisplayText = currentGroup ? currentGroup.name : "All Votes";
 
-  if (!user || groups.length === 0) {
+  if (groups.length === 0) {
     return null;
   }
 

--- a/src/pages/EditionView/tabs/ArtistsTab/filters/GroupFilterDropdown.tsx
+++ b/src/pages/EditionView/tabs/ArtistsTab/filters/GroupFilterDropdown.tsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -7,7 +8,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Users, ChevronDown } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUserGroupsQuery } from "@/api/groups/useUserGroups";
+import { userGroupsQuery } from "@/api/groups/useUserGroups";
 
 interface GroupFilterDropdownProps {
   selectedGroupId?: string;
@@ -38,7 +39,7 @@ function GroupFilterDropdownContent({
   selectedGroupId,
   onGroupChange,
 }: GroupFilterDropdownProps & { userId: string }) {
-  const { data: groups } = useUserGroupsQuery(userId);
+  const { data: groups } = useSuspenseQuery(userGroupsQuery(userId));
 
   const hasActiveGroupFilter = selectedGroupId;
   const currentGroup = groups.find((g) => g.id === selectedGroupId);

--- a/src/pages/EditionView/tabs/ArtistsTab/useSetFiltering.ts
+++ b/src/pages/EditionView/tabs/ArtistsTab/useSetFiltering.ts
@@ -1,20 +1,12 @@
 import { useEffect, useState, useMemo, useCallback } from "react";
 import type { FilterSortState } from "@/hooks/useUrlState";
 import { FestivalSet } from "@/api/sets/types";
-import { useGroupMembersQuery } from "@/api/groups/useGroupMembers";
 
 export function useSetFiltering(
   sets: FestivalSet[],
   filterSortState: FilterSortState,
+  groupMemberIds: Set<string>,
 ) {
-  const groupMembersQuery = useGroupMembersQuery(
-    filterSortState?.groupId || "",
-  );
-  const groupMemberIds = useMemo(() => {
-    if (!groupMembersQuery.data) return new Set<string>();
-    return new Set(groupMembersQuery.data.map((member) => member.id));
-  }, [groupMembersQuery.data]);
-
   const [lockedOrder, setLockedOrder] = useState<FestivalSet[]>([]);
 
   // Calculate rating for a set based on vote weights

--- a/src/pages/FestivalSelection.tsx
+++ b/src/pages/FestivalSelection.tsx
@@ -19,58 +19,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { AppHeader } from "@/components/layout/AppHeader";
 
 export default function FestivalSelection() {
-  const {
-    data: availableFestivals = [],
-    isLoading: festivalsLoading,
-    isError: festivalsError,
-    refetch,
-  } = useFestivalsQuery();
-
-  function handleRetry() {
-    refetch();
-  }
-
-  if (festivalsLoading) {
-    return (
-      <div className="min-h-screen bg-app-gradient flex items-center justify-center">
-        <div className="text-white text-xl">Loading festivals...</div>
-      </div>
-    );
-  }
-
-  if (festivalsError) {
-    return (
-      <div className="min-h-screen bg-app-gradient">
-        <div className="container mx-auto px-4 py-8">
-          <PageTitle title="Select Festival" />
-          <TopBar showGroupsButton />
-
-          <div className="flex items-center justify-center mt-16">
-            <Card className="w-full max-w-md bg-white/10 border-purple-400/30">
-              <CardHeader className="text-center">
-                <Music className="h-16 w-16 mx-auto text-red-400 mb-4" />
-                <CardTitle className="text-white">
-                  Couldn't Load Festivals
-                </CardTitle>
-                <CardDescription className="text-purple-200">
-                  There was an error loading the festivals. Please check your
-                  connection and try again.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="flex justify-center">
-                <button
-                  onClick={handleRetry}
-                  className="px-6 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
-                >
-                  Retry
-                </button>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const { data: availableFestivals } = useFestivalsQuery();
 
   if (availableFestivals.length === 0) {
     return (

--- a/src/pages/FestivalSelection.tsx
+++ b/src/pages/FestivalSelection.tsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Music, GlobeIcon } from "lucide-react";
 import {
   Card,
@@ -6,7 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { useFestivalsQuery } from "@/api/festivals/useFestivals";
+import { festivalsQuery } from "@/api/festivals/useFestivals";
 import { Festival } from "@/api/festivals/types";
 import {
   createFestivalSubdomainUrl,
@@ -19,7 +20,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { AppHeader } from "@/components/layout/AppHeader";
 
 export default function FestivalSelection() {
-  const { data: availableFestivals } = useFestivalsQuery();
+  const { data: availableFestivals } = useSuspenseQuery(festivalsQuery());
 
   if (availableFestivals.length === 0) {
     return (

--- a/src/pages/SetDetails/SetGroupVoting.tsx
+++ b/src/pages/SetDetails/SetGroupVoting.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
@@ -9,7 +10,7 @@ import {
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUserGroupsQuery } from "@/api/groups/useUserGroups";
+import { userGroupsQuery } from "@/api/groups/useUserGroups";
 import { useGroupVotesQuery } from "@/api/voting/useGroupVotes";
 import { Users } from "lucide-react";
 import { VOTE_CONFIG, VOTES_TYPES, getVoteConfig } from "@/lib/voteConfig";
@@ -36,7 +37,7 @@ function SetGroupVotingContent({
   artistId: string;
   userId: string;
 }) {
-  const { data: groups } = useUserGroupsQuery(userId);
+  const { data: groups } = useSuspenseQuery(userGroupsQuery(userId));
   const [selectedGroupId, setSelectedGroupId] = useState<string>("");
 
   // Set default group when groups load

--- a/src/pages/SetDetails/SetGroupVoting.tsx
+++ b/src/pages/SetDetails/SetGroupVoting.tsx
@@ -21,7 +21,22 @@ interface SetGroupVotingProps {
 
 export function SetGroupVoting({ setId: artistId }: SetGroupVotingProps) {
   const { user } = useAuth();
-  const { data: groups = [] } = useUserGroupsQuery(user?.id);
+
+  if (!user) {
+    return null;
+  }
+
+  return <SetGroupVotingContent artistId={artistId} userId={user.id} />;
+}
+
+function SetGroupVotingContent({
+  artistId,
+  userId,
+}: {
+  artistId: string;
+  userId: string;
+}) {
+  const { data: groups } = useUserGroupsQuery(userId);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("");
 
   // Set default group when groups load
@@ -38,7 +53,7 @@ export function SetGroupVoting({ setId: artistId }: SetGroupVotingProps) {
   );
 
   // Don't show if user has no groups
-  if (!user || groups.length === 0) {
+  if (groups.length === 0) {
     return null;
   }
 

--- a/src/pages/admin/ArtistsManagement/AddArtistDialog.tsx
+++ b/src/pages/admin/ArtistsManagement/AddArtistDialog.tsx
@@ -62,7 +62,7 @@ export function AddArtistDialog({
   const [logoFile, setLogoFile] = useState<File | null>(null);
 
   // React Query hooks
-  const { data: genres = [], isLoading: isLoadingGenres } = useGenresQuery();
+  const { data: genres } = useGenresQuery();
   const createArtistMutation = useCreateArtistMutation();
   const updateArtistMutation = useUpdateArtistMutation();
 
@@ -185,12 +185,7 @@ export function AddArtistDialog({
                       genres={genres}
                       value={field.value || []}
                       onValueChange={field.onChange}
-                      placeholder={
-                        isLoadingGenres
-                          ? "Loading genres..."
-                          : "Select genres..."
-                      }
-                      disabled={isLoadingGenres}
+                      placeholder="Select genres..."
                     />
                   </FormControl>
                   <FormMessage />
@@ -264,9 +259,7 @@ export function AddArtistDialog({
               type="submit"
               className="w-full"
               disabled={
-                createArtistMutation.isPending ||
-                updateArtistMutation.isPending ||
-                isLoadingGenres
+                createArtistMutation.isPending || updateArtistMutation.isPending
               }
             >
               {createArtistMutation.isPending || updateArtistMutation.isPending

--- a/src/pages/admin/ArtistsManagement/AddArtistDialog.tsx
+++ b/src/pages/admin/ArtistsManagement/AddArtistDialog.tsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -23,7 +24,7 @@ import {
 import { Music } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserPermissionsQuery } from "@/api/auth/useUserPermissions";
-import { useGenresQuery } from "@/api/genres/useGenres";
+import { genresQuery } from "@/api/genres/useGenres";
 import { useCreateArtistMutation } from "@/api/artists/useCreateArtist";
 import { useUpdateArtistMutation } from "@/api/artists/useUpdateArtist";
 import { GenreMultiSelect } from "./GenreMultiSelect";
@@ -62,7 +63,7 @@ export function AddArtistDialog({
   const [logoFile, setLogoFile] = useState<File | null>(null);
 
   // React Query hooks
-  const { data: genres } = useGenresQuery();
+  const { data: genres } = useSuspenseQuery(genresQuery());
   const createArtistMutation = useCreateArtistMutation();
   const updateArtistMutation = useUpdateArtistMutation();
 

--- a/src/pages/admin/ArtistsManagement/BulkEditor/GenresCell.tsx
+++ b/src/pages/admin/ArtistsManagement/BulkEditor/GenresCell.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { GenreMultiSelect } from "../GenreMultiSelect";
-import { useGenresQuery } from "@/api/genres/useGenres";
+import { genresQuery } from "@/api/genres/useGenres";
 import { Check, X } from "lucide-react";
 
 interface GenresCellProps {
@@ -13,7 +14,7 @@ export function GenresCell({ value, onSave }: GenresCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [genreIds, setGenreIds] = useState<string[]>([]);
 
-  const { data: genres = [] } = useGenresQuery();
+  const { data: genres } = useSuspenseQuery(genresQuery());
 
   function handleEdit() {
     const currentGenreIds = value || [];

--- a/src/pages/admin/festivals/FestivalManagementTable.tsx
+++ b/src/pages/admin/festivals/FestivalManagementTable.tsx
@@ -10,8 +10,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Loader2, Edit2, Trash2, Image as ImageIcon } from "lucide-react";
+import { Edit2, Trash2, Image as ImageIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FestivalLogoDialog } from "./FestivalLogoDialog";
 import { useState } from "react";
@@ -25,12 +24,7 @@ export function FestivalManagementTable({
   onSelect: (festival: Festival) => void;
   selected: string;
 }) {
-  const {
-    data: festivals = [],
-    isLoading,
-    isError,
-    refetch,
-  } = useFestivalsQuery({ all: true });
+  const { data: festivals } = useFestivalsQuery({ all: true });
   const deleteFestivalMutation = useDeleteFestivalMutation();
 
   const [logoDialogOpen, setLogoDialogOpen] = useState(false);
@@ -52,38 +46,6 @@ export function FestivalManagementTable({
   function handleLogoManagement(festival: Festival) {
     setSelectedFestivalForLogo(festival);
     setLogoDialogOpen(true);
-  }
-
-  if (isLoading) {
-    return (
-      <Card>
-        <CardContent className="flex items-center justify-center p-8">
-          <Loader2 className="h-6 w-6 animate-spin mr-2" />
-          <span>Loading festivals...</span>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  if (isError) {
-    return (
-      <Card>
-        <CardContent className="flex flex-col items-center justify-center p-8 gap-4">
-          <div className="text-center">
-            <p className="text-red-600 font-medium mb-2">
-              Error Loading Festivals
-            </p>
-            <p className="text-sm text-gray-600">
-              There was an error loading the festivals. Please check your
-              connection and try again.
-            </p>
-          </div>
-          <Button onClick={() => refetch()} variant="outline">
-            Retry
-          </Button>
-        </CardContent>
-      </Card>
-    );
   }
 
   return (

--- a/src/pages/admin/festivals/FestivalManagementTable.tsx
+++ b/src/pages/admin/festivals/FestivalManagementTable.tsx
@@ -1,4 +1,5 @@
-import { useFestivalsQuery } from "@/api/festivals/useFestivals";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { festivalsQuery } from "@/api/festivals/useFestivals";
 import { useDeleteFestivalMutation } from "@/api/festivals/useDeleteFestival";
 import { Festival } from "@/api/festivals/types";
 import {
@@ -24,7 +25,7 @@ export function FestivalManagementTable({
   onSelect: (festival: Festival) => void;
   selected: string;
 }) {
-  const { data: festivals } = useFestivalsQuery({ all: true });
+  const { data: festivals } = useSuspenseQuery(festivalsQuery({ all: true }));
   const deleteFestivalMutation = useDeleteFestivalMutation();
 
   const [logoDialogOpen, setLogoDialogOpen] = useState(false);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -25,6 +25,7 @@ import { z } from "zod";
 import type { QueryClient } from "@tanstack/react-query";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
+import { userGroupsQuery } from "@/api/groups/useUserGroups";
 
 const rootSearchSchema = z.object({
   invite: z.string().optional(),
@@ -43,6 +44,13 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       data: { session },
     } = await supabase.auth.getSession();
     return { user: session?.user ?? null };
+  },
+  loader: async ({ context }) => {
+    if (context.user) {
+      void context.queryClient.ensureQueryData(
+        userGroupsQuery(context.user.id, { all: false }),
+      );
+    }
   },
 });
 

--- a/src/routes/admin/artists.tsx
+++ b/src/routes/admin/artists.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ArtistBulkEditor } from "@/pages/admin/ArtistsManagement/ArtistBulkEditor";
+import { genresQuery } from "@/api/genres/useGenres";
 
 export const Route = createFileRoute("/admin/artists")({
   component: ArtistBulkEditor,
+  loader: async ({ context }) => {
+    void context.queryClient.ensureQueryData(genresQuery());
+  },
 });

--- a/src/routes/admin/artists/duplicates.tsx
+++ b/src/routes/admin/artists/duplicates.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { DuplicateArtistsPage } from "@/pages/admin/ArtistsManagement/DuplicateArtistsPage";
+import { genresQuery } from "@/api/genres/useGenres";
 
 export const Route = createFileRoute("/admin/artists/duplicates")({
   component: DuplicateArtistsPage,
+  loader: async ({ context }) => {
+    void context.queryClient.ensureQueryData(genresQuery());
+  },
 });

--- a/src/routes/admin/festivals.tsx
+++ b/src/routes/admin/festivals.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import AdminFestivals from "@/pages/admin/festivals/AdminFestivals";
+import { festivalsQuery } from "@/api/festivals/useFestivals";
 
 export const Route = createFileRoute("/admin/festivals")({
   component: AdminFestivals,
+  loader: async ({ context }) => {
+    void context.queryClient.ensureQueryData(festivalsQuery({ all: true }));
+  },
 });

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/$setSlug.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/$setSlug.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/searchSchemas";
 import { setBySlugQuery } from "@/api/sets/useSetBySlug";
 import { artistNotesQuery } from "@/api/artist-notes/useArtistNotes";
+import { genresQuery } from "@/api/genres/useGenres";
 
 export const Route = createFileRoute(
   "/festivals/$festivalSlug/editions/$editionSlug/sets/$setSlug",
@@ -16,6 +17,7 @@ export const Route = createFileRoute(
     middlewares: [stripSearchParams(filterSortSearchDefaults)],
   },
   loader: async ({ params, context }) => {
+    void context.queryClient.ensureQueryData(genresQuery());
     const set = await context.queryClient.ensureQueryData(
       setBySlugQuery(params.setSlug, context.edition.id),
     );

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/index.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/index.tsx
@@ -5,6 +5,7 @@ import {
   filterSortSearchSchema,
 } from "@/lib/searchSchemas";
 import { genresQuery } from "@/api/genres/useGenres";
+import { groupMembersQuery } from "@/api/groups/useGroupMembers";
 
 export const Route = createFileRoute(
   "/festivals/$festivalSlug/editions/$editionSlug/sets/",
@@ -14,7 +15,11 @@ export const Route = createFileRoute(
   search: {
     middlewares: [stripSearchParams(filterSortSearchDefaults)],
   },
-  loader: async ({ context }) => {
+  loaderDeps: ({ search }) => ({ groupId: search.groupId }),
+  loader: async ({ context, deps }) => {
     void context.queryClient.ensureQueryData(genresQuery());
+    if (deps.groupId) {
+      void context.queryClient.ensureQueryData(groupMembersQuery(deps.groupId));
+    }
   },
 });


### PR DESCRIPTION
Converts useGroupMembersQuery, useUserGroupsQuery, useFestivalsQuery, and useGenresQuery to useSuspenseQuery, adding route-loader prefetches wherever each is consumed (root shell, sets index/detail, admin artists/festivals routes) so no call site is left with an unhandled loading/error state (closes #109).

## Verification
- Sign in, load `/` and `/festivals/:slug`; festival lists and header groups indicator render without a stray spinner.
- Deep-link directly to `/festivals/:slug/editions/:slug/sets?groupId=<id>`; the group filter resolves without error.
- Pick a group filter for the first time on the sets list; that section suspends briefly instead of showing a separate spinner.
- Open `/admin/artists`, `/admin/artists/duplicates`, and `/admin/festivals`; genre/festival data loads without a manual loading branch.
- `pnpm test` and `pnpm run lint` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zPmjZr8QrriCzLUgdGUt9)_