### PR TITLE
chore(types): enable exactOptionalPropertyTypes

### DIFF
--- a/src/api/artist-notes/types.ts
+++ b/src/api/artist-notes/types.ts
@@ -7,8 +7,8 @@ export type SetNote = {
   note_content: string;
   created_at: string;
   updated_at: string;
-  author_username?: string;
-  author_email?: string;
+  author_username?: string | undefined;
+  author_email?: string | undefined;
 };
 
 // Query key factory

--- a/src/api/auth/useSignInWithOtpMutation.ts
+++ b/src/api/auth/useSignInWithOtpMutation.ts
@@ -4,7 +4,7 @@ import { useToast } from "@/components/ui/use-toast";
 
 interface SignInWithOtpParams {
   email: string;
-  inviteToken?: string;
+  inviteToken?: string | undefined;
 }
 
 export function useSignInWithOtpMutation() {

--- a/src/api/auth/useUpdateProfile.ts
+++ b/src/api/auth/useUpdateProfile.ts
@@ -11,11 +11,14 @@ async function updateProfile(variables: {
   const { userId, updates } = variables;
 
   // Validate username uniqueness before attempting update
+  const trimmedUsername = updates.username?.trim();
   const { data: validationResult, error: validationError } = await supabase.rpc(
     "validate_profile_update",
     {
       user_id: userId,
-      new_username: updates.username?.trim(),
+      ...(trimmedUsername !== undefined
+        ? { new_username: trimmedUsername }
+        : {}),
     },
   );
 

--- a/src/api/auth/useUpdateProfile.ts
+++ b/src/api/auth/useUpdateProfile.ts
@@ -1,7 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
 import { profileKeys } from "./types";
+
+type ValidateProfileUpdateArgs =
+  Database["public"]["Functions"]["validate_profile_update"]["Args"];
 
 // Mutation function
 async function updateProfile(variables: {
@@ -12,10 +16,7 @@ async function updateProfile(variables: {
 
   // Validate username uniqueness before attempting update
   const trimmedUsername = updates.username?.trim();
-  const rpcArgs: {
-    user_id: string;
-    new_username?: string;
-  } = { user_id: userId };
+  const rpcArgs: ValidateProfileUpdateArgs = { user_id: userId };
   if (trimmedUsername !== undefined) {
     rpcArgs.new_username = trimmedUsername;
   }

--- a/src/api/auth/useUpdateProfile.ts
+++ b/src/api/auth/useUpdateProfile.ts
@@ -12,14 +12,16 @@ async function updateProfile(variables: {
 
   // Validate username uniqueness before attempting update
   const trimmedUsername = updates.username?.trim();
+  const rpcArgs: {
+    user_id: string;
+    new_username?: string;
+  } = { user_id: userId };
+  if (trimmedUsername !== undefined) {
+    rpcArgs.new_username = trimmedUsername;
+  }
   const { data: validationResult, error: validationError } = await supabase.rpc(
     "validate_profile_update",
-    {
-      user_id: userId,
-      ...(trimmedUsername !== undefined
-        ? { new_username: trimmedUsername }
-        : {}),
-    },
+    rpcArgs,
   );
 
   if (validationError) {

--- a/src/api/editions/types.ts
+++ b/src/api/editions/types.ts
@@ -8,7 +8,7 @@ export type FestivalEdition =
 export const editionsKeys = {
   root: (festivalId: string) =>
     [...festivalsKeys.root(), festivalId, "editions"] as const,
-  all: (festivalId: string, { all }: { all?: boolean } = {}) =>
+  all: (festivalId: string, { all }: { all?: boolean | undefined } = {}) =>
     [...editionsKeys.root(festivalId), { all }] as const,
   item: ({
     editionId,

--- a/src/api/editions/useFestivalEditionsForFestival.ts
+++ b/src/api/editions/useFestivalEditionsForFestival.ts
@@ -4,7 +4,7 @@ import { FestivalEdition, editionsKeys } from "./types";
 
 export async function fetchFestivalEditions(
   festivalId: string,
-  { all }: { all?: boolean } = {},
+  { all }: { all?: boolean | undefined } = {},
 ): Promise<FestivalEdition[]> {
   let query = supabase
     .from("festival_editions")
@@ -31,7 +31,7 @@ export async function fetchFestivalEditions(
 
 export function editionsForFestivalQuery(
   festivalId: string,
-  { all }: { all?: boolean } = {},
+  { all }: { all?: boolean | undefined } = {},
 ) {
   return queryOptions({
     queryKey: editionsKeys.all(festivalId, { all }),
@@ -41,7 +41,7 @@ export function editionsForFestivalQuery(
 
 export function useFestivalEditionsForFestivalQuery(
   festivalId: string | undefined,
-  { all }: { all?: boolean } = {},
+  { all }: { all?: boolean | undefined } = {},
 ) {
   return useQuery({
     ...editionsForFestivalQuery(festivalId!, { all }),

--- a/src/api/festivals/types.ts
+++ b/src/api/festivals/types.ts
@@ -5,7 +5,7 @@ export type Festival = Database["public"]["Tables"]["festivals"]["Row"];
 // Query key factory for festivals
 export const festivalsKeys = {
   root: () => ["festivals"] as const,
-  all: ({ all }: { all?: boolean } = {}) =>
+  all: ({ all }: { all?: boolean | undefined } = {}) =>
     [...festivalsKeys.root(), { all }] as const,
   item: (festivalId: string) => [...festivalsKeys.root(), festivalId] as const,
   bySlug: (festivalSlug: string) =>

--- a/src/api/festivals/useFestivals.ts
+++ b/src/api/festivals/useFestivals.ts
@@ -6,7 +6,9 @@ import { isTimeoutError, withTimeout } from "@/lib/timeout";
 async function fetchFestivals({
   all,
   signal,
-}: { all?: boolean; signal?: AbortSignal } = {}): Promise<Festival[]> {
+}: { all?: boolean | undefined; signal?: AbortSignal } = {}): Promise<
+  Festival[]
+> {
   let query = supabase
     .from("festivals")
     .select("*")
@@ -32,7 +34,7 @@ async function fetchFestivals({
 export function festivalsQuery({
   all,
   timeoutMs = 10000,
-}: { all?: boolean; timeoutMs?: number } = {}) {
+}: { all?: boolean | undefined; timeoutMs?: number } = {}) {
   return queryOptions({
     queryKey: festivalsKeys.all({ all }),
     queryFn: ({ signal }) =>

--- a/src/api/groups/types.ts
+++ b/src/api/groups/types.ts
@@ -11,8 +11,8 @@ export type Group = Database["public"]["Tables"]["groups"]["Row"] & {
 export type GroupMember =
   Database["public"]["Tables"]["group_members"]["Row"] & {
     profiles?: {
-      username?: string;
-      email?: string;
+      username?: string | undefined;
+      email?: string | undefined;
     };
   };
 

--- a/src/api/groups/useCreateGroup.ts
+++ b/src/api/groups/useCreateGroup.ts
@@ -1,8 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
 import { groupsKeys } from "./types";
 import { generateSlug } from "@/lib/slug";
+
+type GroupInsert = Database["public"]["Tables"]["groups"]["Insert"];
 
 // Mutation function
 async function createGroup(variables: {
@@ -12,12 +15,7 @@ async function createGroup(variables: {
 }) {
   const { name, description, userId } = variables;
 
-  const groupData: {
-    name: string;
-    slug: string;
-    created_by: string;
-    description?: string;
-  } = {
+  const groupData: GroupInsert = {
     name,
     slug: generateSlug(name),
     created_by: userId,

--- a/src/api/groups/useCreateGroup.ts
+++ b/src/api/groups/useCreateGroup.ts
@@ -7,7 +7,7 @@ import { generateSlug } from "@/lib/slug";
 // Mutation function
 async function createGroup(variables: {
   name: string;
-  description?: string;
+  description?: string | undefined;
   userId: string;
 }) {
   const { name, description, userId } = variables;
@@ -17,8 +17,8 @@ async function createGroup(variables: {
     .insert({
       name,
       slug: generateSlug(name),
-      description,
       created_by: userId,
+      ...(description !== undefined ? { description } : {}),
     })
     .select()
     .single();

--- a/src/api/groups/useCreateGroup.ts
+++ b/src/api/groups/useCreateGroup.ts
@@ -12,14 +12,23 @@ async function createGroup(variables: {
 }) {
   const { name, description, userId } = variables;
 
+  const groupData: {
+    name: string;
+    slug: string;
+    created_by: string;
+    description?: string;
+  } = {
+    name,
+    slug: generateSlug(name),
+    created_by: userId,
+  };
+  if (description !== undefined) {
+    groupData.description = description;
+  }
+
   const { data: group, error } = await supabase
     .from("groups")
-    .insert({
-      name,
-      slug: generateSlug(name),
-      created_by: userId,
-      ...(description !== undefined ? { description } : {}),
-    })
+    .insert(groupData)
     .select()
     .single();
 

--- a/src/api/invites/useGenerateInviteMutation.ts
+++ b/src/api/invites/useGenerateInviteMutation.ts
@@ -21,15 +21,23 @@ async function generateInviteLink(
     throw new Error("Authentication required");
   }
 
-  const inviteData = {
+  const inviteData: {
+    group_id: string;
+    invite_token: string;
+    created_by: string;
+    expires_at?: string;
+    max_uses?: number;
+  } = {
     group_id: groupId,
     invite_token: token,
     created_by: user.id,
-    ...(options?.expiresAt !== undefined
-      ? { expires_at: options.expiresAt.toISOString() }
-      : {}),
-    ...(options?.maxUses !== undefined ? { max_uses: options.maxUses } : {}),
   };
+  if (options?.expiresAt !== undefined) {
+    inviteData.expires_at = options.expiresAt.toISOString();
+  }
+  if (options?.maxUses !== undefined) {
+    inviteData.max_uses = options.maxUses;
+  }
 
   const { error } = await supabase.from("group_invites").insert(inviteData);
 

--- a/src/api/invites/useGenerateInviteMutation.ts
+++ b/src/api/invites/useGenerateInviteMutation.ts
@@ -25,8 +25,10 @@ async function generateInviteLink(
     group_id: groupId,
     invite_token: token,
     created_by: user.id,
-    expires_at: options?.expiresAt?.toISOString(),
-    max_uses: options?.maxUses,
+    ...(options?.expiresAt !== undefined
+      ? { expires_at: options.expiresAt.toISOString() }
+      : {}),
+    ...(options?.maxUses !== undefined ? { max_uses: options.maxUses } : {}),
   };
 
   const { error } = await supabase.from("group_invites").insert(inviteData);

--- a/src/api/invites/useGenerateInviteMutation.ts
+++ b/src/api/invites/useGenerateInviteMutation.ts
@@ -1,7 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/components/ui/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
 import { inviteKeys } from "./types";
+
+type GroupInviteInsert =
+  Database["public"]["Tables"]["group_invites"]["Insert"];
 
 async function generateInviteLink(
   groupId: string,
@@ -21,13 +25,7 @@ async function generateInviteLink(
     throw new Error("Authentication required");
   }
 
-  const inviteData: {
-    group_id: string;
-    invite_token: string;
-    created_by: string;
-    expires_at?: string;
-    max_uses?: number;
-  } = {
+  const inviteData: GroupInviteInsert = {
     group_id: groupId,
     invite_token: token,
     created_by: user.id,

--- a/src/api/ratings/useRateSet.ts
+++ b/src/api/ratings/useRateSet.ts
@@ -12,7 +12,7 @@ async function rateSet({
   setId: string;
   rating: number;
   userId: string;
-  existingRating?: number;
+  existingRating?: number | undefined;
 }) {
   if (existingRating === rating) {
     const { error } = await supabase

--- a/src/api/sets/useUpdateSet.ts
+++ b/src/api/sets/useUpdateSet.ts
@@ -25,13 +25,19 @@ async function updateSet(variables: { id: string; updates: UpdateSetInput }) {
   const { id, updates } = variables;
 
   const updateData: SetUpdate = {
-    name: updates.name,
-    description: updates.description,
-    festival_edition_id: updates.festival_edition_id,
-    stage_id: updates.stage_id,
-    time_start: updates.time_start,
-    time_end: updates.time_end,
-    archived: updates.archived,
+    ...(updates.name !== undefined ? { name: updates.name } : {}),
+    ...(updates.description !== undefined
+      ? { description: updates.description }
+      : {}),
+    ...(updates.festival_edition_id !== undefined
+      ? { festival_edition_id: updates.festival_edition_id }
+      : {}),
+    ...(updates.stage_id !== undefined ? { stage_id: updates.stage_id } : {}),
+    ...(updates.time_start !== undefined
+      ? { time_start: updates.time_start }
+      : {}),
+    ...(updates.time_end !== undefined ? { time_end: updates.time_end } : {}),
+    ...(updates.archived !== undefined ? { archived: updates.archived } : {}),
   };
   if (updates.name !== undefined) {
     updateData.slug = generateSlug(updates.name);

--- a/src/api/sets/useUpdateSet.ts
+++ b/src/api/sets/useUpdateSet.ts
@@ -24,23 +24,28 @@ export type UpdateSetInput = Partial<
 async function updateSet(variables: { id: string; updates: UpdateSetInput }) {
   const { id, updates } = variables;
 
-  const updateData: SetUpdate = {
-    ...(updates.name !== undefined ? { name: updates.name } : {}),
-    ...(updates.description !== undefined
-      ? { description: updates.description }
-      : {}),
-    ...(updates.festival_edition_id !== undefined
-      ? { festival_edition_id: updates.festival_edition_id }
-      : {}),
-    ...(updates.stage_id !== undefined ? { stage_id: updates.stage_id } : {}),
-    ...(updates.time_start !== undefined
-      ? { time_start: updates.time_start }
-      : {}),
-    ...(updates.time_end !== undefined ? { time_end: updates.time_end } : {}),
-    ...(updates.archived !== undefined ? { archived: updates.archived } : {}),
-  };
+  const updateData: SetUpdate = {};
   if (updates.name !== undefined) {
+    updateData.name = updates.name;
     updateData.slug = generateSlug(updates.name);
+  }
+  if (updates.description !== undefined) {
+    updateData.description = updates.description;
+  }
+  if (updates.festival_edition_id !== undefined) {
+    updateData.festival_edition_id = updates.festival_edition_id;
+  }
+  if (updates.stage_id !== undefined) {
+    updateData.stage_id = updates.stage_id;
+  }
+  if (updates.time_start !== undefined) {
+    updateData.time_start = updates.time_start;
+  }
+  if (updates.time_end !== undefined) {
+    updateData.time_end = updates.time_end;
+  }
+  if (updates.archived !== undefined) {
+    updateData.archived = updates.archived;
   }
 
   const { data, error } = await supabase

--- a/src/api/voting/useVoteMutation.ts
+++ b/src/api/voting/useVoteMutation.ts
@@ -8,7 +8,7 @@ export async function vote(variables: {
   setId: string;
   voteType: number;
   userId: string;
-  existingVote?: number;
+  existingVote?: number | undefined;
 }) {
   const { setId, voteType, userId, existingVote } = variables;
 

--- a/src/components/Admin/ScheduleImport/CsvUploadStep.tsx
+++ b/src/components/Admin/ScheduleImport/CsvUploadStep.tsx
@@ -10,7 +10,7 @@ import { CsvDropZone } from "./CsvDropZone";
 
 type Props = {
   festivalEditionId: string;
-  defaultTimezone?: string;
+  defaultTimezone?: string | undefined;
   onDiffReady: (diff: DiffResult, timezone: string) => void;
 };
 

--- a/src/components/ArtistImageLoader.tsx
+++ b/src/components/ArtistImageLoader.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Music } from "lucide-react";
 
 interface ArtistImageLoaderProps {
-  src?: string | null;
+  src?: string | null | undefined;
   alt: string;
   className?: string;
 }

--- a/src/components/AuthDialog/AuthDialog.tsx
+++ b/src/components/AuthDialog/AuthDialog.tsx
@@ -15,8 +15,8 @@ interface AuthDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
-  inviteToken?: string;
-  groupName?: string;
+  inviteToken?: string | undefined;
+  groupName?: string | undefined;
 }
 
 export function AuthDialog({

--- a/src/components/AuthDialog/EmailStep.tsx
+++ b/src/components/AuthDialog/EmailStep.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 interface EmailStepProps {
-  inviteToken?: string;
+  inviteToken?: string | undefined;
   onSuccess: (email: string) => void;
 }
 

--- a/src/components/AuthDialog/OtpStep.tsx
+++ b/src/components/AuthDialog/OtpStep.tsx
@@ -11,7 +11,7 @@ import {
 
 interface OtpStepProps {
   email: string;
-  inviteToken?: string;
+  inviteToken?: string | undefined;
   onSuccess: () => void;
 }
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,12 +2,15 @@ import React from "react";
 
 interface ErrorBoundaryState {
   hasError: boolean;
-  error?: Error;
+  error?: Error | undefined;
 }
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
-  fallback?: React.ComponentType<{ error?: Error; retry: () => void }>;
+  fallback?: React.ComponentType<{
+    error?: Error | undefined;
+    retry: () => void;
+  }>;
 }
 
 export class ErrorBoundary extends React.Component<
@@ -46,7 +49,7 @@ function DefaultErrorFallback({
   error,
   retry,
 }: {
-  error?: Error;
+  error?: Error | undefined;
   retry: () => void;
 }) {
   return (

--- a/src/components/StageBadge.tsx
+++ b/src/components/StageBadge.tsx
@@ -2,9 +2,9 @@ import { MapPin } from "lucide-react";
 
 interface StageBadgeProps {
   stageName: string;
-  stageColor?: string;
-  size?: "sm" | "md";
-  showIcon?: boolean;
+  stageColor?: string | undefined;
+  size?: "sm" | "md" | undefined;
+  showIcon?: boolean | undefined;
 }
 
 export function StageBadge({

--- a/src/components/filters/FilterToggle.tsx
+++ b/src/components/filters/FilterToggle.tsx
@@ -8,7 +8,7 @@ interface FilterToggleProps {
   hasActiveFilters: boolean;
   activeFilterCount: number;
   label?: string;
-  onClearFilters?: () => void;
+  onClearFilters?: (() => void) | undefined;
 }
 
 export function FilterToggle({

--- a/src/components/layout/AppHeader/FestivalIndicator.tsx
+++ b/src/components/layout/AppHeader/FestivalIndicator.tsx
@@ -1,7 +1,7 @@
 interface FestivalIndicatorProps {
   isTitleVisible?: boolean;
-  logoUrl?: string | null;
-  festivalName?: string;
+  logoUrl?: string | null | undefined;
+  festivalName?: string | undefined;
 }
 
 export function FestivalIndicator({

--- a/src/components/layout/AppHeader/TitleSection.tsx
+++ b/src/components/layout/AppHeader/TitleSection.tsx
@@ -3,7 +3,7 @@ import { Music, Heart } from "lucide-react";
 
 interface TitleSectionProps {
   title: string;
-  logoUrl?: string | null;
+  logoUrl?: string | null | undefined;
   onLogoRefChange?: (ref: HTMLElement | null) => void;
 }
 

--- a/src/components/layout/AppHeader/UserAvatar.tsx
+++ b/src/components/layout/AppHeader/UserAvatar.tsx
@@ -1,8 +1,8 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 interface UserAvatarProps {
-  username?: string | null;
-  email?: string | null;
+  username?: string | null | undefined;
+  email?: string | null | undefined;
   size?: "sm" | "md" | "lg";
 }
 

--- a/src/components/layout/AppHeader/UserMenu.tsx
+++ b/src/components/layout/AppHeader/UserMenu.tsx
@@ -18,7 +18,7 @@ type Profile = Database["public"]["Tables"]["profiles"]["Row"];
 
 interface UserMenuProps {
   user: User;
-  profile?: Profile;
+  profile?: Profile | undefined;
   onSignOut: () => void;
   isMobile?: boolean;
 }

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -90,14 +90,13 @@ ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
 const ContextMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
-    checked={checked}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -93,14 +93,13 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
-    checked={checked}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -126,14 +126,13 @@ MenubarItem.displayName = MenubarPrimitive.Item.displayName;
 const MenubarCheckboxItem = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <MenubarPrimitive.CheckboxItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
-    checked={checked}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -29,7 +29,7 @@ interface MultiSelectProps {
   searchPlaceholder?: string;
   emptyMessage?: string;
   disabled?: boolean;
-  className?: string;
+  className?: string | undefined;
 }
 
 export function MultiSelect({

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -4,7 +4,21 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root;
+type SelectProps = Omit<
+  React.ComponentProps<typeof SelectPrimitive.Root>,
+  "value"
+> & {
+  value?: string | undefined;
+};
+
+function Select({ value, ...props }: SelectProps) {
+  return (
+    <SelectPrimitive.Root
+      {...(value !== undefined ? { value } : {})}
+      {...props}
+    />
+  );
+}
 
 const SelectGroup = SelectPrimitive.Group;
 

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -4,11 +4,11 @@ import { Toaster as Sonner, toast } from "sonner";
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 function Toaster({ ...props }: ToasterProps) {
-  const { theme } = useTheme();
+  const { theme = "system" } = useTheme();
 
   return (
     <Sonner
-      theme={(theme ?? "system") as "light" | "dark" | "system"}
+      theme={theme as "light" | "dark" | "system"}
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -4,11 +4,11 @@ import { Toaster as Sonner, toast } from "sonner";
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 function Toaster({ ...props }: ToasterProps) {
-  const { theme = "system" } = useTheme();
+  const { theme } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={(theme ?? "system") as "light" | "dark" | "system"}
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -12,21 +12,42 @@ const ToggleGroupContext = React.createContext<
   variant: "default",
 });
 
+type ToggleGroupProps = (
+  | (Omit<ToggleGroupPrimitive.ToggleGroupSingleProps, "value"> & {
+      value?: string | undefined;
+    })
+  | (Omit<ToggleGroupPrimitive.ToggleGroupMultipleProps, "value"> & {
+      value?: string[] | undefined;
+    })
+) &
+  VariantProps<typeof toggleVariants>;
+
 const ToggleGroup = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
-    VariantProps<typeof toggleVariants>
->(({ className, variant, size, children, ...props }, ref) => (
-  <ToggleGroupPrimitive.Root
-    ref={ref}
-    className={cn("flex items-center justify-center gap-1", className)}
-    {...props}
-  >
-    <ToggleGroupContext.Provider value={{ variant, size }}>
-      {children}
-    </ToggleGroupContext.Provider>
-  </ToggleGroupPrimitive.Root>
-));
+  ToggleGroupProps
+>(({ className, variant, size, children, value, ...props }, ref) => {
+  // TS can't carry the exactOptionalPropertyTypes-safe shape through a
+  // spread of a destructured union's rest; the cast just restates what
+  // ToggleGroupProps above already guarantees.
+  const rootProps = {
+    ...props,
+    ...(value !== undefined ? { value } : {}),
+  } as
+    | ToggleGroupPrimitive.ToggleGroupSingleProps
+    | ToggleGroupPrimitive.ToggleGroupMultipleProps;
+
+  return (
+    <ToggleGroupPrimitive.Root
+      ref={ref}
+      className={cn("flex items-center justify-center gap-1", className)}
+      {...rootProps}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+});
 
 ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
 

--- a/src/contexts/FestivalEditionContext.tsx
+++ b/src/contexts/FestivalEditionContext.tsx
@@ -24,7 +24,7 @@ export function useFestivalEdition() {
 
 interface FestivalEditionProviderProps {
   festival: Festival;
-  editionSlug?: string;
+  editionSlug?: string | undefined;
 }
 
 export function FestivalEditionProvider({

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -39,11 +39,11 @@ type Action =
     }
   | {
       type: ActionType["DISMISS_TOAST"];
-      toastId?: ToasterToast["id"];
+      toastId?: ToasterToast["id"] | undefined;
     }
   | {
       type: ActionType["REMOVE_TOAST"];
-      toastId?: ToasterToast["id"];
+      toastId?: ToasterToast["id"] | undefined;
     };
 
 interface State {

--- a/src/hooks/useScheduleData.ts
+++ b/src/hooks/useScheduleData.ts
@@ -26,8 +26,8 @@ export interface ScheduleArtist {
   name: string;
   slug?: string;
   stageId?: string;
-  startTime?: Date;
-  endTime?: Date;
+  startTime?: Date | undefined;
+  endTime?: Date | undefined;
   votes?: { vote_type: number; user_id: string }[];
   formattedTimeRange?: string | null;
   conflictsWith?: string[];

--- a/src/lib/scheduleFilter.ts
+++ b/src/lib/scheduleFilter.ts
@@ -19,9 +19,9 @@ export interface ScheduleFilterCriteria {
   voteTypes?: VoteType[];
   voteScope?: VoteScope;
   /** `undefined` (logged out) makes vote filtering inert, not exclusionary. */
-  currentUserId?: string;
+  currentUserId?: string | undefined;
   /** `undefined` (group members still loading, or no group) makes group-scope vote filtering inert. */
-  groupMemberIds?: Set<string>;
+  groupMemberIds?: Set<string> | undefined;
 }
 
 function matchesTimeOfDay(

--- a/src/lib/timelineCalculator.ts
+++ b/src/lib/timelineCalculator.ts
@@ -44,7 +44,7 @@ export interface TimelineData {
   timeSlots: Date[];
   stages: Array<{
     name: string;
-    color?: string;
+    color?: string | undefined;
     sets: HorizontalTimelineSet[];
   }>;
   totalWidth: number;

--- a/src/lib/timelineMountMoment.ts
+++ b/src/lib/timelineMountMoment.ts
@@ -3,7 +3,7 @@ import { fromZonedTime } from "date-fns-tz";
 import type { ScheduleWindow } from "@/lib/timelineCalculator";
 
 export interface TimelineMountMomentInput {
-  scrollTo?: string;
+  scrollTo?: string | undefined;
   day: string;
   timezone: string;
   festivalStart: Date;

--- a/src/pages/EditionView/EditionHero.tsx
+++ b/src/pages/EditionView/EditionHero.tsx
@@ -3,7 +3,7 @@ import { useFestivalPhase } from "@/hooks/useFestivalPhase";
 
 interface EditionHeroProps {
   title: string;
-  logoUrl?: string | null;
+  logoUrl?: string | null | undefined;
   onRowRefChange?: (node: HTMLElement | null) => void;
 }
 

--- a/src/pages/EditionView/tabs/InfoTab/EditionTitle.tsx
+++ b/src/pages/EditionView/tabs/InfoTab/EditionTitle.tsx
@@ -1,5 +1,5 @@
 interface EditionTitleProps {
-  name?: string;
+  name?: string | undefined;
 }
 
 export function EditionTitle({ name }: EditionTitleProps) {

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageLabels.tsx
@@ -1,7 +1,7 @@
 import { DEFAULT_STAGE_COLOR } from "@/lib/constants/stages";
 
 interface StageLabelsProps {
-  stages: Array<{ name: string; color?: string }>;
+  stages: Array<{ name: string; color?: string | undefined }>;
 }
 
 export function StageLabels({ stages }: StageLabelsProps) {

--- a/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageRow.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/horizontal/StageRow.tsx
@@ -4,7 +4,7 @@ import type { HorizontalTimelineSet } from "@/lib/timelineCalculator";
 interface StageRowProps {
   stage: {
     name: string;
-    color?: string;
+    color?: string | undefined;
     sets: HorizontalTimelineSet[];
   };
   totalWidth: number;

--- a/src/pages/EditionView/tabs/ScheduleTab/list/ListDayGroup.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/ListDayGroup.tsx
@@ -9,7 +9,10 @@ import type { ScheduleSet } from "@/hooks/useScheduleData";
 
 interface TimeSlot {
   time: Date;
-  sets: (ScheduleSet & { stageName: string; stageColor?: string })[];
+  sets: (ScheduleSet & {
+    stageName: string;
+    stageColor?: string | undefined;
+  })[];
 }
 
 interface ListDayGroupProps {

--- a/src/pages/EditionView/tabs/ScheduleTab/list/MobileSetCard.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/MobileSetCard.tsx
@@ -8,8 +8,8 @@ import { StageBadge } from "@/components/StageBadge";
 import type { ScheduleSet } from "@/hooks/useScheduleData";
 
 interface MobileSetCardProps {
-  set: ScheduleSet & { stageName: string; stageColor?: string };
-  timezone?: string;
+  set: ScheduleSet & { stageName: string; stageColor?: string | undefined };
+  timezone?: string | undefined;
 }
 
 export function MobileSetCard({ set, timezone }: MobileSetCardProps) {

--- a/src/pages/EditionView/tabs/ScheduleTab/list/TimeSlotGroup.tsx
+++ b/src/pages/EditionView/tabs/ScheduleTab/list/TimeSlotGroup.tsx
@@ -6,12 +6,15 @@ import type { ScheduleSet } from "@/hooks/useScheduleData";
 
 interface TimeSlot {
   time: Date;
-  sets: (ScheduleSet & { stageName: string; stageColor?: string })[];
+  sets: (ScheduleSet & {
+    stageName: string;
+    stageColor?: string | undefined;
+  })[];
 }
 
 interface TimeSlotGroupProps {
   timeSlot: TimeSlot;
-  timezone?: string;
+  timezone?: string | undefined;
 }
 
 export function TimeSlotGroup({ timeSlot, timezone }: TimeSlotGroupProps) {

--- a/src/pages/EditionView/tabs/VoteTab/filters/FilterSortControls.tsx
+++ b/src/pages/EditionView/tabs/VoteTab/filters/FilterSortControls.tsx
@@ -22,7 +22,7 @@ interface FilterSortControlsProps {
   onStateChange: (updates: Partial<FilterSortState>) => void;
   onClear: () => void;
   editionId: string;
-  votePerspective?: VotePerspectiveProps;
+  votePerspective?: VotePerspectiveProps | undefined;
 }
 
 export function FilterSortControls({

--- a/src/pages/ExploreSetPage/SetExploreCard/SetAudioPlayer.tsx
+++ b/src/pages/ExploreSetPage/SetExploreCard/SetAudioPlayer.tsx
@@ -1,5 +1,5 @@
 interface SetAudioPlayerProps {
-  soundcloudUrl?: string;
+  soundcloudUrl?: string | undefined;
   isActive?: boolean;
 }
 

--- a/src/pages/ExploreSetPage/SetExploreCard/SetCardHeader.tsx
+++ b/src/pages/ExploreSetPage/SetExploreCard/SetCardHeader.tsx
@@ -4,7 +4,7 @@ import { StageBadgeById } from "@/components/StageBadgeById";
 import { useScheduleReveal } from "@/hooks/useScheduleReveal";
 
 interface SetCardHeaderProps {
-  stageId?: string;
+  stageId?: string | undefined;
   timeStart: string | null;
 }
 

--- a/src/pages/ExploreSetPage/SetExploreCard/SoundCloudBadge.tsx
+++ b/src/pages/ExploreSetPage/SetExploreCard/SoundCloudBadge.tsx
@@ -1,6 +1,6 @@
 interface SoundCloudBadgeProps {
   soundcloudUrl?: string | null;
-  onClick?: (e: React.MouseEvent) => void;
+  onClick?: ((e: React.MouseEvent) => void) | undefined;
 }
 
 export function SoundCloudBadge({

--- a/src/pages/ExploreSetPage/useExplorableSets.tsx
+++ b/src/pages/ExploreSetPage/useExplorableSets.tsx
@@ -5,7 +5,7 @@ export function useExplorableSets({
   editionId,
   userVotes,
 }: {
-  editionId?: string;
+  editionId?: string | undefined;
   userVotes: Record<string, number>;
 }) {
   const setsQuery = useSetsByEditionQuery(editionId);

--- a/src/pages/Settings/ActiveGroupSetting.tsx
+++ b/src/pages/Settings/ActiveGroupSetting.tsx
@@ -24,7 +24,7 @@ export function ActiveGroupSetting({
       </p>
       <ToggleGroup
         type="single"
-        value={activeGroupId}
+        value={activeGroupId ?? ""}
         onValueChange={(value) => {
           if (value) {
             setActiveGroup(value);

--- a/src/pages/Settings/ActiveGroupSetting.tsx
+++ b/src/pages/Settings/ActiveGroupSetting.tsx
@@ -24,7 +24,7 @@ export function ActiveGroupSetting({
       </p>
       <ToggleGroup
         type="single"
-        value={activeGroupId ?? ""}
+        {...(activeGroupId !== undefined ? { value: activeGroupId } : {})}
         onValueChange={(value) => {
           if (value) {
             setActiveGroup(value);

--- a/src/pages/Settings/ActiveGroupSetting.tsx
+++ b/src/pages/Settings/ActiveGroupSetting.tsx
@@ -24,7 +24,7 @@ export function ActiveGroupSetting({
       </p>
       <ToggleGroup
         type="single"
-        {...(activeGroupId !== undefined ? { value: activeGroupId } : {})}
+        value={activeGroupId}
         onValueChange={(value) => {
           if (value) {
             setActiveGroup(value);

--- a/src/pages/admin/festivals/StageSelector.tsx
+++ b/src/pages/admin/festivals/StageSelector.tsx
@@ -22,7 +22,11 @@ export function StageSelector({
   return (
     <div className="space-y-2">
       <Label htmlFor="stage">Stage</Label>
-      <Select value={value} onValueChange={onValueChange} disabled={isLoading}>
+      <Select
+        value={value ?? ""}
+        onValueChange={onValueChange}
+        disabled={isLoading}
+      >
         <SelectTrigger>
           <SelectValue
             placeholder={isLoading ? "Loading stages..." : "Select a stage"}

--- a/src/pages/admin/festivals/StageSelector.tsx
+++ b/src/pages/admin/festivals/StageSelector.tsx
@@ -22,11 +22,7 @@ export function StageSelector({
   return (
     <div className="space-y-2">
       <Label htmlFor="stage">Stage</Label>
-      <Select
-        {...(value !== undefined ? { value } : {})}
-        onValueChange={onValueChange}
-        disabled={isLoading}
-      >
+      <Select value={value} onValueChange={onValueChange} disabled={isLoading}>
         <SelectTrigger>
           <SelectValue
             placeholder={isLoading ? "Loading stages..." : "Select a stage"}

--- a/src/pages/admin/festivals/StageSelector.tsx
+++ b/src/pages/admin/festivals/StageSelector.tsx
@@ -23,7 +23,7 @@ export function StageSelector({
     <div className="space-y-2">
       <Label htmlFor="stage">Stage</Label>
       <Select
-        value={value ?? ""}
+        {...(value !== undefined ? { value } : {})}
         onValueChange={onValueChange}
         disabled={isLoading}
       >

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalInfoField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalInfoField.tsx
@@ -8,7 +8,7 @@ import { getTextAlignmentClasses } from "@/lib/textAlignment";
 
 interface FestivalInfoFieldProps {
   festivalId: string;
-  infoText?: string | null;
+  infoText?: string | null | undefined;
 }
 
 interface InfoFormData {
@@ -50,7 +50,7 @@ function InfoFieldForm({
   onSave,
 }: {
   festivalId: string;
-  infoText?: string | null;
+  infoText?: string | null | undefined;
   onCancel: () => void;
   onSave: () => void;
 }) {

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalMapField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalMapField.tsx
@@ -8,7 +8,7 @@ import { useMapUpload } from "./shared/useMapUpload";
 
 interface FestivalMapFieldProps {
   festivalId: string;
-  mapImageUrl?: string | null;
+  mapImageUrl?: string | null | undefined;
 }
 
 interface MapFormData {
@@ -51,7 +51,7 @@ function MapFieldForm({
   onSave,
 }: {
   festivalId: string;
-  mapImageUrl?: string | null;
+  mapImageUrl?: string | null | undefined;
   onCancel: () => void;
   onSave: () => void;
 }) {

--- a/src/pages/admin/festivals/info/FestivalFields/FestivalSocialField.tsx
+++ b/src/pages/admin/festivals/info/FestivalFields/FestivalSocialField.tsx
@@ -8,8 +8,8 @@ import { useFestivalInfoMutation } from "@/api/festival-info/useFestivalInfoMuta
 
 interface FestivalSocialFieldProps {
   festivalId: string;
-  facebookUrl?: string | null;
-  instagramUrl?: string | null;
+  facebookUrl?: string | null | undefined;
+  instagramUrl?: string | null | undefined;
 }
 
 interface SocialFormData {
@@ -72,8 +72,8 @@ function SocialFieldForm({
   onSave,
 }: {
   festivalId: string;
-  facebookUrl?: string | null;
-  instagramUrl?: string | null;
+  facebookUrl?: string | null | undefined;
+  instagramUrl?: string | null | undefined;
 
   onCancel: () => void;
   onSave: () => void;

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug/schedule/list.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug/schedule/list.tsx
@@ -33,7 +33,10 @@ export const Route = createFileRoute(
 
 interface TimeSlot {
   time: Date;
-  sets: (ScheduleSet & { stageName: string; stageColor?: string })[];
+  sets: (ScheduleSet & {
+    stageName: string;
+    stageColor?: string | undefined;
+  })[];
 }
 
 interface DayGroup {
@@ -86,7 +89,7 @@ function ListSchedule() {
     // startTime can't be placed into a time slot, so they're dropped here.
     const allSets: (ScheduleSet & {
       stageName: string;
-      stageColor?: string;
+      stageColor?: string | undefined;
     })[] = [];
 
     filteredScheduleDays.forEach((day) => {
@@ -108,7 +111,7 @@ function ListSchedule() {
     // Group sets by start time
     const timeGroups = new Map<
       string,
-      (ScheduleSet & { stageName: string; stageColor?: string })[]
+      (ScheduleSet & { stageName: string; stageColor?: string | undefined })[]
     >();
 
     allSets.forEach((set) => {

--- a/src/services/scheduleImport/parseCsv.ts
+++ b/src/services/scheduleImport/parseCsv.ts
@@ -30,15 +30,15 @@ export function parseScheduleCsv(csvContent: string): CsvRow[] {
       const endTime = row["end time"]?.trim() || undefined;
       const description = row.description?.trim() || undefined;
 
-      return {
-        artists,
-        ...(setName !== undefined ? { setName } : {}),
-        ...(stage !== undefined ? { stage } : {}),
-        ...(date !== undefined ? { date } : {}),
-        ...(startTime !== undefined ? { startTime } : {}),
-        ...(endTime !== undefined ? { endTime } : {}),
-        ...(description !== undefined ? { description } : {}),
-      };
+      const csvRow: CsvRow = { artists };
+      if (setName !== undefined) csvRow.setName = setName;
+      if (stage !== undefined) csvRow.stage = stage;
+      if (date !== undefined) csvRow.date = date;
+      if (startTime !== undefined) csvRow.startTime = startTime;
+      if (endTime !== undefined) csvRow.endTime = endTime;
+      if (description !== undefined) csvRow.description = description;
+
+      return csvRow;
     })
     .filter((row) => row.artists.length > 0);
 

--- a/src/services/scheduleImport/parseCsv.ts
+++ b/src/services/scheduleImport/parseCsv.ts
@@ -23,14 +23,21 @@ export function parseScheduleCsv(csvContent: string): CsvRow[] {
           .filter(Boolean),
       );
 
+      const setName = row["set name"]?.trim() || undefined;
+      const stage = row.stage?.trim() || undefined;
+      const date = row.date?.trim() || undefined;
+      const startTime = row["start time"]?.trim() || undefined;
+      const endTime = row["end time"]?.trim() || undefined;
+      const description = row.description?.trim() || undefined;
+
       return {
         artists,
-        setName: row["set name"]?.trim() || undefined,
-        stage: row.stage?.trim() || undefined,
-        date: row.date?.trim() || undefined,
-        startTime: row["start time"]?.trim() || undefined,
-        endTime: row["end time"]?.trim() || undefined,
-        description: row.description?.trim() || undefined,
+        ...(setName !== undefined ? { setName } : {}),
+        ...(stage !== undefined ? { stage } : {}),
+        ...(date !== undefined ? { date } : {}),
+        ...(startTime !== undefined ? { startTime } : {}),
+        ...(endTime !== undefined ? { endTime } : {}),
+        ...(description !== undefined ? { description } : {}),
       };
     })
     .filter((row) => row.artists.length > 0);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,6 +16,7 @@
 
     /* Linting */
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Enables `exactOptionalPropertyTypes` in `tsconfig.app.json` and fixes the resulting type errors, per #37. Most fixes widen prop/param types to explicitly accept `undefined`; mutation payload builders (`useUpdateSet`, `useUpdateProfile`, `useCreateGroup`, `useGenerateInviteMutation`, `parseCsv`) now build their objects with conditional spreads instead of assigning `undefined` directly.

Closes #37.

## Verification
- `npx tsc --noEmit -p tsconfig.app.json` — 0 errors
- `pnpm run lint` — 0 errors (2 pre-existing unrelated warnings)
- `pnpm test -- --run` — 494/494 passing
- Manually check the Active Group toggle in Settings and the Stage selector in admin still show "nothing selected" correctly when no value is set (fixed to omit the `value` prop rather than coerce to `""`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvzpJZujRJYbrrUg17nT78)_