### PR TITLE
fix(routes): address Copilot review feedback from PR #271

### DIFF
--- a/src/lib/constants/legal.ts
+++ b/src/lib/constants/legal.ts
@@ -1,0 +1,1 @@
+export const LEGAL_DOCS_LAST_UPDATED = "July 8, 2025";

--- a/src/routes/cookies.tsx
+++ b/src/routes/cookies.tsx
@@ -3,6 +3,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { Link } from "@tanstack/react-router";
+import { LEGAL_DOCS_LAST_UPDATED } from "@/lib/constants/legal";
 
 export const Route = createFileRoute("/cookies")({
   component: CookiePolicy,
@@ -24,7 +25,7 @@ function CookiePolicy() {
             </Button>
             <h1 className="text-3xl font-bold mb-2">Cookie Policy</h1>
             <p className="text-muted-foreground">
-              Last updated: {new Date().toLocaleDateString()}
+              Last updated: {LEGAL_DOCS_LAST_UPDATED}
             </p>
           </div>
 

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/explore.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/explore.tsx
@@ -89,7 +89,7 @@ function ExploreSetPage() {
     </div>
   );
 
-  async function handleVote(voteType: number) {
+  function handleVote(voteType: number) {
     if (!currentSet || isAnimating) return;
 
     if (!user) {
@@ -101,31 +101,35 @@ function ExploreSetPage() {
 
     setIsAnimating(true);
 
-    try {
-      await voteMutation.mutateAsync({
+    voteMutation.mutate(
+      {
         setId: currentSet.id,
         voteType,
         userId: user.id,
         existingVote,
-      });
+      },
+      {
+        onSuccess: () => {
+          setDirection(voteType >= 1 ? "right" : "left");
 
-      setDirection(voteType >= 1 ? "right" : "left");
-
-      setTimeout(() => {
-        if (isLastSet) {
-          navigate({
-            from: "/festivals/$festivalSlug/editions/$editionSlug/explore",
-            to: "../sets",
-          });
-        } else {
-          setDirection(null);
-        }
-        setIsAnimating(false);
-      }, 300);
-    } catch (error) {
-      console.error("Failed to vote:", error);
-      setIsAnimating(false);
-    }
+          setTimeout(() => {
+            if (isLastSet) {
+              navigate({
+                from: "/festivals/$festivalSlug/editions/$editionSlug/explore",
+                to: "../sets",
+              });
+            } else {
+              setDirection(null);
+            }
+            setIsAnimating(false);
+          }, 300);
+        },
+        onError: (error) => {
+          console.error("Failed to vote:", error);
+          setIsAnimating(false);
+        },
+      },
+    );
   }
 
   function handleSwipe(direction: "left" | "right") {

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/index.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/sets/index.tsx
@@ -118,7 +118,7 @@ function GroupFilteredSetsPanel({
 }: FilteredSetsPanelProps & { groupId: string }) {
   const { data: members } = useSuspenseQuery(groupMembersQuery(groupId));
   const groupMemberIds = useMemo(
-    () => new Set(members.map((member) => member.id)),
+    () => new Set(members.map((member) => member.user_id)),
     [members],
   );
 

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/social.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/social.tsx
@@ -57,6 +57,7 @@ function SocialTab() {
 
               <div className="relative">
                 <iframe
+                  title="Facebook page timeline"
                   src={`https://www.facebook.com/plugins/page.php?href=${encodeURIComponent(facebook_url)}&tabs=timeline&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId=1064955115428877`}
                   width="100%"
                   height="500"

--- a/src/routes/festivals/$festivalSlug/index.tsx
+++ b/src/routes/festivals/$festivalSlug/index.tsx
@@ -194,8 +194,11 @@ function EditionSelection() {
                       )}
                     </div>
 
-                    <Button className="w-full mt-4 bg-purple-600 hover:bg-purple-700 text-white border-purple-600">
-                      Select Edition
+                    <Button
+                      asChild
+                      className="w-full mt-4 bg-purple-600 hover:bg-purple-700 text-white border-purple-600"
+                    >
+                      <span>Select Edition</span>
                     </Button>
                   </CardContent>
                 </Card>

--- a/src/routes/festivals/$festivalSlug/index.tsx
+++ b/src/routes/festivals/$festivalSlug/index.tsx
@@ -194,11 +194,9 @@ function EditionSelection() {
                       )}
                     </div>
 
-                    <Link to={linkPath}>
-                      <Button className="w-full mt-4 bg-purple-600 hover:bg-purple-700 text-white border-purple-600">
-                        Select Edition
-                      </Button>
-                    </Link>
+                    <Button className="w-full mt-4 bg-purple-600 hover:bg-purple-700 text-white border-purple-600">
+                      Select Edition
+                    </Button>
                   </CardContent>
                 </Card>
               </Link>

--- a/src/routes/festivals/$festivalSlug/index.tsx
+++ b/src/routes/festivals/$festivalSlug/index.tsx
@@ -126,11 +126,8 @@ function EditionSelection() {
             const linkPath = `/festivals/${festival.slug}/editions/${edition.slug}`;
 
             return (
-              <Link key={festival.id} to={linkPath} className="block">
-                <Card
-                  key={edition.id}
-                  className="bg-white/10 border-purple-400/30 hover:bg-white/15 transition-all duration-300 cursor-pointer group"
-                >
+              <Link key={edition.id} to={linkPath} className="block">
+                <Card className="bg-white/10 border-purple-400/30 hover:bg-white/15 transition-all duration-300 cursor-pointer group">
                   <CardHeader>
                     <div className="flex items-start justify-between">
                       <div className="flex-1">

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -3,6 +3,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { Link } from "@tanstack/react-router";
+import { LEGAL_DOCS_LAST_UPDATED } from "@/lib/constants/legal";
 
 export const Route = createFileRoute("/privacy")({
   component: PrivacyPolicy,
@@ -24,7 +25,7 @@ function PrivacyPolicy() {
             </Button>
             <h1 className="text-3xl font-bold mb-2">Privacy Policy</h1>
             <p className="text-muted-foreground">
-              Last updated: {new Date().toLocaleDateString()}
+              Last updated: {LEGAL_DOCS_LAST_UPDATED}
             </p>
           </div>
 

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -3,6 +3,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { Link } from "@tanstack/react-router";
+import { LEGAL_DOCS_LAST_UPDATED } from "@/lib/constants/legal";
 
 export const Route = createFileRoute("/terms")({
   component: TermsOfService,
@@ -24,7 +25,7 @@ function TermsOfService() {
             </Button>
             <h1 className="text-3xl font-bold mb-2">Terms of Service</h1>
             <p className="text-muted-foreground">
-              Last updated: {new Date().toLocaleDateString()}
+              Last updated: {LEGAL_DOCS_LAST_UPDATED}
             </p>
           </div>
 


### PR DESCRIPTION
Fixes 6 issues Copilot flagged on PR #271's route inlining: broken group vote filtering, a nested link, a duplicate list key, a stale iframe title, dynamic "last updated" dates on legal pages, and a `mutateAsync`/try-catch pattern replaced with the repo's preferred `mutate` callback style.

## Verification
- Open a festival with multiple editions; each card links correctly and no console warnings about duplicate keys appear.
- Click the "Select Edition" button; confirm no nested-link console warning and navigation still works.
- On an edition's sets page, filter by a group; confirm votes are now correctly filtered by group members.
- Visit `/terms`, `/privacy`, `/cookies`; "Last updated" shows a fixed date (July 8, 2025) instead of today's date.
- Visit the Social tab for a festival with a Facebook page configured; inspect the iframe and confirm it has a `title` attribute.
- On the Explore tab, cast a vote; confirm the card animates and advances as before, and an error is still handled gracefully (e.g. offline).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzuMRJPmN2NqE9GRdD2VBQ)_