### PR TITLE
ci(deno): run commit-schedule tests for real

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,11 +73,6 @@ jobs:
 
       - name: Run Deno tests for Edge Functions
         env:
-          # commit-schedule's tests are integration tests against the real
-          # RPC; without these they silently no-op (see skipIfNoEnv in the
-          # test file). Fixed local Supabase demo credentials from `supabase
-          # start` — not a secret, and only reachable on this runner's
-          # 127.0.0.1.
           SUPABASE_URL: http://127.0.0.1:54321
           SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,11 +47,6 @@ jobs:
     name: Run Edge Function Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      # commit-schedule's tests are integration tests against the real RPC;
-      # without these they silently no-op (see skipIfNoEnv in the test file).
-      SUPABASE_URL: http://127.0.0.1:54321
-      SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
 
     steps:
       - uses: actions/checkout@v5
@@ -77,6 +72,14 @@ jobs:
           npx supabase db reset
 
       - name: Run Deno tests for Edge Functions
+        env:
+          # commit-schedule's tests are integration tests against the real
+          # RPC; without these they silently no-op (see skipIfNoEnv in the
+          # test file). Fixed local Supabase demo credentials from `supabase
+          # start` — not a secret, and only reachable on this runner's
+          # 127.0.0.1.
+          SUPABASE_URL: http://127.0.0.1:54321
+          SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
         run: |
           set -e
           for fn in supabase/functions/*/; do

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,14 +46,35 @@ jobs:
   deno-test:
     name: Run Edge Function Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    env:
+      # commit-schedule's tests are integration tests against the real RPC;
+      # without these they silently no-op (see skipIfNoEnv in the test file).
+      SUPABASE_URL: http://127.0.0.1:54321
+      SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
 
     steps:
       - uses: actions/checkout@v5
 
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+
+      - name: Setup Supabase
+        run: |
+          npx supabase start
+          sleep 10
+          npx supabase db reset
 
       - name: Run Deno tests for Edge Functions
         run: |

--- a/supabase/functions/commit-schedule/commit-schedule.test.ts
+++ b/supabase/functions/commit-schedule/commit-schedule.test.ts
@@ -11,16 +11,6 @@ import { createClient } from "npm:@supabase/supabase-js@2.57.4";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
-function skipIfNoEnv() {
-  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-    console.warn(
-      "Skipping integration tests: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set",
-    );
-    return true;
-  }
-  return false;
-}
-
 function adminClient() {
   return createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
 }
@@ -50,7 +40,6 @@ async function getTestUserId(
 }
 
 Deno.test("commit_schedule: creates new artist and set", async () => {
-  if (skipIfNoEnv()) return;
   const db = adminClient();
   const editionId = await getTestEditionId(db);
   const userId = await getTestUserId(db);
@@ -92,7 +81,6 @@ Deno.test("commit_schedule: creates new artist and set", async () => {
 Deno.test(
   "commit_schedule: updates existing set without creating duplicate",
   async () => {
-    if (skipIfNoEnv()) return;
     const db = adminClient();
     const editionId = await getTestEditionId(db);
     const userId = await getTestUserId(db);
@@ -159,7 +147,6 @@ Deno.test(
 );
 
 Deno.test("commit_schedule: archives orphaned sets", async () => {
-  if (skipIfNoEnv()) return;
   const db = adminClient();
   const editionId = await getTestEditionId(db);
   const userId = await getTestUserId(db);
@@ -202,7 +189,6 @@ Deno.test("commit_schedule: archives orphaned sets", async () => {
 Deno.test(
   "commit_schedule: midnight-crossing times stored correctly",
   async () => {
-    if (skipIfNoEnv()) return;
     const db = adminClient();
     const editionId = await getTestEditionId(db);
     const userId = await getTestUserId(db);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -57,6 +57,15 @@ INSERT INTO auth.identities (
   now()
 ) ON CONFLICT (id) DO NOTHING;
 
+-- Grants the seeded user an admin role so admin-only integration tests
+-- (e.g. commit-schedule's Deno tests) have a real admin user id to act as.
+INSERT INTO public.admin_roles (user_id, role, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'admin',
+  '11111111-1111-1111-1111-111111111111'
+) ON CONFLICT (user_id, role) DO NOTHING;
+
 
 
 -- Insert festival artists with realistic schedule (July 12-14, 2025)


### PR DESCRIPTION
The deno-test job never set `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` or started Supabase, so `commit-schedule.test.ts`'s 4 tests hit `skipIfNoEnv()` and reported green without running.
Starts Supabase and resets the DB in that job, same as the e2e jobs do, and seeds an `admin_roles` row for the fixed test user so `getTestUserId()` has a real admin to act as.

## Verification
- Open the "Run Edge Function Tests" job on this PR and confirm `commit_schedule: ...` tests execute (not skipped) and pass.
- Confirm `diff-schedule`'s tests still pass unaffected — they don't read the new env vars.
- Break the RPC (e.g. comment out a line in `commit_schedule__create_sets`) locally against `supabase start` and confirm the corresponding test fails.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC47NFpGZS7E7BHfTsLAyd)_