### PR TITLE
ci(e2e): cache apt packages for playwright os deps

### DIFF
--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -45,6 +45,13 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-${{ inputs.browsers }}
 
+      - name: Cache apt packages
+        id: apt-cache
+        uses: actions/cache@v6
+        with:
+          path: /var/cache/apt/archives
+          key: apt-${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps ${{ inputs.browsers != 'all' && inputs.browsers || '' }}

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /var/cache/apt/archives/*.deb
-          key: apt-${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          key: apt-${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ inputs.browsers }}
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -49,7 +49,7 @@ jobs:
         id: apt-cache
         uses: actions/cache@v6
         with:
-          path: /var/cache/apt/archives
+          path: /var/cache/apt/archives/*.deb
           key: apt-${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Browsers


### PR DESCRIPTION
Caches `/var/cache/apt/archives` keyed on Playwright version so `install-deps` restores `.deb` files from cache instead of re-downloading them from Ubuntu mirrors on every run.

## Verification
- Diff is CI config only, no app runtime behavior to exercise.
- Trigger the E2E workflow twice; confirm the second run's "Install Playwright OS dependencies"/"Install Playwright Browsers" step is faster and the apt cache step shows a cache hit.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XztUp86LnzpA1xAhc19Xc)_