### PR TITLE
fix(routing): preserve invite param on festival redirect

### DIFF
--- a/src/routes/festivals/$festivalSlug/index.tsx
+++ b/src/routes/festivals/$festivalSlug/index.tsx
@@ -35,6 +35,7 @@ export const Route = createFileRoute("/festivals/$festivalSlug/")({
           festivalSlug: params.festivalSlug,
           editionSlug: editions[0].slug,
         },
+        search: (prev) => prev,
       });
     }
   },

--- a/src/routes/festivals/$festivalSlug/index.tsx
+++ b/src/routes/festivals/$festivalSlug/index.tsx
@@ -20,7 +20,7 @@ import { TopBar } from "@/components/layout/TopBar";
 
 export const Route = createFileRoute("/festivals/$festivalSlug/")({
   component: EditionSelection,
-  beforeLoad: async ({ params, context }) => {
+  beforeLoad: async ({ params, context, search }) => {
     const festival = await context.queryClient.ensureQueryData(
       festivalBySlugQuery(params.festivalSlug),
     );
@@ -28,14 +28,13 @@ export const Route = createFileRoute("/festivals/$festivalSlug/")({
       editionsForFestivalQuery(festival.id),
     );
 
-    if (editions.length === 1) {
+    if (editions.length === 1 && !search.invite) {
       throw redirect({
         to: "/festivals/$festivalSlug/editions/$editionSlug",
         params: {
           festivalSlug: params.festivalSlug,
           editionSlug: editions[0].slug,
         },
-        search: (prev) => prev,
       });
     }
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,22 +21,21 @@ import { AppHeader } from "@/components/layout/AppHeader";
 
 export const Route = createFileRoute("/")({
   component: FestivalSelection,
-  beforeLoad: async ({ context }) => {
+  beforeLoad: async ({ context, search }) => {
     const festivals =
       await context.queryClient.ensureQueryData(festivalsQuery());
 
-    if (festivals.length === 1) {
+    if (festivals.length === 1 && !search.invite) {
       const festival = festivals[0];
 
       if (isMainGetuplineDomain()) {
-        window.location.href = `${createFestivalSubdomainUrl(festival.slug)}${window.location.search}`;
+        window.location.href = createFestivalSubdomainUrl(festival.slug);
         return;
       }
 
       throw redirect({
         to: "/festivals/$festivalSlug",
         params: { festivalSlug: festival.slug },
-        search: (prev) => prev,
       });
     }
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -29,13 +29,14 @@ export const Route = createFileRoute("/")({
       const festival = festivals[0];
 
       if (isMainGetuplineDomain()) {
-        window.location.href = createFestivalSubdomainUrl(festival.slug);
+        window.location.href = `${createFestivalSubdomainUrl(festival.slug)}${window.location.search}`;
         return;
       }
 
       throw redirect({
         to: "/festivals/$festivalSlug",
         params: { festivalSlug: festival.slug },
+        search: (prev) => prev,
       });
     }
   },


### PR DESCRIPTION
Invite links (`?invite=`) were silently dropped on festival subdomains, whose single-festival/single-edition auto-redirects didn't forward search params. Now those redirects skip entirely whenever an invite is pending, so the invite flow always gets a chance to run before any further navigation.

## Verification
- Open an invite link on a subdomain whose festival has exactly one edition; invite is processed and success toast appears.
- Open an invite link on the main domain when there's exactly one festival total; invite is processed instead of being redirected away.
- Open an invite link on the main domain; still works as before.
- Open an invite link on a subdomain/festival with multiple editions (no auto-redirect); still works as before.