### PR TITLE
fix(e2e): scope schedule filter selectors to day region

### DIFF
--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -68,10 +68,10 @@ test.describe("My-vote chips", () => {
       .click();
 
     // Below md the chips live inside the filter sheet, not the toolbar.
-    let chips = page.getByRole("group", { name: "Filter by my vote" });
+    let chips = page.getByRole("group", { name: "Filter by my vote" }).first();
     const inSheet = !(await chips.isVisible());
     if (inSheet) {
-      await page.getByTestId("schedule-filters-trigger").click();
+      await page.getByTestId("schedule-filters-trigger").first().click();
       chips = page.getByRole("dialog").getByRole("group", {
         name: "Filter by my vote",
       });

--- a/tests/e2e/schedule-vote-chips.spec.ts
+++ b/tests/e2e/schedule-vote-chips.spec.ts
@@ -68,10 +68,14 @@ test.describe("My-vote chips", () => {
       .click();
 
     // Below md the chips live inside the filter sheet, not the toolbar.
-    let chips = page.getByRole("group", { name: "Filter by my vote" }).first();
+    const dayGroups = page.getByRole("region");
+    const firstDayGroup = dayGroups.first();
+
+    let chips = firstDayGroup.getByRole("group", { name: "Filter by my vote" });
     const inSheet = !(await chips.isVisible());
     if (inSheet) {
-      await page.getByTestId("schedule-filters-trigger").first().click();
+      const filterButton = firstDayGroup.getByRole("button", { name: "Filters" });
+      await filterButton.click();
       chips = page.getByRole("dialog").getByRole("group", {
         name: "Filter by my vote",
       });


### PR DESCRIPTION
Scoped filter chip and trigger selectors in schedule-vote-chips test to a specific day region instead of matching ambiguously across all days. Playwright strict mode was failing because selectors resolved to 3 elements (one per day region). Also changed filter button selector from getByTestId to getByRole("button", { name: "Filters" }) to match the actual DOM structure.

## Verification
- Navigate to `/festivals/test/editions/2025/schedule/list` on a mobile viewport
- Vote "Must Go" on one set and "Interested" on another
- Click the Filters button in any day header
- Verify the filter sheet opens and chips are visible
- Click "Must Go" and "Interested" to filter the schedule
- Verify both sets remain visible and unvoted sets are hidden
- Close the sheet and verify the badge shows "2" active filters
- Repeat on desktop viewport (chips in toolbar instead of sheet)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEfredM6LSxGPT8RuXF4iu)_