### PR TITLE
ci(staging): add db-fix and db-force-push PR commands

### DIFF
--- a/.github/scripts/extract-repair-command.test.ts
+++ b/.github/scripts/extract-repair-command.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { extractRepairCommand } from "./extract-repair-command.ts";
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+);
+
+function readFixture(name: string) {
+  return readFileSync(path.join(fixturesDir, name), "utf8");
+}
+
+describe("extractRepairCommand", () => {
+  it("extracts the repair command from PR #273's actual failing staging-push log", () => {
+    const log = readFixture("pr-273-migration-history-drift.txt");
+    expect(extractRepairCommand(log)).toBe(
+      "supabase migration repair --status reverted 20260814140000",
+    );
+  });
+
+  it("extracts a repair command listing multiple migration versions", () => {
+    const log = readFixture("multiple-reverted-versions.txt");
+    expect(extractRepairCommand(log)).toBe(
+      "supabase migration repair --status reverted 20260801120000 20260802093000 20260803081500",
+    );
+  });
+
+  it("returns null when the log has no suggested repair command", () => {
+    const log = readFixture("no-repair-command-connection-timeout.txt");
+    expect(extractRepairCommand(log)).toBeNull();
+  });
+
+  it("returns null for an empty log", () => {
+    expect(extractRepairCommand("")).toBeNull();
+  });
+});

--- a/.github/scripts/extract-repair-command.ts
+++ b/.github/scripts/extract-repair-command.ts
@@ -1,0 +1,7 @@
+const REPAIR_COMMAND_RE =
+  /^supabase migration repair --status (?:applied|reverted)(?: \d+)+$/m;
+
+export function extractRepairCommand(logText: string): string | null {
+  const match = REPAIR_COMMAND_RE.exec(logText);
+  return match ? match[0].trim() : null;
+}

--- a/.github/scripts/extract-repair-command.ts
+++ b/.github/scripts/extract-repair-command.ts
@@ -1,7 +1,9 @@
+// GitHub's raw job-log API (repos/{owner}/{repo}/actions/jobs/{job_id}/logs) prefixes
+// every line with an ISO-8601 timestamp, e.g. "2026-08-17T14:16:05.3705761Z <line>".
 const REPAIR_COMMAND_RE =
-  /^supabase migration repair --status (?:applied|reverted)(?: \d+)+$/m;
+  /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+Z )?(supabase migration repair --status (?:applied|reverted)(?: \d+)+)$/m;
 
 export function extractRepairCommand(logText: string): string | null {
   const match = REPAIR_COMMAND_RE.exec(logText);
-  return match ? match[0].trim() : null;
+  return match ? match[1].trim() : null;
 }

--- a/.github/scripts/fixtures/multiple-reverted-versions.txt
+++ b/.github/scripts/fixtures/multiple-reverted-versions.txt
@@ -1,10 +1,10 @@
 2026-08-10T09:02:11.1200000Z Connecting to remote database...
 2026-08-10T09:02:12.4400000Z Remote migration versions not found in local migrations directory.
-
-Make sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:
-supabase migration repair --status reverted 20260801120000 20260802093000 20260803081500
-
-And update local migrations to match remote database:
-supabase db pull
-
-##[error]Process completed with exit code 1.
+2026-08-10T09:02:12.4410000Z
+2026-08-10T09:02:12.4420000Z Make sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:
+2026-08-10T09:02:12.4430000Z supabase migration repair --status reverted 20260801120000 20260802093000 20260803081500
+2026-08-10T09:02:12.4440000Z
+2026-08-10T09:02:12.4450000Z And update local migrations to match remote database:
+2026-08-10T09:02:12.4460000Z supabase db pull
+2026-08-10T09:02:12.4470000Z
+2026-08-10T09:02:12.4480000Z ##[error]Process completed with exit code 1.

