### PR TITLE
feat(search): add artist-links edge function

### DIFF
--- a/supabase/functions/_shared/soundcloud-api/api.ts
+++ b/supabase/functions/_shared/soundcloud-api/api.ts
@@ -92,7 +92,7 @@ export async function fetchSoundCloudAPI<T>(
       rawData: JSON.stringify(rawData).slice(0, 200) + "...",
     });
     throw new SoundCloudAPIError(
-      "Invalid response format from SoundCloud API",
+      "SoundCloud returned data in an unexpected format (their API may have changed), see function logs for details",
       {
         status: 200,
         statusText: "OK",

--- a/supabase/functions/_shared/soundcloud-api/auth.ts
+++ b/supabase/functions/_shared/soundcloud-api/auth.ts
@@ -1,83 +1,275 @@
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getAdminClient } from "../auth.ts";
 import { SoundCloudTokenResponseSchema } from "./schemas.ts";
+import type { SoundCloudTokenResponse } from "./schemas.ts";
 
-let cachedToken: {
-  token: string;
-  expiresAt: number;
-  refreshToken: string;
-} | null = null;
+// Token endpoint per https://developers.soundcloud.com/docs/api/guide
+// (secure.soundcloud.com, not the legacy api.soundcloud.com/oauth2/token).
+const TOKEN_URL = "https://secure.soundcloud.com/oauth/token";
+const PROVIDER = "soundcloud";
+const EXPIRY_BUFFER_MS = 60 * 1000;
+const LEASE_SECONDS = 15;
+const POLL_INTERVAL_MS = 500;
+const MAX_WAIT_MS = 15 * 1000;
 
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+interface StoredToken {
+  access_token: string | null;
+  refresh_token: string | null;
+  expires_at: string | null;
+}
+
+// SoundCloud's token endpoint is rate limited (50 client_credentials grants
+// per 12h per app) and refresh tokens are single-use, so tokens are persisted
+// in the provider_tokens table and shared across instances. Acquisition is
+// serialized through a DB lease so only one instance ever hits the token
+// endpoint; everyone else reuses the stored token or waits for the refresh.
 export async function getSoundCloudAccessToken(
   clientId: string,
   clientSecret: string,
 ): Promise<string> {
-  if (
-    cachedToken &&
-    cachedToken.expiresAt > Date.now() + 60 * 1000 // 1 minute buffer
-  ) {
-    console.log("[getSoundCloudAccessToken] Using cached access token");
+  if (cachedToken && cachedToken.expiresAt > Date.now() + EXPIRY_BUFFER_MS) {
     return cachedToken.token;
   }
 
-  console.log("[getSoundCloudAccessToken] Requesting access token...");
+  const supabase = getAdminClient();
 
-  const tokenUrl = "https://api.soundcloud.com/oauth2/token";
-  try {
-    const response = await fetch(tokenUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-      },
-      body: "grant_type=client_credentials",
-    });
-
-    console.log(
-      `[getSoundCloudAccessToken] Token response status: ${response.status} ${response.statusText}`,
-    );
-
-    if (!response.ok) {
-      const errorBody = await response
-        .text()
-        .catch(() => "Unable to read error response");
-      console.error("[getSoundCloudAccessToken] Failed to get access token:", {
-        status: response.status,
-        statusText: response.statusText,
-        body: errorBody,
-      });
-      throw new Error(
-        `Failed to get SoundCloud access token: ${response.statusText}`,
-      );
-    }
-
-    const rawData = await response.json();
-
-    // Validate the token response structure
-    try {
-      const tokenData = SoundCloudTokenResponseSchema.parse(rawData);
-      console.log(
-        "[getSoundCloudAccessToken] Successfully obtained and validated access token",
-      );
-      const token = tokenData.access_token;
-      const expiresIn = tokenData.expires_in || 60; // Default to 1 minute if not provided
-      const expiresAt = Date.now() + expiresIn * 1000;
-
-      // Cache the token
-      cachedToken = { token, expiresAt, refreshToken: tokenData.refresh_token };
-      return token;
-    } catch (validationError) {
-      console.error(
-        "[getSoundCloudAccessToken] Invalid token response format:",
-        {
-          error: validationError,
-          rawData: JSON.stringify(rawData).slice(0, 200) + "...",
-        },
-      );
-      throw new Error("Invalid access token response from SoundCloud");
-    }
-  } catch (error) {
-    console.error("[getSoundCloudAccessToken] Error obtaining access token:", {
-      error,
-    });
-    throw error;
+  const stored = await readStoredToken(supabase);
+  if (isFresh(stored)) {
+    console.log("[getSoundCloudAccessToken] Using stored access token");
+    return cacheToken(stored.access_token, stored.expires_at);
   }
+
+  const deadline = Date.now() + MAX_WAIT_MS;
+  while (true) {
+    const lease = await claimLease(supabase);
+
+    if (lease.claimed) {
+      try {
+        const tokenData = await requestToken(
+          clientId,
+          clientSecret,
+          lease.refreshToken,
+        );
+        await storeToken(supabase, tokenData);
+        cachedToken = {
+          token: tokenData.access_token,
+          expiresAt: Date.now() + tokenData.expires_in * 1000,
+        };
+        return tokenData.access_token;
+      } catch (error) {
+        await releaseLease(supabase);
+        throw error;
+      }
+    }
+
+    const refreshed = await readStoredToken(supabase);
+    if (isFresh(refreshed)) {
+      console.log(
+        "[getSoundCloudAccessToken] Using token refreshed by another instance",
+      );
+      return cacheToken(refreshed.access_token, refreshed.expires_at);
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        "SoundCloud authentication is busy, please try again shortly",
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}
+
+function isFresh(
+  row: StoredToken | null,
+): row is StoredToken & { access_token: string; expires_at: string } {
+  return Boolean(
+    row?.access_token &&
+      row.expires_at &&
+      new Date(row.expires_at).getTime() > Date.now() + EXPIRY_BUFFER_MS,
+  );
+}
+
+function cacheToken(token: string, expiresAt: string): string {
+  cachedToken = { token, expiresAt: new Date(expiresAt).getTime() };
+  return token;
+}
+
+async function readStoredToken(
+  supabase: SupabaseClient,
+): Promise<StoredToken | null> {
+  const { data, error } = await supabase
+    .from("provider_tokens")
+    .select("access_token, refresh_token, expires_at")
+    .eq("provider", PROVIDER)
+    .maybeSingle();
+
+  if (error) {
+    console.error(
+      "[getSoundCloudAccessToken] Failed to read stored token:",
+      error,
+    );
+    return null;
+  }
+  return data;
+}
+
+async function claimLease(
+  supabase: SupabaseClient,
+): Promise<{ claimed: boolean; refreshToken: string | null }> {
+  const { data, error } = await supabase.rpc("claim_provider_token_lease", {
+    p_provider: PROVIDER,
+    p_lease_seconds: LEASE_SECONDS,
+  });
+
+  if (error) {
+    // Degraded mode: without the lease we can't guarantee serialization, but
+    // failing the search over a lease-bookkeeping error would be worse.
+    console.error("[getSoundCloudAccessToken] Failed to claim lease:", error);
+    return { claimed: true, refreshToken: null };
+  }
+
+  const rows = data as { refresh_token: string | null }[] | null;
+  if (!rows || rows.length === 0) {
+    return { claimed: false, refreshToken: null };
+  }
+  return { claimed: true, refreshToken: rows[0].refresh_token };
+}
+
+async function storeToken(
+  supabase: SupabaseClient,
+  tokenData: SoundCloudTokenResponse,
+): Promise<void> {
+  const { error } = await supabase.rpc("store_provider_token", {
+    p_provider: PROVIDER,
+    p_access_token: tokenData.access_token,
+    p_refresh_token: tokenData.refresh_token,
+    p_expires_in: tokenData.expires_in,
+  });
+
+  if (error) {
+    console.error("[getSoundCloudAccessToken] Failed to persist token:", error);
+  }
+}
+
+async function releaseLease(supabase: SupabaseClient): Promise<void> {
+  const { error } = await supabase
+    .from("provider_tokens")
+    .update({ lock_until: null })
+    .eq("provider", PROVIDER);
+
+  if (error) {
+    console.error("[getSoundCloudAccessToken] Failed to release lease:", error);
+  }
+}
+
+async function requestToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string | null,
+): Promise<SoundCloudTokenResponse> {
+  if (refreshToken) {
+    const refreshed = await tryRefreshGrant(
+      clientId,
+      clientSecret,
+      refreshToken,
+    );
+    if (refreshed) {
+      return refreshed;
+    }
+  }
+  return await clientCredentialsGrant(clientId, clientSecret);
+}
+
+// Refresh grant sends credentials in the form body (unlike client_credentials,
+// which requires HTTP Basic), per the SoundCloud API guide.
+async function tryRefreshGrant(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<SoundCloudTokenResponse | null> {
+  console.log("[getSoundCloudAccessToken] Refreshing access token...");
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response
+      .text()
+      .catch(() => "Unable to read error response");
+    console.error("[getSoundCloudAccessToken] Refresh grant failed:", {
+      status: response.status,
+      statusText: response.statusText,
+      body: errorBody,
+    });
+    if (response.status === 429) {
+      throw new Error("SoundCloud rate limit exceeded, please try again later");
+    }
+    return null;
+  }
+
+  const parsed = SoundCloudTokenResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    console.error(
+      "[getSoundCloudAccessToken] Invalid refresh response format:",
+      parsed.error,
+    );
+    return null;
+  }
+
+  console.log("[getSoundCloudAccessToken] Successfully refreshed access token");
+  return parsed.data;
+}
+
+async function clientCredentialsGrant(
+  clientId: string,
+  clientSecret: string,
+): Promise<SoundCloudTokenResponse> {
+  console.log("[getSoundCloudAccessToken] Requesting new access token...");
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+    },
+    body: "grant_type=client_credentials",
+  });
+
+  if (!response.ok) {
+    const errorBody = await response
+      .text()
+      .catch(() => "Unable to read error response");
+    console.error("[getSoundCloudAccessToken] Failed to get access token:", {
+      status: response.status,
+      statusText: response.statusText,
+      body: errorBody,
+    });
+    if (response.status === 429) {
+      throw new Error("SoundCloud rate limit exceeded, please try again later");
+    }
+    throw new Error(
+      `Failed to get SoundCloud access token: ${response.statusText}`,
+    );
+  }
+
+  const parsed = SoundCloudTokenResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    console.error("[getSoundCloudAccessToken] Invalid token response format:", {
+      error: parsed.error,
+    });
+    throw new Error("Invalid access token response from SoundCloud");
+  }
+
+  console.log("[getSoundCloudAccessToken] Successfully obtained access token");
+  return parsed.data;
 }

