### PR TITLE
ci(migrate): gate staging push behind label lock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,9 +62,29 @@ jobs:
             functions:
               - 'supabase/functions/**'
 
-  migrate:
+  check-lock:
+    name: Verify staging lock ownership
     needs: resolve
-    if: needs.resolve.outputs.migrations == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'staging'))
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'staging')
+    runs-on: ubuntu-latest
+    outputs:
+      is_holder: ${{ steps.check.outputs.is_holder }}
+    steps:
+      - name: Confirm no other open PR currently holds the staging label
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          OTHERS=$(gh pr list --repo "$REPO" --label staging --state open --json number \
+            --jq "[.[] | select(.number != $PR)] | length")
+          echo "is_holder=$([[ "$OTHERS" -eq 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+  migrate:
+    needs: [resolve, check-lock]
+    if: needs.resolve.outputs.migrations == 'true' && (github.event_name != 'pull_request' || needs.check-lock.outputs.is_holder == 'true')
     uses: ./.github/workflows/_db_migrate.yml
     with:
       target: ${{ needs.resolve.outputs.target }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
 
   migrate:
     needs: resolve
-    if: needs.resolve.outputs.migrations == 'true'
+    if: needs.resolve.outputs.migrations == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'staging'))
     uses: ./.github/workflows/_db_migrate.yml
     with:
       target: ${{ needs.resolve.outputs.target }}

--- a/.github/workflows/staging-lock.yml
+++ b/.github/workflows/staging-lock.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: staging-lock
+  cancel-in-progress: false
+
 jobs:
   enforce-lock:
     name: Enforce exclusive staging lock

--- a/.github/workflows/staging-lock.yml
+++ b/.github/workflows/staging-lock.yml
@@ -1,0 +1,29 @@
+name: Staging Lock
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enforce-lock:
+    name: Enforce exclusive staging lock
+    if: github.event.label.name == 'staging'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject if another open PR already holds the lock
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          HOLDER=$(gh pr list --repo "$REPO" --label staging --state open --json number \
+            --jq "[.[] | select(.number != $PR)] | .[0].number // empty")
+
+          if [[ -n "$HOLDER" ]]; then
+            gh pr edit "$PR" --repo "$REPO" --remove-label staging
+            gh pr comment "$PR" --repo "$REPO" --body "The \`staging\` label was removed — PR #$HOLDER already holds the staging lock. Wait for it to merge or close, then re-add \`staging\` here."
+          fi

--- a/.github/workflows/staging-lock.yml
+++ b/.github/workflows/staging-lock.yml
@@ -1,7 +1,7 @@
 name: Staging Lock
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 permissions:

--- a/.github/workflows/staging-lock.yml
+++ b/.github/workflows/staging-lock.yml
@@ -20,6 +20,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           HOLDER=$(gh pr list --repo "$REPO" --label staging --state open --json number \
             --jq "[.[] | select(.number != $PR)] | .[0].number // empty")
 


### PR DESCRIPTION
Adds an exclusive `staging` label lock so only one open PR can push migrations to the shared staging DB at a time.
Unlabeled PRs no longer auto-push; adding the label to a second open PR is rejected with a comment naming the current holder.

## Verification
- Open a PR touching `supabase/migrations/**` without the `staging` label — the Deploy workflow's migrate job is skipped.
- Add the `staging` label, then push a commit — the migrate job now runs and pushes to staging.
- Add `staging` to a second open PR while the first still holds it — the label is auto-removed from the second and a comment names the first PR.
- Merge or close the first PR, then add `staging` to the second — it's no longer rejected.

Closes #294

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5pCrxxNb6eyiZUhzCdJLc)_