--- a/.github/scripts/fixtures/multiple-reverted-versions.txt
+++ b/.github/scripts/fixtures/multiple-reverted-versions.txt
@@ -1,0 +1,10 @@
+2026-08-10T09:02:11.1200000Z Connecting to remote database...
+2026-08-10T09:02:12.4400000Z Remote migration versions not found in local migrations directory.
+
+Make sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:
+supabase migration repair --status reverted 20260801120000 20260802093000 20260803081500
+
+And update local migrations to match remote database:
+supabase db pull
+
+##[error]Process completed with exit code 1.

--- a/.github/scripts/fixtures/no-repair-command-connection-timeout.txt
+++ b/.github/scripts/fixtures/no-repair-command-connection-timeout.txt
@@ -1,4 +1,4 @@
 2026-08-05T22:14:03.0010000Z Connecting to remote database...
 2026-08-05T22:14:33.0450000Z failed to connect to postgres: dial tcp: i/o timeout
-
-##[error]Process completed with exit code 1.
+2026-08-05T22:14:33.0460000Z
+2026-08-05T22:14:33.0470000Z ##[error]Process completed with exit code 1.

--- a/.github/scripts/fixtures/no-repair-command-connection-timeout.txt
+++ b/.github/scripts/fixtures/no-repair-command-connection-timeout.txt
@@ -1,0 +1,4 @@
+2026-08-05T22:14:03.0010000Z Connecting to remote database...
+2026-08-05T22:14:33.0450000Z failed to connect to postgres: dial tcp: i/o timeout
+
+##[error]Process completed with exit code 1.

--- a/.github/scripts/fixtures/pr-273-migration-history-drift.txt
+++ b/.github/scripts/fixtures/pr-273-migration-history-drift.txt
@@ -1,0 +1,10 @@
+2026-08-17T14:16:03.9620230Z Connecting to remote database...
+2026-08-17T14:16:05.3691921Z Remote migration versions not found in local migrations directory.
+
+Make sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:
+supabase migration repair --status reverted 20260814140000
+
+And update local migrations to match remote database:
+supabase db pull
+
+##[error]Process completed with exit code 1.

--- a/.github/scripts/fixtures/pr-273-migration-history-drift.txt
+++ b/.github/scripts/fixtures/pr-273-migration-history-drift.txt
@@ -1,10 +1,14 @@
+2026-08-17T14:16:01.0143475Z   DB_PASSWORD: ***
+2026-08-17T14:16:03.8827314Z Finished supabase link.
+2026-08-17T14:16:03.9002211Z A new version of Supabase CLI is available: v2.114.0 (currently installed v2.70.0)
+2026-08-17T14:16:03.9003992Z We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli
 2026-08-17T14:16:03.9620230Z Connecting to remote database...
 2026-08-17T14:16:05.3691921Z Remote migration versions not found in local migrations directory.
-
-Make sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:
-supabase migration repair --status reverted 20260814140000
-
-And update local migrations to match remote database:
-supabase db pull
-
-##[error]Process completed with exit code 1.
+2026-08-17T14:16:05.3704057Z
+2026-08-17T14:16:05.3704707Z Make sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:
+2026-08-17T14:16:05.3705761Z supabase migration repair --status reverted 20260814140000
+2026-08-17T14:16:05.3706210Z
+2026-08-17T14:16:05.3706881Z And update local migrations to match remote database:
+2026-08-17T14:16:05.3707489Z supabase db pull
+2026-08-17T14:16:05.3707718Z
+2026-08-17T14:16:05.3727834Z ##[error]Process completed with exit code 1.

--- a/.github/scripts/print-repair-command.ts
+++ b/.github/scripts/print-repair-command.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { extractRepairCommand } from "./extract-repair-command.ts";
+
+const [, , logPath] = process.argv;
+const log = readFileSync(logPath, "utf8");
+const command = extractRepairCommand(log);
+
+if (command) {
+  process.stdout.write(command);
+}

--- a/.github/workflows/staging-db-commands.yml
+++ b/.github/workflows/staging-db-commands.yml
@@ -76,11 +76,7 @@ jobs:
     timeout-minutes: 10
     environment: staging
     steps:
