### PR TITLE
test(integration): add integration-test harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm test` - Run Vitest unit tests
 - `pnpm run test:ui` - Run unit tests with UI
 - `pnpm run test:coverage` - Run unit tests with coverage
+- `pnpm run test:integration` - Run Vitest integration tests (`*.integration.test.ts`) against a manually-started local Supabase instance
 - `pnpm run test:e2e` - Run Playwright end-to-end tests
 - `pnpm run test:e2e:ui` - Run tests with Playwright UI
 - `pnpm run test:e2e:headed` - Run tests in headed mode

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest --config vitest.integration.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/src/api/genres/useGenres.integration.test.ts
+++ b/src/api/genres/useGenres.integration.test.ts
@@ -35,6 +35,11 @@ describe("useGenresQuery", () => {
   });
 
   it("returns an empty array when there are no genres", async () => {
+    // music_genres has no per-request filter, so the only way to observe a
+    // real empty response is to empty the whole (shared, seeded) table and
+    // restore it after. #281 replaces this with scoped, uniquely-named
+    // fixtures so tests stop touching shared seed data — until then, this
+    // is deliberately the one place in the suite that does.
     const [genresSnapshot, linksSnapshot] = await Promise.all([
       testSupabase.from("music_genres").select("*"),
       testSupabase.from("artist_music_genres").select("*"),

--- a/src/api/genres/useGenres.integration.test.ts
+++ b/src/api/genres/useGenres.integration.test.ts
@@ -1,28 +1,17 @@
-import { createElement, Suspense, type ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useGenresQuery } from "./useGenres";
-import { registerCleanup, testSupabase } from "@/test/integration/harness";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { genresQuery } from "./useGenres";
+import {
+  createQueryWrapper,
+  registerCleanup,
+  testSupabase,
+} from "@/test/integration/harness";
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      createElement(Suspense, { fallback: null }, children),
-    );
-  };
-}
-
-describe("useGenresQuery", () => {
+describe("genresQuery", () => {
   it("returns the genres seeded in the local Supabase instance", async () => {
-    const { result } = renderHook(() => useGenresQuery(), {
-      wrapper: createWrapper(),
+    const { result } = renderHook(() => useSuspenseQuery(genresQuery()), {
+      wrapper: createQueryWrapper(),
     });
 
     await waitFor(() => {
@@ -70,8 +59,8 @@ describe("useGenresQuery", () => {
       .not("id", "is", null);
     if (deleteError) throw deleteError;
 
-    const { result } = renderHook(() => useGenresQuery(), {
-      wrapper: createWrapper(),
+    const { result } = renderHook(() => useSuspenseQuery(genresQuery()), {
+      wrapper: createQueryWrapper(),
     });
 
     await waitFor(() => {

--- a/src/api/genres/useGenres.integration.test.ts
+++ b/src/api/genres/useGenres.integration.test.ts
@@ -1,0 +1,76 @@
+import { createElement, Suspense, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useGenresQuery } from "./useGenres";
+import { registerCleanup, testSupabase } from "@/test/integration/harness";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(Suspense, { fallback: null }, children),
+    );
+  };
+}
+
+describe("useGenresQuery", () => {
+  it("returns the genres seeded in the local Supabase instance", async () => {
+    const { result } = renderHook(() => useGenresQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data.length).toBeGreaterThan(0);
+    });
+
+    expect(result.current.data).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "Techno" })]),
+    );
+  });
+
+  it("returns an empty array when there are no genres", async () => {
+    const [genresSnapshot, linksSnapshot] = await Promise.all([
+      testSupabase.from("music_genres").select("*"),
+      testSupabase.from("artist_music_genres").select("*"),
+    ]);
+    if (genresSnapshot.error) throw genresSnapshot.error;
+    if (linksSnapshot.error) throw linksSnapshot.error;
+
+    // Register the restore before mutating, so it still runs (and puts the
+    // shared seed data back) even if an assertion below throws.
+    registerCleanup(async () => {
+      if (genresSnapshot.data.length > 0) {
+        const { error } = await testSupabase
+          .from("music_genres")
+          .insert(genresSnapshot.data);
+        if (error) throw error;
+      }
+      if (linksSnapshot.data.length > 0) {
+        const { error } = await testSupabase
+          .from("artist_music_genres")
+          .insert(linksSnapshot.data);
+        if (error) throw error;
+      }
+    });
+
+    const { error: deleteError } = await testSupabase
+      .from("music_genres")
+      .delete()
+      .not("id", "is", null);
+    if (deleteError) throw deleteError;
+
+    const { result } = renderHook(() => useGenresQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
+  });
+});

--- a/src/api/genres/useGenres.ts
+++ b/src/api/genres/useGenres.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Genre, genresKeys } from "./types";
 
@@ -21,8 +21,4 @@ export function genresQuery() {
     queryFn: fetchGenres,
     staleTime: 10 * 60 * 1000,
   });
-}
-
-export function useGenresQuery() {
-  return useSuspenseQuery(genresQuery());
 }

--- a/src/api/genres/useGenres.ts
+++ b/src/api/genres/useGenres.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Genre, genresKeys } from "./types";
 
@@ -21,4 +21,8 @@ export function genresQuery() {
     queryFn: fetchGenres,
     staleTime: 10 * 60 * 1000,
   });
+}
+
+export function useGenresQuery() {
+  return useSuspenseQuery(genresQuery());
 }

--- a/src/test/integration/harness.ts
+++ b/src/test/integration/harness.ts
@@ -1,15 +1,20 @@
+import { createElement, Suspense, type ReactNode } from "react";
 import { afterEach } from "vitest";
 import { createClient } from "@supabase/supabase-js";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Database } from "@/integrations/supabase/types";
 import { TEST_CONFIG } from "../../../tests/config/test-env";
 
 // Service-role client for test setup/teardown only — it bypasses RLS.
 // Code under test always goes through the app's own anon-key client
 // (`@/integrations/supabase/client`), which the integration setup file
-// points at this same local instance.
+// points at this same local instance. Auth session features are disabled
+// since this client never signs in — leaving them on would spin up
+// unnecessary token-refresh timers.
 export const testSupabase = createClient<Database>(
   TEST_CONFIG.SUPABASE_URL,
   TEST_CONFIG.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false, autoRefreshToken: false } },
 );
 
 type Cleanup = () => Promise<void> | void;
@@ -24,8 +29,34 @@ export function registerCleanup(cleanup: Cleanup): void {
 }
 
 afterEach(async () => {
+  const errors: unknown[] = [];
   while (cleanups.length > 0) {
     const cleanup = cleanups.pop();
-    await cleanup?.();
+    try {
+      await cleanup?.();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw errors.length === 1
+      ? errors[0]
+      : new AggregateError(errors, "Integration test cleanup failed");
   }
 });
+
+// Shared QueryClient + Suspense wrapper for `renderHook` in integration
+// tests that exercise a Suspense query hook against real Supabase data.
+export function createQueryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(Suspense, { fallback: null }, children),
+    );
+  };
+}

--- a/src/test/integration/harness.ts
+++ b/src/test/integration/harness.ts
@@ -1,21 +1,15 @@
 import { afterEach } from "vitest";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@/integrations/supabase/types";
-
-// Supabase CLI's fixed local-dev credentials (never a real secret) — the
-// same defaults tests/config/test-env.ts uses for the Playwright suite.
-const SUPABASE_URL = process.env.TEST_SUPABASE_URL ?? "http://127.0.0.1:54321";
-const SUPABASE_SERVICE_ROLE_KEY =
-  process.env.TEST_SUPABASE_SERVICE_ROLE_KEY ??
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+import { TEST_CONFIG } from "../../../tests/config/test-env";
 
 // Service-role client for test setup/teardown only — it bypasses RLS.
 // Code under test always goes through the app's own anon-key client
 // (`@/integrations/supabase/client`), which the integration setup file
 // points at this same local instance.
 export const testSupabase = createClient<Database>(
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
+  TEST_CONFIG.SUPABASE_URL,
+  TEST_CONFIG.SUPABASE_SERVICE_ROLE_KEY,
 );
 
 type Cleanup = () => Promise<void> | void;

--- a/src/test/integration/harness.ts
+++ b/src/test/integration/harness.ts
@@ -1,0 +1,37 @@
+import { afterEach } from "vitest";
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@/integrations/supabase/types";
+
+// Supabase CLI's fixed local-dev credentials (never a real secret) — the
+// same defaults tests/config/test-env.ts uses for the Playwright suite.
+const SUPABASE_URL = process.env.TEST_SUPABASE_URL ?? "http://127.0.0.1:54321";
+const SUPABASE_SERVICE_ROLE_KEY =
+  process.env.TEST_SUPABASE_SERVICE_ROLE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+// Service-role client for test setup/teardown only — it bypasses RLS.
+// Code under test always goes through the app's own anon-key client
+// (`@/integrations/supabase/client`), which the integration setup file
+// points at this same local instance.
+export const testSupabase = createClient<Database>(
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+);
+
+type Cleanup = () => Promise<void> | void;
+
+const cleanups: Cleanup[] = [];
+
+// Later tickets' fixture factories register their teardown here so every
+// row they create self-cleans; until then, tests can register ad-hoc
+// cleanup directly.
+export function registerCleanup(cleanup: Cleanup): void {
+  cleanups.push(cleanup);
+}
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const cleanup = cleanups.pop();
+    await cleanup?.();
+  }
+});

--- a/src/test/integration/setup.ts
+++ b/src/test/integration/setup.ts
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
+import "../webidlPolyfills";
+import { TEST_CONFIG } from "../../../tests/config/test-env";
 
 // Pin the timezone so date formatting is deterministic regardless of the
 // machine's local zone.
@@ -8,52 +10,9 @@ process.env.TZ = "UTC";
 // Point the app's real Supabase client at a manually-started local instance
 // instead of the fake values the unit-test tier stubs — integration tests
 // issue real requests and assert on real responses.
-vi.stubEnv(
-  "VITE_SUPABASE_URL",
-  process.env.TEST_SUPABASE_URL ?? "http://127.0.0.1:54321",
-);
+vi.stubEnv("VITE_SUPABASE_URL", TEST_CONFIG.SUPABASE_URL);
 vi.stubEnv(
   "VITE_SUPABASE_PUBLISHABLE_KEY",
   process.env.TEST_SUPABASE_ANON_KEY ??
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0",
 );
-
-// Polyfill for ArrayBuffer.prototype.resizable and SharedArrayBuffer.prototype.growable
-// These are needed by webidl-conversions package
-if (
-  typeof ArrayBuffer !== "undefined" &&
-  !Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "resizable")
-) {
-  Object.defineProperty(ArrayBuffer.prototype, "resizable", {
-    get() {
-      return false;
-    },
-    configurable: true,
-  });
-}
-
-if (
-  typeof SharedArrayBuffer !== "undefined" &&
-  !Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "growable")
-) {
-  Object.defineProperty(SharedArrayBuffer.prototype, "growable", {
-    get() {
-      return false;
-    },
-    configurable: true,
-  });
-}
-
-// Polyfill for webidl-conversions and whatwg-url
-if (typeof global.Set === "undefined") {
-  global.Set = Set;
-}
-if (typeof global.Map === "undefined") {
-  global.Map = Map;
-}
-if (typeof global.WeakMap === "undefined") {
-  global.WeakMap = WeakMap;
-}
-if (typeof global.WeakSet === "undefined") {
-  global.WeakSet = WeakSet;
-}

--- a/src/test/integration/setup.ts
+++ b/src/test/integration/setup.ts
@@ -2,21 +2,21 @@ import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
 // Pin the timezone so date formatting is deterministic regardless of the
-// machine's local zone. Tests that assert "UTC calendar day" fallbacks only
-// hold when the process runs in UTC (as CI does); Node re-reads TZ on the next
-// Date operation, so setting it here covers every worker.
+// machine's local zone.
 process.env.TZ = "UTC";
 
-// Stub the Supabase env vars so the client module can initialise even when
-// VITE_SUPABASE_URL / VITE_SUPABASE_PUBLISHABLE_KEY aren't set in the test
-// environment. This is the unit-test tier: tests that exercise data
-// fetching mock the relevant query hooks, so the client itself never
-// actually issues a request. Tests that need real Supabase data belong in
-// the integration tier instead (`*.integration.test.ts`, run via
-// `pnpm test:integration`), which wires up a real client — see
-// `src/test/integration/`.
-vi.stubEnv("VITE_SUPABASE_URL", "http://localhost:54321");
-vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-anon-key");
+// Point the app's real Supabase client at a manually-started local instance
+// instead of the fake values the unit-test tier stubs — integration tests
+// issue real requests and assert on real responses.
+vi.stubEnv(
+  "VITE_SUPABASE_URL",
+  process.env.TEST_SUPABASE_URL ?? "http://127.0.0.1:54321",
+);
+vi.stubEnv(
+  "VITE_SUPABASE_PUBLISHABLE_KEY",
+  process.env.TEST_SUPABASE_ANON_KEY ??
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0",
+);
 
 // Polyfill for ArrayBuffer.prototype.resizable and SharedArrayBuffer.prototype.growable
 // These are needed by webidl-conversions package

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
+import "./webidlPolyfills";
 
 // Pin the timezone so date formatting is deterministic regardless of the
 // machine's local zone. Tests that assert "UTC calendar day" fallbacks only
@@ -17,43 +18,3 @@ process.env.TZ = "UTC";
 // `src/test/integration/`.
 vi.stubEnv("VITE_SUPABASE_URL", "http://localhost:54321");
 vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-anon-key");
-
-// Polyfill for ArrayBuffer.prototype.resizable and SharedArrayBuffer.prototype.growable
-// These are needed by webidl-conversions package
-if (
-  typeof ArrayBuffer !== "undefined" &&
-  !Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "resizable")
-) {
-  Object.defineProperty(ArrayBuffer.prototype, "resizable", {
-    get() {
-      return false;
-    },
-    configurable: true,
-  });
-}
-
-if (
-  typeof SharedArrayBuffer !== "undefined" &&
-  !Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "growable")
-) {
-  Object.defineProperty(SharedArrayBuffer.prototype, "growable", {
-    get() {
-      return false;
-    },
-    configurable: true,
-  });
-}
-
-// Polyfill for webidl-conversions and whatwg-url
-if (typeof global.Set === "undefined") {
-  global.Set = Set;
-}
-if (typeof global.Map === "undefined") {
-  global.Map = Map;
-}
-if (typeof global.WeakMap === "undefined") {
-  global.WeakMap = WeakMap;
-}
-if (typeof global.WeakSet === "undefined") {
-  global.WeakSet = WeakSet;
-}

--- a/src/test/webidlPolyfills.ts
+++ b/src/test/webidlPolyfills.ts
@@ -25,15 +25,15 @@ if (
 }
 
 // Polyfill for webidl-conversions and whatwg-url
-if (typeof global.Set === "undefined") {
-  global.Set = Set;
+if (typeof globalThis.Set === "undefined") {
+  globalThis.Set = Set;
 }
-if (typeof global.Map === "undefined") {
-  global.Map = Map;
+if (typeof globalThis.Map === "undefined") {
+  globalThis.Map = Map;
 }
-if (typeof global.WeakMap === "undefined") {
-  global.WeakMap = WeakMap;
+if (typeof globalThis.WeakMap === "undefined") {
+  globalThis.WeakMap = WeakMap;
 }
-if (typeof global.WeakSet === "undefined") {
-  global.WeakSet = WeakSet;
+if (typeof globalThis.WeakSet === "undefined") {
+  globalThis.WeakSet = WeakSet;
 }

--- a/src/test/webidlPolyfills.ts
+++ b/src/test/webidlPolyfills.ts
@@ -1,0 +1,39 @@
+// Polyfill for ArrayBuffer.prototype.resizable and SharedArrayBuffer.prototype.growable
+// These are needed by webidl-conversions package
+if (
+  typeof ArrayBuffer !== "undefined" &&
+  !Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "resizable")
+) {
+  Object.defineProperty(ArrayBuffer.prototype, "resizable", {
+    get() {
+      return false;
+    },
+    configurable: true,
+  });
+}
+
+if (
+  typeof SharedArrayBuffer !== "undefined" &&
+  !Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "growable")
+) {
+  Object.defineProperty(SharedArrayBuffer.prototype, "growable", {
+    get() {
+      return false;
+    },
+    configurable: true,
+  });
+}
+
+// Polyfill for webidl-conversions and whatwg-url
+if (typeof global.Set === "undefined") {
+  global.Set = Set;
+}
+if (typeof global.Map === "undefined") {
+  global.Map = Map;
+}
+if (typeof global.WeakMap === "undefined") {
+  global.WeakMap = WeakMap;
+}
+if (typeof global.WeakSet === "undefined") {
+  global.WeakSet = WeakSet;
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -17,5 +17,10 @@
     "noFallthroughCasesInSwitch": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "vitest.integration.config.ts",
+    "playwright.config.ts"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
       "**/tests/e2e/**", // Exclude Playwright E2E tests
       "supabase/**", // Exclude Deno-only Edge Function tests
+      "**/*.integration.test.ts", // Exclude the integration-test tier (see vitest.integration.config.ts)
     ],
   },
   resolve: {

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react-swc";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    globalSetup: "./vitest.global-setup.ts",
+    setupFiles: ["./src/test/integration/setup.ts"],
+    include: ["src/**/*.integration.test.ts"],
+    pool: "forks",
+    // Tests share one local Supabase instance and some mutate shared tables
+    // (see useGenres.integration.test.ts's empty-result case), so run test
+    // files serially to avoid cross-test races.
+    fileParallelism: false,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Adds a `*.integration.test.ts` Vitest tier that runs against a real local Supabase instance instead of mocking, plus a shared harness (service-role client with session persistence disabled, a best-effort cleanup registry, and a reusable QueryClient+Suspense wrapper) that later tickets' fixture factories will build on.
Proven end-to-end by `genresQuery()`'s real success and empty-result cases, exercised via `useSuspenseQuery` the same way the app itself calls it — no mocking, no bespoke wrapper hook.

## Verification
- Run `pnpm test` — the new `*.integration.test.ts` file is excluded and the existing unit suite (485 tests) passes unaffected.
- Start local Supabase (`supabase start`), then run `pnpm test:integration` — `genresQuery()`'s test passes against real seeded genres and restores the `music_genres`/`artist_music_genres` tables after the empty-result case.
- Run `pnpm run typecheck` and `pnpm run lint` — both clean.

Closes #280

---
_Generated by [Claude Code](https://claude.ai/code/session_017toUhvwdoZrGk8i9ahtyEX)_