### PR TITLE
fix(ci): allow escape sequences in db-fix log fetch

### DIFF
--- a/.github/workflows/staging-db-commands.yml
+++ b/.github/workflows/staging-db-commands.yml
@@ -125,7 +125,7 @@ jobs:
           JOB_ID: ${{ steps.find.outputs.job_id }}
         run: |
           set -euo pipefail
-          gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" > job.log
+          gh api --allow-escape-sequences "repos/$REPO/actions/jobs/$JOB_ID/logs" > job.log
           COMMAND=$(node .github/scripts/print-repair-command.ts job.log)
           if [[ -z "$COMMAND" ]]; then
             echo "found=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`gh api` refuses to print a raw response containing terminal escape sequences unless told to — and GitHub Actions job logs are full of ANSI color codes from step group headers. Without `--allow-escape-sequences`, `gh api` errors out instead of writing `job.log`, so `/db-fix`'s extraction step never even sees the log content. Caught this from a real `/db-fix` run against PR #273 that got past the previous (pnpm cache) fix and failed here instead.

## Verification
- Comment `/db-fix` on a PR holding the `staging` label after a real failed staging push; confirm the log fetch succeeds and the step proceeds to run `print-repair-command.ts` against real content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5pCrxxNb6eyiZUhzCdJLc)_