### PR TITLE
fix(router): exempt top-level routes from festival subdomain rewrite

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,7 +25,7 @@ const queryClient = new QueryClient({
 const reservedTopLevelSegments = new Set(
   Object.values(routeTree.children ?? {})
     .map((route) => route.fullPath.split("/")[1] ?? "")
-    .filter((segment) => segment !== "festivals"),
+    .filter((segment) => segment !== "festivals" && segment !== ""),
 );
 
 const router = createRouter({

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,7 +24,7 @@ const queryClient = new QueryClient({
 
 const reservedTopLevelSegments = new Set(
   Object.values(routeTree.children ?? {})
-    .map((route) => route.fullPath.split("/")[1] ?? "")
+    .map((route) => route.options.path.split("/")[1] ?? "")
     .filter((segment) => segment !== "festivals" && segment !== ""),
 );
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,12 @@ const queryClient = new QueryClient({
   },
 });
 
+const reservedTopLevelSegments = new Set(
+  Object.values(routeTree.children ?? {})
+    .map((route) => route.fullPath.split("/")[1] ?? "")
+    .filter((segment) => segment !== "festivals"),
+);
+
 const router = createRouter({
   routeTree,
   context: {
@@ -43,6 +49,9 @@ const router = createRouter({
 
       const [subdomain] = parts;
       if (subdomain === "www") return url;
+
+      const firstSegment = url.pathname.split("/")[1] ?? "";
+      if (reservedTopLevelSegments.has(firstSegment)) return url;
 
       url.pathname = `/festivals/${subdomain}${url.pathname}`;
       return url;


### PR DESCRIPTION
Fixes the subdomain rewrite unconditionally prefixing every path with `/festivals/<slug>`, which broke `/admin` and other top-level routes on festival subdomains. The exempted segment set is derived from `routeTree`'s root children, so new top-level routes stay exempt automatically.

Closes #270

## Verification
- Visit `<festival-slug>.getupline.com/admin` — resolves to the admin panel instead of a not-found page.
- Visit `<festival-slug>.getupline.com/cookies`, `/privacy`, `/terms`, `/groups` — still resolve normally.
- Visit `<festival-slug>.getupline.com/festivals/<slug>/...` (festival-scoped pages) — still rewritten/resolved as before.
- Visit `www.getupline.com` and localhost — unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DajuRQNDF3W5nkhdksn9Lw)_