--- a/supabase/functions/_shared/soundcloud-api/auth.ts
+++ b/supabase/functions/_shared/soundcloud-api/auth.ts
@@ -11,6 +11,9 @@ const EXPIRY_BUFFER_MS = 60 * 1000;
 const LEASE_SECONDS = 15;
 const POLL_INTERVAL_MS = 500;
 const MAX_WAIT_MS = 15 * 1000;
+// Keep the token request strictly shorter than the lease so a hung request
+// can't outlive its own lease and race the next holder.
+const TOKEN_REQUEST_TIMEOUT_MS = 10 * 1000;
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
@@ -55,14 +58,14 @@ export async function getSoundCloudAccessToken(): Promise<string> {
           clientSecret,
           lease.refreshToken,
         );
-        await storeToken(supabase, tokenData);
+        await storeToken(supabase, tokenData, lease.leaseId);
         cachedToken = {
           token: tokenData.access_token,
           expiresAt: Date.now() + tokenData.expires_in * 1000,
         };
         return tokenData.access_token;
       } catch (error) {
-        await releaseLease(supabase);
+        await releaseLease(supabase, lease.leaseId);
         throw error;
       }
     }
@@ -120,32 +123,46 @@ async function readStoredToken(
 
 async function claimLease(
   supabase: SupabaseClient,
-): Promise<{ claimed: boolean; refreshToken: string | null }> {
+): Promise<
+  | { claimed: true; refreshToken: string | null; leaseId: string }
+  | { claimed: false }
+> {
   const { data, error } = await supabase.rpc("claim_provider_token_lease", {
     p_provider: PROVIDER,
     p_lease_seconds: LEASE_SECONDS,
   });
 
   if (error) {
-    // Degraded mode: without the lease we can't guarantee serialization, but
-    // failing the search over a lease-bookkeeping error would be worse.
+    // Fail closed: proceeding without the lease would let every cold
+    // instance stampede the token endpoint, which is exactly what the
+    // lease exists to prevent.
     console.error("[getSoundCloudAccessToken] Failed to claim lease:", error);
-    return { claimed: true, refreshToken: null };
+    throw new Error(
+      "SoundCloud authentication is temporarily unavailable, please try again",
+    );
   }
 
-  const rows = data as { refresh_token: string | null }[] | null;
+  const rows = data as
+    | { refresh_token: string | null; lease_id: string }[]
+    | null;
   if (!rows || rows.length === 0) {
-    return { claimed: false, refreshToken: null };
+    return { claimed: false };
   }
-  return { claimed: true, refreshToken: rows[0].refresh_token };
+  return {
+    claimed: true,
+    refreshToken: rows[0].refresh_token,
+    leaseId: rows[0].lease_id,
+  };
 }
 
 async function storeToken(
   supabase: SupabaseClient,
   tokenData: SoundCloudTokenResponse,
+  leaseId: string,
 ): Promise<void> {
-  const { error } = await supabase.rpc("store_provider_token", {
+  const { data, error } = await supabase.rpc("store_provider_token", {
     p_provider: PROVIDER,
+    p_lease_id: leaseId,
     p_access_token: tokenData.access_token,
     p_refresh_token: tokenData.refresh_token,
     p_expires_in: tokenData.expires_in,
@@ -153,14 +170,21 @@ async function storeToken(
 
   if (error) {
     console.error("[getSoundCloudAccessToken] Failed to persist token:", error);
+  } else if (data === false) {
+    console.warn(
+      "[getSoundCloudAccessToken] Lease expired before the token was stored; keeping it in-memory only",
+    );
   }
 }
 
-async function releaseLease(supabase: SupabaseClient): Promise<void> {
-  const { error } = await supabase
-    .from("provider_tokens")
-    .update({ lock_until: null })
-    .eq("provider", PROVIDER);
+async function releaseLease(
+  supabase: SupabaseClient,
+  leaseId: string,
+): Promise<void> {
+  const { error } = await supabase.rpc("release_provider_token_lease", {
+    p_provider: PROVIDER,
+    p_lease_id: leaseId,
+  });
 
   if (error) {
     console.error("[getSoundCloudAccessToken] Failed to release lease:", error);
@@ -194,16 +218,23 @@ async function tryRefreshGrant(
 ): Promise<SoundCloudTokenResponse | null> {
   console.log("[getSoundCloudAccessToken] Refreshing access token...");
 
-  const response = await fetch(TOKEN_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "refresh_token",
-      client_id: clientId,
-      client_secret: clientSecret,
-      refresh_token: refreshToken,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+      }),
+      signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    console.error("[getSoundCloudAccessToken] Refresh request failed:", error);
+    return null;
+  }
 
   if (!response.ok) {
     const errorBody = await response
@@ -239,14 +270,21 @@ async function clientCredentialsGrant(
 ): Promise<SoundCloudTokenResponse> {
   console.log("[getSoundCloudAccessToken] Requesting new access token...");
 
-  const response = await fetch(TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-    },
-    body: "grant_type=client_credentials",
-  });
+  let response: Response;
+  try {
+    response = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+      },
+      body: "grant_type=client_credentials",
+      signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    console.error("[getSoundCloudAccessToken] Token request failed:", error);
+    throw new Error("Failed to reach SoundCloud, please try again later");
+  }
 
   if (!response.ok) {
     const errorBody = await response

--- a/supabase/functions/_shared/soundcloud-api/auth.ts
+++ b/supabase/functions/_shared/soundcloud-api/auth.ts
@@ -25,10 +25,13 @@ interface StoredToken {
 // in the provider_tokens table and shared across instances. Acquisition is
 // serialized through a DB lease so only one instance ever hits the token
 // endpoint; everyone else reuses the stored token or waits for the refresh.
-export async function getSoundCloudAccessToken(
-  clientId: string,
-  clientSecret: string,
-): Promise<string> {
+export async function getSoundCloudAccessToken(): Promise<string> {
+  const clientId = Deno.env.get("SOUNDCLOUD_CLIENT_ID");
+  const clientSecret = Deno.env.get("SOUNDCLOUD_CLIENT_SECRET");
+  if (!clientId || !clientSecret) {
+    throw new Error("SoundCloud credentials are not configured");
+  }
+
   if (cachedToken && cachedToken.expiresAt > Date.now() + EXPIRY_BUFFER_MS) {
     return cachedToken.token;
   }

--- a/supabase/functions/get-artist-soundcloud-playlist/index.ts
+++ b/supabase/functions/get-artist-soundcloud-playlist/index.ts
@@ -39,22 +39,8 @@ serve(async (req) => {
       );
     }
 
-    // Get SoundCloud credentials from environment
-    const clientId = Deno.env.get("SOUNDCLOUD_CLIENT_ID");
-    const clientSecret = Deno.env.get("SOUNDCLOUD_CLIENT_SECRET");
-
-    if (!clientId || !clientSecret) {
-      return new Response(
-        JSON.stringify({ error: "SoundCloud credentials not configured" }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        },
-      );
-    }
-
     console.log("Getting SoundCloud access token...");
-    const accessToken = await getSoundCloudAccessToken(clientId, clientSecret);
+    const accessToken = await getSoundCloudAccessToken();
 
     console.log("Resolving SoundCloud URL:", soundcloudUrl);
     // First resolve the URL to get user info

--- a/supabase/functions/search-artist-links/deno.json
+++ b/supabase/functions/search-artist-links/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "none"
+}

--- a/supabase/functions/search-artist-links/deno.lock
+++ b/supabase/functions/search-artist-links/deno.lock
@@ -1,0 +1,18 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    }
+  }
+}

--- a/supabase/functions/search-artist-links/index.ts
+++ b/supabase/functions/search-artist-links/index.ts
@@ -4,8 +4,8 @@ import { buildCorsHeaders } from "../_shared/cors.ts";
 import { searchSoundCloud } from "./soundcloud-adapter.ts";
 import { searchSpotify } from "./spotify-adapter.ts";
 import type {
-  Candidate,
   Provider,
+  ProviderSearchOutcome,
   SearchRequest,
   SearchResponse,
   SearchResult,
@@ -13,7 +13,7 @@ import type {
 
 const searchByProvider: Record<
   Provider,
-  (artistNames: string[]) => Promise<Map<string, Candidate[]>>
+  (artistNames: string[]) => Promise<Map<string, ProviderSearchOutcome>>
 > = {
   soundcloud: searchSoundCloud,
   spotify: searchSpotify,
@@ -66,16 +66,17 @@ serve(async (req) => {
       console.log(`[search-artist-links] Searching ${provider}...`);
 
       try {
-        const candidatesMap = await searchByProvider[provider](
+        const outcomeMap = await searchByProvider[provider](
           request.artistNames,
         );
 
         for (const artistName of request.artistNames) {
-          const candidates = candidatesMap.get(artistName) || [];
+          const outcome = outcomeMap.get(artistName) ?? { candidates: [] };
           results.push({
             artistName,
             provider,
-            candidates,
+            candidates: outcome.candidates,
+            ...(outcome.error && { error: outcome.error }),
           });
         }
       } catch (providerError) {
@@ -84,11 +85,17 @@ serve(async (req) => {
           providerError,
         );
 
+        const message =
+          providerError instanceof Error
+            ? providerError.message
+            : `${provider} search failed`;
+
         for (const artistName of request.artistNames) {
           results.push({
             artistName,
             provider,
             candidates: [],
+            error: message,
           });
         }
       }

--- a/supabase/functions/search-artist-links/index.ts
+++ b/supabase/functions/search-artist-links/index.ts
@@ -1,0 +1,114 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { buildCorsHeaders } from "../_shared/cors.ts";
+import { searchSoundCloud } from "./soundcloud-adapter.ts";
+import { searchSpotify } from "./spotify-adapter.ts";
+import type {
+  Provider,
+  SearchRequest,
+  SearchResponse,
+  SearchResult,
+} from "./types.ts";
+
+const SearchRequestSchema = z.object({
+  artistNames: z.array(z.string()).min(1),
+  provider: z.enum(["soundcloud", "spotify"]).optional(),
+});
+
+serve(async (req) => {
+  const corsHeaders = buildCorsHeaders(req);
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const body = await req.json();
+
+    const parsed = SearchRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return new Response(
+        JSON.stringify({
+          error: "Invalid request",
+          details: parsed.error.errors,
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const request: SearchRequest = parsed.data;
+    const providers: Provider[] = request.provider
+      ? [request.provider]
+      : ["soundcloud", "spotify"];
+
+    const results: SearchResult[] = [];
+
+    for (const provider of providers) {
+      console.log(`[search-artist-links] Searching ${provider}...`);
+
+      try {
+        let candidatesMap;
+
+        if (provider === "soundcloud") {
+          candidatesMap = await searchSoundCloud(request.artistNames);
+        } else if (provider === "spotify") {
+          candidatesMap = await searchSpotify(request.artistNames);
+        } else {
+          continue;
+        }
+
+        for (const artistName of request.artistNames) {
+          const candidates = candidatesMap.get(artistName) || [];
+          results.push({
+            artistName,
+            provider,
+            candidates,
+          });
+        }
+      } catch (providerError) {
+        console.error(
+          `[search-artist-links] Provider ${provider} failed:`,
+          providerError,
+        );
+
+        for (const artistName of request.artistNames) {
+          results.push({
+            artistName,
+            provider,
+            candidates: [],
+          });
+        }
+      }
+    }
+
+    const response: SearchResponse = { results };
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("[search-artist-links] Error:", error);
+
+    return new Response(
+      JSON.stringify({
+        error: "Internal server error",
+        message: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+});

--- a/supabase/functions/search-artist-links/index.ts
+++ b/supabase/functions/search-artist-links/index.ts
@@ -4,11 +4,20 @@ import { buildCorsHeaders } from "../_shared/cors.ts";
 import { searchSoundCloud } from "./soundcloud-adapter.ts";
 import { searchSpotify } from "./spotify-adapter.ts";
 import type {
+  Candidate,
   Provider,
   SearchRequest,
   SearchResponse,
   SearchResult,
 } from "./types.ts";
+
+const searchByProvider: Record<
+  Provider,
+  (artistNames: string[]) => Promise<Map<string, Candidate[]>>
+> = {
+  soundcloud: searchSoundCloud,
+  spotify: searchSpotify,
+};
 
 const SearchRequestSchema = z.object({
   artistNames: z.array(z.string()).min(1),
@@ -57,15 +66,9 @@ serve(async (req) => {
       console.log(`[search-artist-links] Searching ${provider}...`);
 
       try {
-        let candidatesMap;
-
-        if (provider === "soundcloud") {
-          candidatesMap = await searchSoundCloud(request.artistNames);
-        } else if (provider === "spotify") {
-          candidatesMap = await searchSpotify(request.artistNames);
-        } else {
-          continue;
-        }
+        const candidatesMap = await searchByProvider[provider](
+          request.artistNames,
+        );
 
         for (const artistName of request.artistNames) {
           const candidates = candidatesMap.get(artistName) || [];

--- a/supabase/functions/search-artist-links/normalize.test.ts
+++ b/supabase/functions/search-artist-links/normalize.test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import type { SoundCloudUser } from "../_shared/soundcloud-api/schemas.ts";
+import { normalizeSoundCloudSearchResult } from "./normalize.ts";
+
+Deno.test(
+  "normalizeSoundCloudSearchResult converts SoundCloud user to Candidate",
+  () => {
+    const user: SoundCloudUser = {
+      id: 12345,
+      username: "testartist",
+      permalink_url: "https://soundcloud.com/testartist",
+      avatar_url: "https://example.com/avatar.jpg",
+      followers_count: 1500,
+      display_name: "Test Artist",
+    };
+
+    const result = normalizeSoundCloudSearchResult(user);
+
+    assertEquals(result.name, "Test Artist");
+    assertEquals(result.url, "https://soundcloud.com/testartist");
+    assertEquals(result.imageUrl, "https://example.com/avatar.jpg");
+    assertEquals(result.followers, 1500);
+    assertEquals(result.genres, []);
+  },
+);
+
+Deno.test(
+  "normalizeSoundCloudSearchResult uses username when display_name is null",
+  () => {
+    const user: SoundCloudUser = {
+      id: 12345,
+      username: "testartist",
+      permalink_url: "https://soundcloud.com/testartist",
+      display_name: null,
+    };
+
+    const result = normalizeSoundCloudSearchResult(user);
+
+    assertEquals(result.name, "testartist");
+  },
+);
+
+Deno.test("normalizeSoundCloudSearchResult handles missing avatar_url", () => {
+  const user: SoundCloudUser = {
+    id: 12345,
+    username: "testartist",
+    permalink_url: "https://soundcloud.com/testartist",
+    avatar_url: null,
+  };
+
+  const result = normalizeSoundCloudSearchResult(user);
+
+  assertEquals(result.imageUrl, null);
+});
+
+Deno.test(
+  "normalizeSoundCloudSearchResult handles missing followers_count",
+  () => {
+    const user: SoundCloudUser = {
+      id: 12345,
+      username: "testartist",
+      permalink_url: "https://soundcloud.com/testartist",
+    };
+
+    const result = normalizeSoundCloudSearchResult(user);
+
+    assertEquals(result.followers, null);
+  },
+);
+
+Deno.test(
+  "normalizeSoundCloudSearchResult handles user with all optional fields",
+  () => {
+    const user: SoundCloudUser = {
+      id: 67890,
+      username: "anotherartist",
+      permalink_url: "https://soundcloud.com/anotherartist",
+      full_name: "Another Artist Full Name",
+      display_name: "Another Artist",
+      followers_count: 5000,
+      avatar_url: "https://example.com/another.jpg",
+    };
+
+    const result = normalizeSoundCloudSearchResult(user);
+
+    assertEquals(result.name, "Another Artist");
+    assertEquals(result.url, "https://soundcloud.com/anotherartist");
+    assertEquals(result.imageUrl, "https://example.com/another.jpg");
+    assertEquals(result.followers, 5000);
+  },
+);

--- a/supabase/functions/search-artist-links/normalize.test.ts
+++ b/supabase/functions/search-artist-links/normalize.test.ts
@@ -69,6 +69,22 @@ Deno.test(
 );
 
 Deno.test(
+  "normalizeSoundCloudSearchResult preserves a followers_count of 0",
+  () => {
+    const user: SoundCloudUser = {
+      id: 12345,
+      username: "testartist",
+      permalink_url: "https://soundcloud.com/testartist",
+      followers_count: 0,
+    };
+
+    const result = normalizeSoundCloudSearchResult(user);
+
+    assertEquals(result.followers, 0);
+  },
+);
+
+Deno.test(
   "normalizeSoundCloudSearchResult handles user with all optional fields",
   () => {
     const user: SoundCloudUser = {

--- a/supabase/functions/search-artist-links/normalize.ts
+++ b/supabase/functions/search-artist-links/normalize.ts
@@ -1,0 +1,16 @@
+import type { SoundCloudUser } from "../_shared/soundcloud-api/schemas.ts";
+import type { Candidate } from "./types.ts";
+
+export function normalizeSoundCloudSearchResult(
+  user: SoundCloudUser,
+): Candidate {
+  const name = user.display_name || user.username;
+
+  return {
+    name,
+    url: user.permalink_url,
+    imageUrl: user.avatar_url || null,
+    followers: user.followers_count || null,
+    genres: [],
+  };
+}

--- a/supabase/functions/search-artist-links/normalize.ts
+++ b/supabase/functions/search-artist-links/normalize.ts
@@ -10,7 +10,7 @@ export function normalizeSoundCloudSearchResult(
     name,
     url: user.permalink_url,
     imageUrl: user.avatar_url || null,
-    followers: user.followers_count || null,
+    followers: user.followers_count ?? null,
     genres: [],
   };
 }

--- a/supabase/functions/search-artist-links/soundcloud-adapter.ts
+++ b/supabase/functions/search-artist-links/soundcloud-adapter.ts
@@ -5,9 +5,12 @@ import { SoundCloudUserSchema } from "../_shared/soundcloud-api/schemas.ts";
 import { normalizeSoundCloudSearchResult } from "./normalize.ts";
 import type { ProviderSearchOutcome } from "./types.ts";
 
-const SoundCloudSearchResponseSchema = z.object({
-  collection: z.array(SoundCloudUserSchema).optional(),
-});
+// /users returns a bare array; with linked_partitioning SoundCloud wraps
+// results in { collection: [...] }. Accept both.
+const SoundCloudSearchResponseSchema = z.union([
+  z.array(SoundCloudUserSchema),
+  z.object({ collection: z.array(SoundCloudUserSchema) }),
+]);
 
 export async function searchSoundCloud(
   artistNames: string[],
@@ -34,9 +37,8 @@ export async function searchSoundCloud(
         SoundCloudSearchResponseSchema,
       );
 
-      const candidates = (response.collection || []).map(
-        normalizeSoundCloudSearchResult,
-      );
+      const users = Array.isArray(response) ? response : response.collection;
+      const candidates = users.map(normalizeSoundCloudSearchResult);
 
       results.set(artistName, { candidates });
       console.log(

--- a/supabase/functions/search-artist-links/soundcloud-adapter.ts
+++ b/supabase/functions/search-artist-links/soundcloud-adapter.ts
@@ -3,7 +3,7 @@ import { fetchSoundCloudAPI } from "../_shared/soundcloud-api/api.ts";
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 import { SoundCloudUserSchema } from "../_shared/soundcloud-api/schemas.ts";
 import { normalizeSoundCloudSearchResult } from "./normalize.ts";
-import type { Candidate } from "./types.ts";
+import type { ProviderSearchOutcome } from "./types.ts";
 
 const SoundCloudSearchResponseSchema = z.object({
   collection: z.array(SoundCloudUserSchema).optional(),
@@ -11,20 +11,14 @@ const SoundCloudSearchResponseSchema = z.object({
 
 export async function searchSoundCloud(
   artistNames: string[],
-): Promise<Map<string, Candidate[]>> {
-  const results = new Map<string, Candidate[]>();
+): Promise<Map<string, ProviderSearchOutcome>> {
+  const results = new Map<string, ProviderSearchOutcome>();
 
   const clientId = Deno.env.get("SOUNDCLOUD_CLIENT_ID");
   const clientSecret = Deno.env.get("SOUNDCLOUD_CLIENT_SECRET");
 
   if (!clientId || !clientSecret) {
-    console.warn(
-      "[searchSoundCloud] Missing SoundCloud credentials, skipping SoundCloud search",
-    );
-    for (const name of artistNames) {
-      results.set(name, []);
-    }
-    return results;
+    throw new Error("SoundCloud credentials are not configured");
   }
 
   const accessToken = await getSoundCloudAccessToken(clientId, clientSecret);
@@ -44,7 +38,7 @@ export async function searchSoundCloud(
         normalizeSoundCloudSearchResult,
       );
 
-      results.set(artistName, candidates);
+      results.set(artistName, { candidates });
       console.log(
         `[searchSoundCloud] Found ${candidates.length} candidates for ${artistName}`,
       );
@@ -53,7 +47,11 @@ export async function searchSoundCloud(
         `[searchSoundCloud] Error searching for artist ${artistName}:`,
         error,
       );
-      results.set(artistName, []);
+      results.set(artistName, {
+        candidates: [],
+        error:
+          error instanceof Error ? error.message : "SoundCloud search failed",
+      });
     }
   }
 

--- a/supabase/functions/search-artist-links/soundcloud-adapter.ts
+++ b/supabase/functions/search-artist-links/soundcloud-adapter.ts
@@ -1,0 +1,61 @@
+import { getSoundCloudAccessToken } from "../_shared/soundcloud-api/auth.ts";
+import { fetchSoundCloudAPI } from "../_shared/soundcloud-api/api.ts";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { SoundCloudUserSchema } from "../_shared/soundcloud-api/schemas.ts";
+import { normalizeSoundCloudSearchResult } from "./normalize.ts";
+import type { Candidate } from "./types.ts";
+
+const SoundCloudSearchResponseSchema = z.object({
+  collection: z.array(SoundCloudUserSchema).optional(),
+});
+
+export async function searchSoundCloud(
+  artistNames: string[],
+): Promise<Map<string, Candidate[]>> {
+  const results = new Map<string, Candidate[]>();
+
+  const clientId = Deno.env.get("SOUNDCLOUD_CLIENT_ID");
+  const clientSecret = Deno.env.get("SOUNDCLOUD_CLIENT_SECRET");
+
+  if (!clientId || !clientSecret) {
+    console.warn(
+      "[searchSoundCloud] Missing SoundCloud credentials, skipping SoundCloud search",
+    );
+    for (const name of artistNames) {
+      results.set(name, []);
+    }
+    return results;
+  }
+
+  const accessToken = await getSoundCloudAccessToken(clientId, clientSecret);
+
+  for (const artistName of artistNames) {
+    try {
+      console.log(`[searchSoundCloud] Searching for artist: ${artistName}`);
+
+      const endpoint = `/users?q=${encodeURIComponent(artistName)}&limit=3`;
+      const response = await fetchSoundCloudAPI(
+        endpoint,
+        accessToken,
+        SoundCloudSearchResponseSchema,
+      );
+
+      const candidates = (response.collection || []).map(
+        normalizeSoundCloudSearchResult,
+      );
+
+      results.set(artistName, candidates);
+      console.log(
+        `[searchSoundCloud] Found ${candidates.length} candidates for ${artistName}`,
+      );
+    } catch (error) {
+      console.error(
+        `[searchSoundCloud] Error searching for artist ${artistName}:`,
+        error,
+      );
+      results.set(artistName, []);
+    }
+  }
+
+  return results;
+}

--- a/supabase/functions/search-artist-links/soundcloud-adapter.ts
+++ b/supabase/functions/search-artist-links/soundcloud-adapter.ts
@@ -17,14 +17,7 @@ export async function searchSoundCloud(
 ): Promise<Map<string, ProviderSearchOutcome>> {
   const results = new Map<string, ProviderSearchOutcome>();
 
-  const clientId = Deno.env.get("SOUNDCLOUD_CLIENT_ID");
-  const clientSecret = Deno.env.get("SOUNDCLOUD_CLIENT_SECRET");
-
-  if (!clientId || !clientSecret) {
-    throw new Error("SoundCloud credentials are not configured");
-  }
-
-  const accessToken = await getSoundCloudAccessToken(clientId, clientSecret);
+  const accessToken = await getSoundCloudAccessToken();
 
   for (const artistName of artistNames) {
     try {

--- a/supabase/functions/search-artist-links/spotify-adapter.ts
+++ b/supabase/functions/search-artist-links/spotify-adapter.ts
@@ -1,15 +1,15 @@
-import type { Candidate } from "./types.ts";
+import type { ProviderSearchOutcome } from "./types.ts";
 
 export async function searchSpotify(
   artistNames: string[],
-): Promise<Map<string, Candidate[]>> {
-  const results = new Map<string, Candidate[]>();
+): Promise<Map<string, ProviderSearchOutcome>> {
+  const results = new Map<string, ProviderSearchOutcome>();
 
   for (const artistName of artistNames) {
     console.log(
       `[searchSpotify] Spotify search stub - no results for: ${artistName}`,
     );
-    results.set(artistName, []);
+    results.set(artistName, { candidates: [] });
   }
 
   return results;

--- a/supabase/functions/search-artist-links/spotify-adapter.ts
+++ b/supabase/functions/search-artist-links/spotify-adapter.ts
@@ -1,0 +1,16 @@
+import type { Candidate } from "./types.ts";
+
+export async function searchSpotify(
+  artistNames: string[],
+): Promise<Map<string, Candidate[]>> {
+  const results = new Map<string, Candidate[]>();
+
+  for (const artistName of artistNames) {
+    console.log(
+      `[searchSpotify] Spotify search stub - no results for: ${artistName}`,
+    );
+    results.set(artistName, []);
+  }
+
+  return results;
+}

--- a/supabase/functions/search-artist-links/types.ts
+++ b/supabase/functions/search-artist-links/types.ts
@@ -1,0 +1,24 @@
+export type Provider = "soundcloud" | "spotify";
+
+export interface SearchRequest {
+  artistNames: string[];
+  provider?: Provider;
+}
+
+export interface Candidate {
+  name: string;
+  url: string;
+  imageUrl: string | null;
+  followers: number | null;
+  genres: string[];
+}
+
+export interface SearchResult {
+  artistName: string;
+  provider: Provider;
+  candidates: Candidate[];
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+}

--- a/supabase/functions/search-artist-links/types.ts
+++ b/supabase/functions/search-artist-links/types.ts
@@ -13,10 +13,16 @@ export interface Candidate {
   genres: string[];
 }
 
+export interface ProviderSearchOutcome {
+  candidates: Candidate[];
+  error?: string;
+}
+
 export interface SearchResult {
   artistName: string;
   provider: Provider;
   candidates: Candidate[];
+  error?: string;
 }
 
 export interface SearchResponse {

--- a/supabase/functions/sync-artist-data/soundcloud-api.ts
+++ b/supabase/functions/sync-artist-data/soundcloud-api.ts
@@ -10,13 +10,6 @@ import type {
   SoundCloudUser,
 } from "../_shared/soundcloud-api/schemas.ts";
 
-const SOUNDCLOUD_CLIENT_ID = Deno.env.get("SOUNDCLOUD_CLIENT_ID")!;
-const SOUNDCLOUD_CLIENT_SECRET = Deno.env.get("SOUNDCLOUD_CLIENT_SECRET")!;
-
-if (!SOUNDCLOUD_CLIENT_ID || !SOUNDCLOUD_CLIENT_SECRET) {
-  throw new Error("SoundCloud API credentials not configured");
-}
-
 export type ArtistData = {
   user: SoundCloudUser;
   topPlaylist: SoundCloudPlaylist | null;
@@ -28,10 +21,7 @@ export async function getArtistDataFromAPI(
   try {
     console.log(`Getting artist data for: ${soundcloudUrl}`);
 
-    const accessToken = await getSoundCloudAccessToken(
-      SOUNDCLOUD_CLIENT_ID,
-      SOUNDCLOUD_CLIENT_SECRET,
-    );
+    const accessToken = await getSoundCloudAccessToken();
 
     // Resolve the URL to get user info
     const resolveEndpoint = `/resolve?url=${encodeURIComponent(soundcloudUrl)}`;

--- a/supabase/migrations/20260821000000_add_provider_tokens.sql
+++ b/supabase/migrations/20260821000000_add_provider_tokens.sql
@@ -46,6 +46,7 @@ AS $$
 $$;
 
 REVOKE EXECUTE ON FUNCTION public.claim_provider_token_lease(TEXT, INTEGER) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_provider_token_lease(TEXT, INTEGER) TO service_role;
 
 -- Store a freshly obtained token set and release the lease. expires_at is
 -- computed server-side to avoid client clock skew.
@@ -69,3 +70,4 @@ AS $$
 $$;
 
 REVOKE EXECUTE ON FUNCTION public.store_provider_token(TEXT, TEXT, TEXT, INTEGER) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.store_provider_token(TEXT, TEXT, TEXT, INTEGER) TO service_role;

--- a/supabase/migrations/20260821000000_add_provider_tokens.sql
+++ b/supabase/migrations/20260821000000_add_provider_tokens.sql
@@ -4,15 +4,21 @@
 -- per 12h per app, 30 per hour per IP) and its refresh tokens are single-use,
 -- so token acquisition must be shared across edge function instances and
 -- strictly serialized: only one caller may talk to the token endpoint at a
--- time. Serialization uses a lease column (lock_until) claimed via a single
--- atomic statement -- advisory locks don't survive PostgREST's connection
--- pooling, and a transaction-scoped lock can't span the HTTP call to the
--- provider.
+-- time. Serialization uses a lease (lock_until + a fencing lease_id) claimed
+-- via a single atomic statement -- advisory locks don't survive PostgREST's
+-- connection pooling, and a transaction-scoped lock can't span the HTTP call
+-- to the provider. The lease_id fences out stale holders: a caller whose
+-- lease expired mid-request can no longer store its (possibly outdated)
+-- token set or clear a lease claimed by someone else.
 --
 -- RLS is enabled with NO policies: only the service role (edge functions)
 -- can touch this table. Tokens never reach browsers.
+--
+-- Written to be safely re-runnable: an earlier revision of this version was
+-- already applied to staging, so re-application after a history repair must
+-- not fail on existing objects.
 
-CREATE TABLE public.provider_tokens (
+CREATE TABLE IF NOT EXISTS public.provider_tokens (
   provider TEXT PRIMARY KEY,
   access_token TEXT,
   refresh_token TEXT,
@@ -21,53 +27,91 @@ CREATE TABLE public.provider_tokens (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+ALTER TABLE public.provider_tokens ADD COLUMN IF NOT EXISTS lease_id UUID;
+
 ALTER TABLE public.provider_tokens ENABLE ROW LEVEL SECURITY;
 
 -- Atomically claim the refresh lease for a provider. Creates the row on
--- first use. Returns the stored refresh token when the lease was claimed
--- (one row), or no rows when another caller currently holds the lease or
--- the stored token is still fresh (caller should re-read instead).
-CREATE OR REPLACE FUNCTION public.claim_provider_token_lease(
+-- first use. Returns the stored refresh token plus a fresh fencing lease_id
+-- when the lease was claimed (one row), or no rows when another caller
+-- currently holds the lease or the stored token is still fresh (caller
+-- should re-read instead).
+DROP FUNCTION IF EXISTS public.claim_provider_token_lease(TEXT, INTEGER);
+CREATE FUNCTION public.claim_provider_token_lease(
   p_provider TEXT,
   p_lease_seconds INTEGER DEFAULT 15
 )
-RETURNS TABLE(refresh_token TEXT)
+RETURNS TABLE(refresh_token TEXT, lease_id UUID)
 LANGUAGE sql
 SET search_path = ''
 AS $$
-  INSERT INTO public.provider_tokens AS pt (provider, lock_until, updated_at)
-  VALUES (p_provider, now() + make_interval(secs => p_lease_seconds), now())
+  INSERT INTO public.provider_tokens AS pt (provider, lock_until, lease_id, updated_at)
+  VALUES (p_provider, now() + make_interval(secs => p_lease_seconds), gen_random_uuid(), now())
   ON CONFLICT (provider) DO UPDATE
     SET lock_until = now() + make_interval(secs => p_lease_seconds),
+        lease_id = gen_random_uuid(),
         updated_at = now()
     WHERE (pt.lock_until IS NULL OR pt.lock_until < now())
       AND (pt.expires_at IS NULL OR pt.expires_at < now() + interval '60 seconds')
-  RETURNING pt.refresh_token;
+  RETURNING pt.refresh_token, pt.lease_id;
 $$;
 
 REVOKE EXECUTE ON FUNCTION public.claim_provider_token_lease(TEXT, INTEGER) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.claim_provider_token_lease(TEXT, INTEGER) TO service_role;
 
--- Store a freshly obtained token set and release the lease. expires_at is
--- computed server-side to avoid client clock skew.
-CREATE OR REPLACE FUNCTION public.store_provider_token(
+-- Store a freshly obtained token set and release the lease. Fenced by
+-- lease_id: a stale holder whose lease was re-claimed stores nothing.
+-- Returns whether the store happened. expires_at is computed server-side
+-- to avoid client clock skew.
+DROP FUNCTION IF EXISTS public.store_provider_token(TEXT, TEXT, TEXT, INTEGER);
+DROP FUNCTION IF EXISTS public.store_provider_token(TEXT, UUID, TEXT, TEXT, INTEGER);
+CREATE FUNCTION public.store_provider_token(
   p_provider TEXT,
+  p_lease_id UUID,
   p_access_token TEXT,
   p_refresh_token TEXT,
   p_expires_in INTEGER
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+SET search_path = ''
+AS $$
+  WITH updated AS (
+    UPDATE public.provider_tokens
+    SET access_token = p_access_token,
+        refresh_token = p_refresh_token,
+        expires_at = now() + make_interval(secs => p_expires_in),
+        lock_until = NULL,
+        lease_id = NULL,
+        updated_at = now()
+    WHERE provider = p_provider
+      AND lease_id = p_lease_id
+    RETURNING 1
+  )
+  SELECT count(*) > 0 FROM updated;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.store_provider_token(TEXT, UUID, TEXT, TEXT, INTEGER) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.store_provider_token(TEXT, UUID, TEXT, TEXT, INTEGER) TO service_role;
+
+-- Release a lease without storing a token (the refresh attempt failed).
+-- Fenced by lease_id like store_provider_token.
+DROP FUNCTION IF EXISTS public.release_provider_token_lease(TEXT, UUID);
+CREATE FUNCTION public.release_provider_token_lease(
+  p_provider TEXT,
+  p_lease_id UUID
 )
 RETURNS VOID
 LANGUAGE sql
 SET search_path = ''
 AS $$
   UPDATE public.provider_tokens
-  SET access_token = p_access_token,
-      refresh_token = p_refresh_token,
-      expires_at = now() + make_interval(secs => p_expires_in),
-      lock_until = NULL,
+  SET lock_until = NULL,
+      lease_id = NULL,
       updated_at = now()
-  WHERE provider = p_provider;
+  WHERE provider = p_provider
+    AND lease_id = p_lease_id;
 $$;
 
-REVOKE EXECUTE ON FUNCTION public.store_provider_token(TEXT, TEXT, TEXT, INTEGER) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.store_provider_token(TEXT, TEXT, TEXT, INTEGER) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.release_provider_token_lease(TEXT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.release_provider_token_lease(TEXT, UUID) TO service_role;

--- a/supabase/migrations/20260821000000_add_provider_tokens.sql
+++ b/supabase/migrations/20260821000000_add_provider_tokens.sql
@@ -1,0 +1,71 @@
+-- Persistent OAuth token store for external providers (SoundCloud, Spotify).
+--
+-- SoundCloud's token endpoint is rate limited (50 client_credentials tokens
+-- per 12h per app, 30 per hour per IP) and its refresh tokens are single-use,
+-- so token acquisition must be shared across edge function instances and
+-- strictly serialized: only one caller may talk to the token endpoint at a
+-- time. Serialization uses a lease column (lock_until) claimed via a single
+-- atomic statement -- advisory locks don't survive PostgREST's connection
+-- pooling, and a transaction-scoped lock can't span the HTTP call to the
+-- provider.
+--
+-- RLS is enabled with NO policies: only the service role (edge functions)
+-- can touch this table. Tokens never reach browsers.
+
+CREATE TABLE public.provider_tokens (
+  provider TEXT PRIMARY KEY,
+  access_token TEXT,
+  refresh_token TEXT,
+  expires_at TIMESTAMPTZ,
+  lock_until TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.provider_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Atomically claim the refresh lease for a provider. Creates the row on
+-- first use. Returns the stored refresh token when the lease was claimed
+-- (one row), or no rows when another caller currently holds the lease or
+-- the stored token is still fresh (caller should re-read instead).
+CREATE OR REPLACE FUNCTION public.claim_provider_token_lease(
+  p_provider TEXT,
+  p_lease_seconds INTEGER DEFAULT 15
+)
+RETURNS TABLE(refresh_token TEXT)
+LANGUAGE sql
+SET search_path = ''
+AS $$
+  INSERT INTO public.provider_tokens AS pt (provider, lock_until, updated_at)
+  VALUES (p_provider, now() + make_interval(secs => p_lease_seconds), now())
+  ON CONFLICT (provider) DO UPDATE
+    SET lock_until = now() + make_interval(secs => p_lease_seconds),
+        updated_at = now()
+    WHERE (pt.lock_until IS NULL OR pt.lock_until < now())
+      AND (pt.expires_at IS NULL OR pt.expires_at < now() + interval '60 seconds')
+  RETURNING pt.refresh_token;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.claim_provider_token_lease(TEXT, INTEGER) FROM PUBLIC, anon, authenticated;
+
+-- Store a freshly obtained token set and release the lease. expires_at is
+-- computed server-side to avoid client clock skew.
+CREATE OR REPLACE FUNCTION public.store_provider_token(
+  p_provider TEXT,
+  p_access_token TEXT,
+  p_refresh_token TEXT,
+  p_expires_in INTEGER
+)
+RETURNS VOID
+LANGUAGE sql
+SET search_path = ''
+AS $$
+  UPDATE public.provider_tokens
+  SET access_token = p_access_token,
+      refresh_token = p_refresh_token,
+      expires_at = now() + make_interval(secs => p_expires_in),
+      lock_until = NULL,
+      updated_at = now()
+  WHERE provider = p_provider;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.store_provider_token(TEXT, TEXT, TEXT, INTEGER) FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
Adds edge function to search for artist links across multiple music platforms (SoundCloud, Spotify stub).
Provider and per-artist failures are surfaced as an `error` field on each result; SoundCloud tokens are now persisted in a service-role-only `provider_tokens` table with DB-lease-serialized refresh, so the token endpoint's rate limits (50 grants/12h) are no longer exhausted by cold starts.

## Verification
- Deploy the function to a test environment
- POST to the function with multiple artist names; verify SoundCloud returns normalized candidates
- Search again after the first request; logs show "Using stored access token" (or the in-memory cache) and no new token-endpoint call
- Check the `provider_tokens` row for `soundcloud`: access/refresh token and `expires_at` populated, `lock_until` null; verify the table is unreadable with anon/authenticated keys
- After the token expires (~1h), search again; logs show a refresh grant (not client_credentials) and the row's `refresh_token` rotates
- Test Spotify provider option; verify it returns empty candidates without error
- Request a single provider only; verify response contains only that provider
- Remove SoundCloud credentials from the environment and search; verify each soundcloud result carries `error: "SoundCloud credentials are not configured"` with empty candidates
- Verify normalization correctly handles missing fields (null avatar_url, missing followers_count, display_name fallback)

Closes #334


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdP5NDJLLG5jBERrPbhvHT)_