### PR TITLE
fix(ci): fix nightly notify script and stages e2e assertion

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -38,8 +38,9 @@ jobs:
     permissions:
       issues: write
     steps:
+      - uses: actions/checkout@v5
       - name: Report nightly failure as a GitHub issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const script = require('./.github/scripts/notify-nightly-failure.js');

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,6 +90,20 @@ per-process email (`generateTestEmail()`) so parallel workers never race over
 the same Mailpit inbox or OTP code. New accounts get the onboarding dialog's
 username step auto-completed so it doesn't block later interactions.
 
+### Smoke tests
+
+`test.describe` blocks tagged `{ tag: "@smoke" }` run on every push/PR to
+`main` via `.github/workflows/e2e-smoke.yml` (`--grep @smoke`, chromium only).
+The full suite otherwise only runs nightly or on PRs labeled `full-e2e`, so
+smoke is most contributors' fast feedback loop — keep it there.
+
+Tag a `describe` block `@smoke` when it's cheap to run on every PR: no
+`signIn()` per test (the OTP flow polls Mailpit and dominates suite runtime),
+or a single shared `signIn()` in `beforeAll` amortized across serial tests
+(see `voting.spec.ts` / `rating.spec.ts`). Avoid tagging files that call
+`signIn()` per test with only one or two tests in the file — the OTP cost
+isn't amortized and isn't worth paying on every PR.
+
 ### Test Data
 
 The test data setup script creates:

--- a/tests/e2e/cookie-consent.spec.ts
+++ b/tests/e2e/cookie-consent.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 const CONSENT_KEY = "gdpr-consent";
 
