### PR TITLE
fix(ci): disable pnpm cache in /db-fix's setup-node step

### DIFF
--- a/.github/workflows/staging-db-commands.yml
+++ b/.github/workflows/staging-db-commands.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - uses: supabase/setup-cli@v3
 


### PR DESCRIPTION
`actions/setup-node@v5` defaults `package-manager-cache` to true, which auto-detects `pnpm` from `package.json` and hard-fails when `pnpm` isn't installed on the runner. Every other workflow in this repo runs `pnpm/action-setup` before `setup-node`; `/db-fix` never needed a package manager at all (its script has zero dependencies), so the step failed outright and skipped every step after it — including the one that finds and runs the actual repair command.

## Verification
- Comment `/db-fix` on a PR holding the `staging` label after a real failed staging push; confirm `setup-node` succeeds and the job proceeds to find/extract/run the repair command instead of stopping dead.
- Confirm `/db-force-push`'s job (which doesn't use `setup-node`) is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5pCrxxNb6eyiZUhzCdJLc)_