-      # Deliberately NOT the PR's head SHA: this job runs PR-comment-triggered
-      # repo scripts while staging secrets are in scope, and db-fix has no need
-      # for PR content (it only reads a version out of a CI log). Checking out
-      # PR-controlled code here would let a malicious PR exfiltrate the staging
-      # credentials the moment a maintainer comments /db-fix on it.
+      # Default branch, not PR head — db-fix runs repo scripts with staging secrets in scope, and doesn't need PR content.
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/staging-db-commands.yml
+++ b/.github/workflows/staging-db-commands.yml
@@ -76,9 +76,14 @@ jobs:
     timeout-minutes: 10
     environment: staging
     steps:
+      # Deliberately NOT the PR's head SHA: this job runs PR-comment-triggered
+      # repo scripts while staging secrets are in scope, and db-fix has no need
+      # for PR content (it only reads a version out of a CI log). Checking out
+      # PR-controlled code here would let a malicious PR exfiltrate the staging
+      # credentials the moment a maintainer comments /db-fix on it.
       - uses: actions/checkout@v5
         with:
-          ref: ${{ needs.authorize.outputs.head_sha }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/staging-db-commands.yml
+++ b/.github/workflows/staging-db-commands.yml
@@ -73,6 +73,7 @@ jobs:
     needs: authorize
     if: needs.authorize.outputs.command == '/db-fix'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: staging
     steps:
       - uses: actions/checkout@v5
@@ -142,7 +143,7 @@ jobs:
         run: |
           set -euo pipefail
           supabase link --project-ref "$PROJECT_REF" --password "$DB_PASSWORD"
-          $COMMAND
+          $COMMAND --password "$DB_PASSWORD"
 
       - name: Report outcome
         if: always()
@@ -173,6 +174,7 @@ jobs:
     needs: authorize
     if: needs.authorize.outputs.command == '/db-force-push'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: staging
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/staging-db-commands.yml
+++ b/.github/workflows/staging-db-commands.yml
@@ -1,0 +1,210 @@
+name: Staging DB Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  authorize:
+    name: Authorize command
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.resolve.outputs.command }}
+      pr: ${{ github.event.issue.number }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+    steps:
+      - name: Resolve command
+        id: resolve
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          TRIMMED=$(echo "$BODY" | xargs || true)
+          case "$TRIMMED" in
+            "/db-fix"|"/db-force-push") echo "command=$TRIMMED" >> "$GITHUB_OUTPUT" ;;
+            *) echo "command=" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Require write access to comment
+        if: steps.resolve.outputs.command != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          LEVEL=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq .permission)
+          echo "@$ACTOR has permission: $LEVEL"
+          case "$LEVEL" in
+            admin|write) ;;
+            *)
+              echo "::error::@$ACTOR does not have write access to $REPO; refusing to run ${{ steps.resolve.outputs.command }}."
+              exit 1
+              ;;
+          esac
+
+      - name: Require the staging label on this PR
+        id: pr
+        if: steps.resolve.outputs.command != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '[.labels[].name] | any(. == "staging")')
+          if [[ "$HAS_LABEL" != "true" ]]; then
+            echo "::error::PR #$PR does not hold the staging label; refusing to run ${{ steps.resolve.outputs.command }}."
+            exit 1
+          fi
+
+          echo "head_sha=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName)" >> "$GITHUB_OUTPUT"
+
+  db-fix:
+    name: /db-fix
+    needs: authorize
+    if: needs.authorize.outputs.command == '/db-fix'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+
+      - uses: supabase/setup-cli@v3
+
+      # The job name comes from how deploy.yml calls the reusable _db_migrate.yml
+      # workflow: "<calling job id> / <called job's name>". If either changes, this
+      # lookup silently stops matching.
+      - name: Find the latest failed staging-push run for this PR
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ needs.authorize.outputs.head_ref }}
+        run: |
+          set -euo pipefail
+          JOB_ID=""
+          for RUN_ID in $(gh run list --repo "$REPO" --workflow deploy.yml --branch "$BRANCH" --event pull_request --json databaseId --jq '.[].databaseId'); do
+            FOUND=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
+              --jq '.jobs[] | select(.name == "migrate / Push migrations (staging)" and .conclusion == "failure") | .id' | head -n1)
+            if [[ -n "$FOUND" ]]; then
+              JOB_ID="$FOUND"
+              break
+            fi
+          done
+
+          if [[ -z "$JOB_ID" ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "job_id=$JOB_ID" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract the repair command from that run's log
+        id: extract
+        if: steps.find.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          JOB_ID: ${{ steps.find.outputs.job_id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" > job.log
+          COMMAND=$(node .github/scripts/print-repair-command.ts job.log)
+          if [[ -z "$COMMAND" ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "command=$COMMAND" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run the suggested migration repair
+        id: repair
+        if: steps.extract.outputs.found == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
+          DB_PASSWORD: ${{ secrets.STAGING_DB_PASSWORD }}
+          COMMAND: ${{ steps.extract.outputs.command }}
+        run: |
+          set -euo pipefail
+          supabase link --project-ref "$PROJECT_REF" --password "$DB_PASSWORD"
+          $COMMAND
+
+      - name: Report outcome
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.authorize.outputs.pr }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FOUND_RUN: ${{ steps.find.outputs.found }}
+          FOUND_COMMAND: ${{ steps.extract.outputs.found }}
+          COMMAND: ${{ steps.extract.outputs.command }}
+          REPAIR_OUTCOME: ${{ steps.repair.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "$FOUND_RUN" != "true" ]]; then
+            BODY="/db-fix: no failed staging-push run was found for this PR. Nothing was run. [Workflow run]($RUN_URL)"
+          elif [[ "$FOUND_COMMAND" != "true" ]]; then
+            BODY="/db-fix: found a failed staging-push run, but no \`supabase migration repair --status ...\` command was printed in its log. Nothing was run. [Workflow run]($RUN_URL)"
+          elif [[ "$REPAIR_OUTCOME" == "success" ]]; then
+            BODY="/db-fix: ran \`$COMMAND\` against staging — succeeded. [Workflow run]($RUN_URL)"
+          else
+            BODY="/db-fix: ran \`$COMMAND\` against staging — failed. [Workflow run]($RUN_URL)"
+          fi
+          gh pr comment "$PR" --repo "$REPO" --body "$BODY"
+
+  db-force-push:
+    name: /db-force-push
+    needs: authorize
+    if: needs.authorize.outputs.command == '/db-force-push'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+
+      - uses: supabase/setup-cli@v3
+
+      - name: Force push all migrations to staging
+        id: push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
+          DB_PASSWORD: ${{ secrets.STAGING_DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+          supabase link --project-ref "$PROJECT_REF" --password "$DB_PASSWORD"
+          supabase db push --include-all --password "$DB_PASSWORD"
+
+      - name: Report outcome
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.authorize.outputs.pr }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTCOME: ${{ steps.push.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "$OUTCOME" == "success" ]]; then
+            BODY="/db-force-push: \`supabase db push --include-all\` against staging succeeded. [Workflow run]($RUN_URL)"
+          else
+            BODY="/db-force-push: \`supabase db push --include-all\` against staging failed. [Workflow run]($RUN_URL)"
+          fi
+          gh pr comment "$PR" --repo "$REPO" --body "$BODY"


### PR DESCRIPTION
Adds `/db-fix` and `/db-force-push` PR-comment commands so a maintainer can resolve staging migration drift through CI without holding the staging DB password directly.
Both require write access and the `staging` label on the commenting PR before touching staging.

## Verification
- Comment `/db-force-push` on a PR holding the `staging` label from a write-access account; confirm it runs `supabase db push --include-all` against staging and comments the result.
- Comment `/db-fix` on a PR holding `staging` after a failed staging push; confirm it extracts and runs the CLI's suggested `migration repair` command and comments the result.
- Comment `/db-fix` when the latest failure has no extractable repair command; confirm it comments an explanation and takes no other action.
- Comment either command from an account without write access, or on a PR without the `staging` label; confirm neither command runs.
- `pnpm test` passes, including `.github/scripts/extract-repair-command.test.ts`, whose fixtures are built from PR #273's real failing staging-push log.
- `pnpm run typecheck` passes.

Closes #296

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5pCrxxNb6eyiZUhzCdJLc)_