-test.describe("Cookie consent banner", () => {
+test.describe("Cookie consent banner", { tag: "@smoke" }, () => {
   test("appears on a fresh visit with no stored consent", async ({ page }) => {
     await page.goto("/");
 

--- a/tests/e2e/mobile-bottom-nav-autohide.spec.ts
+++ b/tests/e2e/mobile-bottom-nav-autohide.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, Page } from "@playwright/test";
 // Seeded in supabase/seed.sql: festival slug "test", edition slug "2025".
 const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 
-test.describe("Mobile bottom tab bar auto-hide", () => {
+test.describe("Mobile bottom tab bar auto-hide", { tag: "@smoke" }, () => {
   test("hides on scroll down and returns on scroll up", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto(LIST_PATH);

--- a/tests/e2e/rating.spec.ts
+++ b/tests/e2e/rating.spec.ts
@@ -15,102 +15,106 @@ const EDITION_SETS_PATH = "/festivals/post-test/editions/2025/sets";
 
 // Each scenario below targets a distinct seeded set so that parallel runs
 // never race over the same set_ratings row.
-test.describe("Rating a set in the Post-Festival phase", () => {
-  test.describe.configure({ mode: "serial" });
+test.describe(
+  "Rating a set in the Post-Festival phase",
+  { tag: "@smoke" },
+  () => {
+    test.describe.configure({ mode: "serial" });
 
-  let context: BrowserContext;
-  let page: Page;
+    let context: BrowserContext;
+    let page: Page;
 
-  test.beforeAll(async ({ browser, baseURL, storageState }) => {
-    context = await browser.newContext({ baseURL, storageState });
-    page = await context.newPage();
-    await signIn(page);
-  });
+    test.beforeAll(async ({ browser, baseURL, storageState }) => {
+      context = await browser.newContext({ baseURL, storageState });
+      page = await context.newPage();
+      await signIn(page);
+    });
 
-  test.afterAll(async () => {
-    await context.close();
-  });
+    test.afterAll(async () => {
+      await context.close();
+    });
 
-  test("shows the Post-Festival rating UI instead of the voting UI", async () => {
-    await page.goto(EDITION_SETS_PATH);
+    test("shows the Post-Festival rating UI instead of the voting UI", async () => {
+      await page.goto(EDITION_SETS_PATH);
 
-    const setCard = page
-      .getByTestId("artist-item")
-      .filter({ hasText: "Maya Jane Coles" });
-    await expect(ratingButton(setCard, "loved")).toBeVisible();
-    await expect(setCard.locator('button[aria-label="Must Go"]')).toHaveCount(
-      0,
-    );
-  });
+      const setCard = page
+        .getByTestId("artist-item")
+        .filter({ hasText: "Maya Jane Coles" });
+      await expect(ratingButton(setCard, "loved")).toBeVisible();
+      await expect(setCard.locator('button[aria-label="Must Go"]')).toHaveCount(
+        0,
+      );
+    });
 
-  test("rates a set Loved it and reflects the selected state", async () => {
-    const setCard = await goToSet(page, "Maya Jane Coles");
-    const loved = ratingButton(setCard, "loved");
+    test("rates a set Loved it and reflects the selected state", async () => {
+      const setCard = await goToSet(page, "Maya Jane Coles");
+      const loved = ratingButton(setCard, "loved");
 
-    await loved.click();
+      await loved.click();
 
-    await expect(loved).toHaveAttribute("aria-pressed", "true");
-    await expect(ratingButton(setCard, "liked")).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
-    await expect(ratingButton(setCard, "meh")).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
-  });
+      await expect(loved).toHaveAttribute("aria-pressed", "true");
+      await expect(ratingButton(setCard, "liked")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+      await expect(ratingButton(setCard, "meh")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
 
-  test("persists a rating across a reload", async () => {
-    const setCard = await goToSet(page, "Ben Böhmer");
-    const liked = ratingButton(setCard, "liked");
+    test("persists a rating across a reload", async () => {
+      const setCard = await goToSet(page, "Ben Böhmer");
+      const liked = ratingButton(setCard, "liked");
 
-    const ratingWrite = page.waitForResponse(
-      (response) =>
-        response.url().includes("/rest/v1/set_ratings") &&
-        response.request().method() !== "GET" &&
-        response.ok(),
-    );
-    await liked.click();
-    await expect(liked).toHaveAttribute("aria-pressed", "true");
-    await ratingWrite;
+      const ratingWrite = page.waitForResponse(
+        (response) =>
+          response.url().includes("/rest/v1/set_ratings") &&
+          response.request().method() !== "GET" &&
+          response.ok(),
+      );
+      await liked.click();
+      await expect(liked).toHaveAttribute("aria-pressed", "true");
+      await ratingWrite;
 
-    await page.reload();
+      await page.reload();
 
-    const setCardAfterReload = page
-      .getByTestId("artist-item")
-      .filter({ hasText: "Ben Böhmer" });
-    await expect(ratingButton(setCardAfterReload, "liked")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-  });
+      const setCardAfterReload = page
+        .getByTestId("artist-item")
+        .filter({ hasText: "Ben Böhmer" });
+      await expect(ratingButton(setCardAfterReload, "liked")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
 
-  test("changes a rating from one type to another instead of adding a second rating", async () => {
-    const setCard = await goToSet(page, "Kiara Scuro");
-    const loved = ratingButton(setCard, "loved");
-    const meh = ratingButton(setCard, "meh");
+    test("changes a rating from one type to another instead of adding a second rating", async () => {
+      const setCard = await goToSet(page, "Kiara Scuro");
+      const loved = ratingButton(setCard, "loved");
+      const meh = ratingButton(setCard, "meh");
 
-    await loved.click();
-    await expect(loved).toHaveAttribute("aria-pressed", "true");
+      await loved.click();
+      await expect(loved).toHaveAttribute("aria-pressed", "true");
 
-    await meh.click();
+      await meh.click();
 
-    await expect(meh).toHaveAttribute("aria-pressed", "true");
-    await expect(loved).toHaveAttribute("aria-pressed", "false");
-  });
+      await expect(meh).toHaveAttribute("aria-pressed", "true");
+      await expect(loved).toHaveAttribute("aria-pressed", "false");
+    });
 
-  test("removes a rating and returns the set to the unrated state", async () => {
-    const setCard = await goToSet(page, "Nils Frahm");
-    const liked = ratingButton(setCard, "liked");
+    test("removes a rating and returns the set to the unrated state", async () => {
+      const setCard = await goToSet(page, "Nils Frahm");
+      const liked = ratingButton(setCard, "liked");
 
-    await liked.click();
-    await expect(liked).toHaveAttribute("aria-pressed", "true");
+      await liked.click();
+      await expect(liked).toHaveAttribute("aria-pressed", "true");
 
-    await liked.click();
+      await liked.click();
 
-    await expect(liked).toHaveAttribute("aria-pressed", "false");
-  });
-});
+      await expect(liked).toHaveAttribute("aria-pressed", "false");
+    });
+  },
+);
 
 async function goToSet(page: Page, setName: string): Promise<Locator> {
   await page.goto(EDITION_SETS_PATH);

--- a/tests/e2e/schedule-filter-sheet.spec.ts
+++ b/tests/e2e/schedule-filter-sheet.spec.ts
@@ -14,7 +14,7 @@ async function openSheet(
   await expect(page.getByTestId("schedule-filter-sheet")).toBeVisible();
 }
 
-test.describe("Schedule filter sheet", () => {
+test.describe("Schedule filter sheet", { tag: "@smoke" }, () => {
   test("opens from the Timeline toolbar with title and description", async ({
     page,
   }) => {

--- a/tests/e2e/schedule-list-day-header.spec.ts
+++ b/tests/e2e/schedule-list-day-header.spec.ts
@@ -4,7 +4,7 @@ import { test, expect, Page, Locator } from "@playwright/test";
 // three festival days (Jul 12-14, 2025), stages "Main Stage" and "Club Stage".
 const LIST_PATH = "/festivals/test/editions/2025/schedule/list";
 
-test.describe("List view sticky day header", () => {
+test.describe("List view sticky day header", { tag: "@smoke" }, () => {
   test("stays stuck across a full day's sets and hands over to the next day", async ({
     page,
   }) => {

--- a/tests/e2e/schedule-reveal-levels.spec.ts
+++ b/tests/e2e/schedule-reveal-levels.spec.ts
@@ -10,7 +10,7 @@ const PATHS: Record<"draft" | "days" | "stages" | "full", string> = {
   full: "/festivals/reveal-test/editions/full/schedule/timeline",
 };
 
-test.describe("Schedule reveal levels", () => {
+test.describe("Schedule reveal levels", { tag: "@smoke" }, () => {
   test("draft shows the not-revealed placeholder and no sets", async ({
     page,
   }) => {

--- a/tests/e2e/schedule-reveal-levels.spec.ts
+++ b/tests/e2e/schedule-reveal-levels.spec.ts
@@ -33,7 +33,9 @@ test.describe("Schedule reveal levels", () => {
     page,
   }) => {
     await page.goto(PATHS.stages);
-    await expect(page.getByText("Fixture Stage")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Fixture Stage" }).first(),
+    ).toBeVisible();
     await expect(page.getByText("Fixture Set Stages")).toBeVisible();
     await expect(page.getByRole("link", { name: "Timeline" })).toHaveCount(0);
     await expect(page.getByRole("link", { name: "List" })).toHaveCount(0);

--- a/tests/e2e/timeline-day-toolbar.spec.ts
+++ b/tests/e2e/timeline-day-toolbar.spec.ts
@@ -5,7 +5,7 @@ import { test, expect } from "@playwright/test";
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
 const SCROLL_ANIMATION_WAIT_MS = 800; // > smooth-scroll animation + the ~300ms debounce
 
-test.describe("Timeline day-jump toolbar", () => {
+test.describe("Timeline day-jump toolbar", { tag: "@smoke" }, () => {
   test("renders one sticky button per festival day, labeled weekday + date", async ({
     page,
   }) => {

--- a/tests/e2e/timeline-now-indicator.spec.ts
+++ b/tests/e2e/timeline-now-indicator.spec.ts
@@ -13,77 +13,85 @@ const NOW_BEFORE_WINDOW = new Date("2025-07-10T12:00:00Z");
 // Two days after the latest seeded set ends.
 const NOW_AFTER_WINDOW = new Date("2025-07-16T12:00:00Z");
 
-test.describe("Timeline Now pill and current-time indicator", () => {
-  test("render when now falls inside the festival window", async ({ page }) => {
-    await page.clock.setFixedTime(NOW_INSIDE_WINDOW);
-    await page.goto(TIMELINE_PATH);
+test.describe(
+  "Timeline Now pill and current-time indicator",
+  { tag: "@smoke" },
+  () => {
+    test("render when now falls inside the festival window", async ({
+      page,
+    }) => {
+      await page.clock.setFixedTime(NOW_INSIDE_WINDOW);
+      await page.goto(TIMELINE_PATH);
 
-    const nowButton = page.getByTestId("now-jump-button");
-    await expect(nowButton).toBeVisible();
+      const nowButton = page.getByTestId("now-jump-button");
+      await expect(nowButton).toBeVisible();
 
-    const indicator = page.getByTestId("timeline-now-indicator");
-    await expect(indicator).toBeVisible();
+      const indicator = page.getByTestId("timeline-now-indicator");
+      await expect(indicator).toBeVisible();
 
-    const left = await indicator.evaluate((el) =>
-      parseFloat((el as HTMLElement).style.left),
-    );
-    expect(left).toBeGreaterThan(0);
-    expect(Number.isFinite(left)).toBe(true);
-  });
-
-  test("are absent when now is before the festival window", async ({
-    page,
-  }) => {
-    await page.clock.setFixedTime(NOW_BEFORE_WINDOW);
-    await page.goto(TIMELINE_PATH);
-
-    await expect(page.getByTestId("now-jump-button")).toHaveCount(0);
-    await expect(page.getByTestId("timeline-now-indicator")).toHaveCount(0);
-  });
-
-  test("are absent when now is after the festival window", async ({ page }) => {
-    await page.clock.setFixedTime(NOW_AFTER_WINDOW);
-    await page.goto(TIMELINE_PATH);
-
-    await expect(page.getByTestId("now-jump-button")).toHaveCount(0);
-    await expect(page.getByTestId("timeline-now-indicator")).toHaveCount(0);
-  });
-
-  test("tapping Now writes scrollTo and smooth-scrolls to the current time", async ({
-    page,
-  }) => {
-    await page.clock.setFixedTime(NOW_INSIDE_WINDOW);
-    await page.goto(TIMELINE_PATH);
-
-    const scrollContainer = page.getByTestId("timeline-scroll-container");
-
-    const nowButton = page.getByTestId("now-jump-button");
-    await expect(nowButton).toBeVisible();
-
-    // Scroll away first so the jump is observable.
-    await scrollContainer.evaluate((el) => {
-      el.scrollLeft = 0;
+      const left = await indicator.evaluate((el) =>
+        parseFloat((el as HTMLElement).style.left),
+      );
+      expect(left).toBeGreaterThan(0);
+      expect(Number.isFinite(left)).toBe(true);
     });
 
-    await nowButton.click();
+    test("are absent when now is before the festival window", async ({
+      page,
+    }) => {
+      await page.clock.setFixedTime(NOW_BEFORE_WINDOW);
+      await page.goto(TIMELINE_PATH);
 
-    // The scrollTo param is written by a debounced scroll listener, so the
-    // URL can transiently hold the pre-jump position until the smooth-scroll
-    // animation settles. Poll until it converges on "now" (5-minute rounding
-    // allows a small window either side).
-    await expect
-      .poll(() => {
-        const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
-        if (!scrollTo) return Infinity;
-        const scrollToDate = new Date(scrollTo);
-        if (Number.isNaN(scrollToDate.getTime())) return Infinity;
-        return Math.abs(scrollToDate.getTime() - NOW_INSIDE_WINDOW.getTime());
-      })
-      .toBeLessThan(5 * 60 * 1000);
+      await expect(page.getByTestId("now-jump-button")).toHaveCount(0);
+      await expect(page.getByTestId("timeline-now-indicator")).toHaveCount(0);
+    });
 
-    const scrollLeftAfterJump = await scrollContainer.evaluate(
-      (el) => el.scrollLeft,
-    );
-    expect(scrollLeftAfterJump).toBeGreaterThan(0);
-  });
-});
+    test("are absent when now is after the festival window", async ({
+      page,
+    }) => {
+      await page.clock.setFixedTime(NOW_AFTER_WINDOW);
+      await page.goto(TIMELINE_PATH);
+
+      await expect(page.getByTestId("now-jump-button")).toHaveCount(0);
+      await expect(page.getByTestId("timeline-now-indicator")).toHaveCount(0);
+    });
+
+    test("tapping Now writes scrollTo and smooth-scrolls to the current time", async ({
+      page,
+    }) => {
+      await page.clock.setFixedTime(NOW_INSIDE_WINDOW);
+      await page.goto(TIMELINE_PATH);
+
+      const scrollContainer = page.getByTestId("timeline-scroll-container");
+
+      const nowButton = page.getByTestId("now-jump-button");
+      await expect(nowButton).toBeVisible();
+
+      // Scroll away first so the jump is observable.
+      await scrollContainer.evaluate((el) => {
+        el.scrollLeft = 0;
+      });
+
+      await nowButton.click();
+
+      // The scrollTo param is written by a debounced scroll listener, so the
+      // URL can transiently hold the pre-jump position until the smooth-scroll
+      // animation settles. Poll until it converges on "now" (5-minute rounding
+      // allows a small window either side).
+      await expect
+        .poll(() => {
+          const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
+          if (!scrollTo) return Infinity;
+          const scrollToDate = new Date(scrollTo);
+          if (Number.isNaN(scrollToDate.getTime())) return Infinity;
+          return Math.abs(scrollToDate.getTime() - NOW_INSIDE_WINDOW.getTime());
+        })
+        .toBeLessThan(5 * 60 * 1000);
+
+      const scrollLeftAfterJump = await scrollContainer.evaluate(
+        (el) => el.scrollLeft,
+      );
+      expect(scrollLeftAfterJump).toBeGreaterThan(0);
+    });
+  },
+);

--- a/tests/e2e/timeline-overview.spec.ts
+++ b/tests/e2e/timeline-overview.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
 // three festival days (Jul 12-14, 2025) each with timed sets.
 const TIMELINE_PATH = "/festivals/test/editions/2025/schedule/timeline";
 
-test.describe("Timeline overview mini-map", () => {
+test.describe("Timeline overview mini-map", { tag: "@smoke" }, () => {
   test("collapsed by default; toggle expands and collapses it", async ({
     page,
   }) => {

--- a/tests/e2e/timeline-scroll.spec.ts
+++ b/tests/e2e/timeline-scroll.spec.ts
@@ -52,158 +52,164 @@ async function waitForScrollToToSettle(page: Page) {
     .toBe(true);
 }
 
-test.describe("Timeline scroll position (scrollTo URL state)", () => {
-  test("untouched timeline has no scrollTo in the URL", async ({ page }) => {
-    await openTimeline(page);
+test.describe(
+  "Timeline scroll position (scrollTo URL state)",
+  { tag: "@smoke" },
+  () => {
+    test("untouched timeline has no scrollTo in the URL", async ({ page }) => {
+      await openTimeline(page);
 
-    expect(new URL(page.url()).searchParams.has("scrollTo")).toBe(false);
-  });
-
-  test("scrolling writes a debounced, rounded scrollTo via history replace", async ({
-    page,
-  }) => {
-    const scrollContainer = await openTimeline(page);
-
-    const historyLengthBeforeScroll = await page.evaluate(
-      () => window.history.length,
-    );
-
-    await scrollContainer.evaluate((el) => {
-      el.scrollLeft = el.scrollLeft + 400;
+      expect(new URL(page.url()).searchParams.has("scrollTo")).toBe(false);
     });
 
-    await expect(page).toHaveURL(/scrollTo=/);
+    test("scrolling writes a debounced, rounded scrollTo via history replace", async ({
+      page,
+    }) => {
+      const scrollContainer = await openTimeline(page);
 
-    const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
-    expect(scrollTo).toBeTruthy();
-    expect(new Date(scrollTo as string).toString()).not.toBe("Invalid Date");
-    // Rounded to 5-minute granularity.
-    expect(new Date(scrollTo as string).getMinutes() % 5).toBe(0);
+      const historyLengthBeforeScroll = await page.evaluate(
+        () => window.history.length,
+      );
 
-    // History replace, not push: writing scrollTo must not grow the
-    // history stack, even across multiple debounced writes.
-    await scrollContainer.evaluate((el) => {
-      el.scrollLeft = el.scrollLeft + 200;
+      await scrollContainer.evaluate((el) => {
+        el.scrollLeft = el.scrollLeft + 400;
+      });
+
+      await expect(page).toHaveURL(/scrollTo=/);
+
+      const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
+      expect(scrollTo).toBeTruthy();
+      expect(new Date(scrollTo as string).toString()).not.toBe("Invalid Date");
+      // Rounded to 5-minute granularity.
+      expect(new Date(scrollTo as string).getMinutes() % 5).toBe(0);
+
+      // History replace, not push: writing scrollTo must not grow the
+      // history stack, even across multiple debounced writes.
+      await scrollContainer.evaluate((el) => {
+        el.scrollLeft = el.scrollLeft + 200;
+      });
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get("scrollTo"))
+        .not.toBe(scrollTo);
+
+      const historyLengthAfterScroll = await page.evaluate(
+        () => window.history.length,
+      );
+      expect(historyLengthAfterScroll).toBe(historyLengthBeforeScroll);
     });
-    await expect
-      .poll(() => new URL(page.url()).searchParams.get("scrollTo"))
-      .not.toBe(scrollTo);
 
-    const historyLengthAfterScroll = await page.evaluate(
-      () => window.history.length,
-    );
-    expect(historyLengthAfterScroll).toBe(historyLengthBeforeScroll);
-  });
+    test("opening a URL with scrollTo centers the viewport on that moment", async ({
+      page,
+    }) => {
+      const scrollContainer = await openTimeline(page);
 
-  test("opening a URL with scrollTo centers the viewport on that moment", async ({
-    page,
-  }) => {
-    const scrollContainer = await openTimeline(page);
+      // Scroll to discover a real, in-range moment to jump back to.
+      await scrollContainer.evaluate((el) => {
+        el.scrollLeft = el.scrollLeft + 600;
+      });
+      await expect
+        .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
+        .toBe(true);
 
-    // Scroll to discover a real, in-range moment to jump back to.
-    await scrollContainer.evaluate((el) => {
-      el.scrollLeft = el.scrollLeft + 600;
+      const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
+      expect(scrollTo).toBeTruthy();
+      const scrollLeftAfterScroll = await scrollContainer.evaluate(
+        (el) => el.scrollLeft,
+      );
+
+      // Reset by navigating away, then open the URL with scrollTo directly.
+      await page.goto(
+        `${TIMELINE_PATH}?scrollTo=${encodeURIComponent(scrollTo as string)}`,
+      );
+      const reloadedContainer = page.getByTestId("timeline-scroll-container");
+      await expect(reloadedContainer).toBeVisible();
+
+      const scrollLeftOnLoad = await reloadedContainer.evaluate(
+        (el) => el.scrollLeft,
+      );
+
+      // Centering is deterministic given the same viewport width, so this
+      // should land close to where the debounced write captured it from.
+      expect(Math.abs(scrollLeftOnLoad - scrollLeftAfterScroll)).toBeLessThan(
+        10,
+      );
     });
-    await expect
-      .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
-      .toBe(true);
 
-    const scrollTo = new URL(page.url()).searchParams.get("scrollTo");
-    expect(scrollTo).toBeTruthy();
-    const scrollLeftAfterScroll = await scrollContainer.evaluate(
-      (el) => el.scrollLeft,
-    );
+    test("back from a set detail page restores the viewport position", async ({
+      page,
+    }) => {
+      const scrollContainer = await openTimeline(page);
 
-    // Reset by navigating away, then open the URL with scrollTo directly.
-    await page.goto(
-      `${TIMELINE_PATH}?scrollTo=${encodeURIComponent(scrollTo as string)}`,
-    );
-    const reloadedContainer = page.getByTestId("timeline-scroll-container");
-    await expect(reloadedContainer).toBeVisible();
+      await scrollContainer.evaluate((el) => {
+        el.scrollLeft = el.scrollLeft + 500;
+      });
+      await expect
+        .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
+        .toBe(true);
 
-    const scrollLeftOnLoad = await reloadedContainer.evaluate(
-      (el) => el.scrollLeft,
-    );
+      const setLink = await findSetLinkInView(scrollContainer);
+      await setLink.scrollIntoViewIfNeeded();
+      await waitForScrollToToSettle(page);
 
-    // Centering is deterministic given the same viewport width, so this
-    // should land close to where the debounced write captured it from.
-    expect(Math.abs(scrollLeftOnLoad - scrollLeftAfterScroll)).toBeLessThan(10);
-  });
+      const urlWithScroll = page.url();
+      const scrollLeftBeforeNav = await scrollContainer.evaluate(
+        (el) => el.scrollLeft,
+      );
 
-  test("back from a set detail page restores the viewport position", async ({
-    page,
-  }) => {
-    const scrollContainer = await openTimeline(page);
+      await setLink.click();
 
-    await scrollContainer.evaluate((el) => {
-      el.scrollLeft = el.scrollLeft + 500;
+      // Wait for the set-detail page to actually render before going back,
+      // otherwise goBack() races the still-in-flight forward navigation and
+      // can pop back to a stale/default search state.
+      await expect(
+        page.getByRole("button", { name: "Back to Artists" }),
+      ).toBeVisible({ timeout: 20000 });
+      await page.goBack();
+      await expect(page).toHaveURL(urlWithScroll);
+
+      const restoredContainer = page.getByTestId("timeline-scroll-container");
+      await expect(restoredContainer).toBeVisible();
+      await expect
+        .poll(async () =>
+          Math.abs(
+            (await restoredContainer.evaluate((el) => el.scrollLeft)) -
+              scrollLeftBeforeNav,
+          ),
+        )
+        .toBeLessThan(10);
     });
-    await expect
-      .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
-      .toBe(true);
 
-    const setLink = await findSetLinkInView(scrollContainer);
-    await setLink.scrollIntoViewIfNeeded();
-    await waitForScrollToToSettle(page);
+    test("a full reload restores the viewport position from scrollTo", async ({
+      page,
+    }) => {
+      const scrollContainer = await openTimeline(page);
 
-    const urlWithScroll = page.url();
-    const scrollLeftBeforeNav = await scrollContainer.evaluate(
-      (el) => el.scrollLeft,
-    );
+      await scrollContainer.evaluate((el) => {
+        el.scrollLeft = el.scrollLeft + 500;
+      });
+      await expect
+        .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
+        .toBe(true);
 
-    await setLink.click();
+      const urlWithScroll = page.url();
+      expect(new URL(urlWithScroll).searchParams.has("scrollTo")).toBe(true);
+      const scrollLeftBeforeReload = await scrollContainer.evaluate(
+        (el) => el.scrollLeft,
+      );
 
-    // Wait for the set-detail page to actually render before going back,
-    // otherwise goBack() races the still-in-flight forward navigation and
-    // can pop back to a stale/default search state.
-    await expect(
-      page.getByRole("button", { name: "Back to Artists" }),
-    ).toBeVisible({ timeout: 20000 });
-    await page.goBack();
-    await expect(page).toHaveURL(urlWithScroll);
-
-    const restoredContainer = page.getByTestId("timeline-scroll-container");
-    await expect(restoredContainer).toBeVisible();
-    await expect
-      .poll(async () =>
-        Math.abs(
-          (await restoredContainer.evaluate((el) => el.scrollLeft)) -
-            scrollLeftBeforeNav,
-        ),
-      )
-      .toBeLessThan(10);
-  });
-
-  test("a full reload restores the viewport position from scrollTo", async ({
-    page,
-  }) => {
-    const scrollContainer = await openTimeline(page);
-
-    await scrollContainer.evaluate((el) => {
-      el.scrollLeft = el.scrollLeft + 500;
+      // Reloading the same URL restores the viewport via mount-time centering
+      // on the scrollTo param.
+      await page.goto(urlWithScroll);
+      const reloadedContainer = page.getByTestId("timeline-scroll-container");
+      await expect(reloadedContainer).toBeVisible();
+      await expect
+        .poll(async () =>
+          Math.abs(
+            (await reloadedContainer.evaluate((el) => el.scrollLeft)) -
+              scrollLeftBeforeReload,
+          ),
+        )
+        .toBeLessThan(10);
     });
-    await expect
-      .poll(() => new URL(page.url()).searchParams.has("scrollTo"))
-      .toBe(true);
-
-    const urlWithScroll = page.url();
-    expect(new URL(urlWithScroll).searchParams.has("scrollTo")).toBe(true);
-    const scrollLeftBeforeReload = await scrollContainer.evaluate(
-      (el) => el.scrollLeft,
-    );
-
-    // Reloading the same URL restores the viewport via mount-time centering
-    // on the scrollTo param.
-    await page.goto(urlWithScroll);
-    const reloadedContainer = page.getByTestId("timeline-scroll-container");
-    await expect(reloadedContainer).toBeVisible();
-    await expect
-      .poll(async () =>
-        Math.abs(
-          (await reloadedContainer.evaluate((el) => el.scrollLeft)) -
-            scrollLeftBeforeReload,
-        ),
-      )
-      .toBeLessThan(10);
-  });
-});
+  },
+);


### PR DESCRIPTION
Fixes the nightly failure-notify job by checking out the repo before it runs, and fixes a strict-mode failure in the stages reveal-level e2e test caused by the day-grouped stage headings.

## Verification
- Trigger the e2e nightly workflow; the notify-failure job resolves `./.github/scripts/notify-nightly-failure.js` without a "module not found" error.
- `pnpm run test:e2e tests/e2e/schedule-reveal-levels.spec.ts` passes against a built server on a seeded db.