### PR TITLE
feat(link-wizard): search-assisted candidate selection

### DIFF
--- a/src/api/artistSearch/mergeCandidateSelection.test.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.test.ts
@@ -3,32 +3,30 @@ import { mergeCandidateSelection } from "./mergeCandidateSelection";
 import type { Candidate } from "./types";
 
 describe("mergeCandidateSelection", () => {
-  it("sets spotify_url when url is selected for spotify", () => {
+  it("sets providerUrl.spotify when url is selected for spotify", () => {
     const candidate = makeCandidate();
 
     const update = mergeCandidateSelection(candidate, "spotify", ["url"]);
 
-    expect(update.spotify_url).toBe(candidate.url);
-    expect(update.soundcloud_url).toBeUndefined();
+    expect(update.providerUrl).toEqual({ spotify: candidate.url });
   });
 
-  it("sets soundcloud_url when url is selected for soundcloud", () => {
+  it("sets providerUrl.soundcloud when url is selected for soundcloud", () => {
     const candidate = makeCandidate({
       url: "https://soundcloud.com/artist",
     });
 
     const update = mergeCandidateSelection(candidate, "soundcloud", ["url"]);
 
-    expect(update.soundcloud_url).toBe(candidate.url);
-    expect(update.spotify_url).toBeUndefined();
+    expect(update.providerUrl).toEqual({ soundcloud: candidate.url });
   });
 
-  it("does not set the url when url is not selected", () => {
+  it("does not set providerUrl when url is not selected", () => {
     const candidate = makeCandidate();
 
     const update = mergeCandidateSelection(candidate, "spotify", ["image"]);
 
-    expect(update.spotify_url).toBeUndefined();
+    expect(update.providerUrl).toBeUndefined();
   });
 
   it("sets image_url when image is selected", () => {
@@ -81,7 +79,7 @@ describe("mergeCandidateSelection", () => {
       "description",
     ]);
 
-    expect(update.spotify_url).toBe(candidate.url);
+    expect(update.providerUrl).toEqual({ spotify: candidate.url });
     expect(update.image_url).toBe(candidate.imageUrl);
     expect(update.description).toBe(candidate.description);
   });

--- a/src/api/artistSearch/mergeCandidateSelection.test.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.test.ts
@@ -32,6 +32,7 @@ function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
     name: "Test Artist",
     url: "https://spotify.com/artist/123",
     imageUrl: "https://example.com/image.jpg",
+    description: "A test artist bio.",
     followers: 1000,
     genres: ["rock", "pop"],
     ...overrides,
@@ -151,6 +152,83 @@ describe("mergeCandidateSelection", () => {
     // Spotify's image wins because it was set first
     expect(update1.image_url).toBe("https://spotify.com/img.jpg");
     expect(update2.image_url).toBeUndefined();
+  });
+
+  it("fills description if not already set on artist", () => {
+    const artist = makeArtist({ id: "a1", description: null });
+    const candidate = makeCandidate({ description: "A great artist." });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.description).toBe(candidate.description);
+  });
+
+  it("does not overwrite existing description on artist", () => {
+    const artist = makeArtist({
+      id: "a1",
+      description: "Existing bio.",
+    });
+    const candidate = makeCandidate({ description: "A great artist." });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.description).toBeUndefined();
+  });
+
+  it("does not overwrite staged description", () => {
+    const artist = makeArtist({ id: "a1", description: null });
+    const candidate = makeCandidate({ description: "A great artist." });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: { description: "Staged bio." },
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.description).toBeUndefined();
+  });
+
+  it("first provider selection wins shared description when both providers selected", () => {
+    const artist = makeArtist({ id: "a1" });
+    const spotifyCandidate = makeCandidate({
+      url: "https://spotify.com/artist/123",
+      description: "Spotify bio.",
+    });
+    const soundcloudCandidate = makeCandidate({
+      url: "https://soundcloud.com/artist",
+      description: "SoundCloud bio.",
+    });
+
+    const context1: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+    const update1 = mergeCandidateSelection(
+      context1,
+      spotifyCandidate,
+      "spotify",
+    );
+
+    const context2: MergeContext = {
+      artist,
+      stagedUpdates: update1,
+    };
+    const update2 = mergeCandidateSelection(
+      context2,
+      soundcloudCandidate,
+      "soundcloud",
+    );
+
+    expect(update1.description).toBe("Spotify bio.");
+    expect(update2.description).toBeUndefined();
   });
 
   it("never writes genres to updates", () => {

--- a/src/api/artistSearch/mergeCandidateSelection.test.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.test.ts
@@ -6,39 +6,6 @@ import {
 import type { Candidate } from "./types";
 import type { Artist } from "@/api/artists/types";
 
-function makeArtist(overrides: Partial<Artist> & { id: string }): Artist {
-  return {
-    name: overrides.name ?? overrides.id,
-    slug: overrides.slug ?? overrides.id,
-    description: null,
-    estimated_date: null,
-    image_url: null,
-    spotify_url: null,
-    soundcloud_url: null,
-    stage: null,
-    time_start: null,
-    time_end: null,
-    archived: false,
-    added_by: "user-1",
-    created_at: "2024-01-01T00:00:00Z",
-    updated_at: "2024-01-01T00:00:00Z",
-    artist_music_genres: [],
-    ...overrides,
-  };
-}
-
-function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
-  return {
-    name: "Test Artist",
-    url: "https://spotify.com/artist/123",
-    imageUrl: "https://example.com/image.jpg",
-    description: "A test artist bio.",
-    followers: 1000,
-    genres: ["rock", "pop"],
-    ...overrides,
-  };
-}
-
 describe("mergeCandidateSelection", () => {
   it("always sets the provider URL field", () => {
     const artist = makeArtist({ id: "a1" });
@@ -244,3 +211,36 @@ describe("mergeCandidateSelection", () => {
     expect(update).not.toHaveProperty("genres");
   });
 });
+
+function makeArtist(overrides: Partial<Artist> & { id: string }): Artist {
+  return {
+    name: overrides.name ?? overrides.id,
+    slug: overrides.slug ?? overrides.id,
+    description: null,
+    estimated_date: null,
+    image_url: null,
+    spotify_url: null,
+    soundcloud_url: null,
+    stage: null,
+    time_start: null,
+    time_end: null,
+    archived: false,
+    added_by: "user-1",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    artist_music_genres: [],
+    ...overrides,
+  };
+}
+
+function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
+  return {
+    name: "Test Artist",
+    url: "https://spotify.com/artist/123",
+    imageUrl: "https://example.com/image.jpg",
+    description: "A test artist bio.",
+    followers: 1000,
+    genres: ["rock", "pop"],
+    ...overrides,
+  };
+}

--- a/src/api/artistSearch/mergeCandidateSelection.test.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.test.ts
@@ -1,237 +1,103 @@
 import { describe, expect, it } from "vitest";
-import {
-  mergeCandidateSelection,
-  type MergeContext,
-} from "./mergeCandidateSelection";
+import { mergeCandidateSelection } from "./mergeCandidateSelection";
 import type { Candidate } from "./types";
-import type { Artist } from "@/api/artists/types";
 
 describe("mergeCandidateSelection", () => {
-  it("always sets the provider URL field", () => {
-    const artist = makeArtist({ id: "a1" });
+  it("sets spotify_url when url is selected for spotify", () => {
     const candidate = makeCandidate();
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
 
-    const update = mergeCandidateSelection(context, candidate, "spotify");
+    const update = mergeCandidateSelection(candidate, "spotify", ["url"]);
 
     expect(update.spotify_url).toBe(candidate.url);
+    expect(update.soundcloud_url).toBeUndefined();
   });
 
-  it("sets soundcloud URL for soundcloud provider", () => {
-    const artist = makeArtist({ id: "a1" });
+  it("sets soundcloud_url when url is selected for soundcloud", () => {
     const candidate = makeCandidate({
       url: "https://soundcloud.com/artist",
     });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
 
-    const update = mergeCandidateSelection(context, candidate, "soundcloud");
+    const update = mergeCandidateSelection(candidate, "soundcloud", ["url"]);
 
     expect(update.soundcloud_url).toBe(candidate.url);
+    expect(update.spotify_url).toBeUndefined();
   });
 
-  it("fills image_url if not already set on artist", () => {
-    const artist = makeArtist({ id: "a1", image_url: null });
+  it("does not set the url when url is not selected", () => {
+    const candidate = makeCandidate();
+
+    const update = mergeCandidateSelection(candidate, "spotify", ["image"]);
+
+    expect(update.spotify_url).toBeUndefined();
+  });
+
+  it("sets image_url when image is selected", () => {
     const candidate = makeCandidate({
       imageUrl: "https://example.com/img.jpg",
     });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
 
-    const update = mergeCandidateSelection(context, candidate, "spotify");
+    const update = mergeCandidateSelection(candidate, "spotify", ["image"]);
 
     expect(update.image_url).toBe(candidate.imageUrl);
   });
 
-  it("does not overwrite existing image_url on artist", () => {
-    const artist = makeArtist({
-      id: "a1",
-      image_url: "https://existing.com/img.jpg",
-    });
-    const candidate = makeCandidate({
-      imageUrl: "https://example.com/img.jpg",
-    });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
+  it("does not set image_url when the candidate has none", () => {
+    const candidate = makeCandidate({ imageUrl: null });
 
-    const update = mergeCandidateSelection(context, candidate, "spotify");
+    const update = mergeCandidateSelection(candidate, "spotify", ["image"]);
 
     expect(update.image_url).toBeUndefined();
   });
 
-  it("does not overwrite staged image_url", () => {
-    const artist = makeArtist({ id: "a1", image_url: null });
-    const candidate = makeCandidate({
-      imageUrl: "https://example.com/img.jpg",
-    });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: { image_url: "https://staged.com/img.jpg" },
-    };
-
-    const update = mergeCandidateSelection(context, candidate, "spotify");
-
-    expect(update.image_url).toBeUndefined();
-  });
-
-  it("first provider selection wins shared image_url when both providers selected", () => {
-    const artist = makeArtist({ id: "a1" });
-    const spotifyCandidate = makeCandidate({
-      url: "https://spotify.com/artist/123",
-      imageUrl: "https://spotify.com/img.jpg",
-    });
-    const soundcloudCandidate = makeCandidate({
-      url: "https://soundcloud.com/artist",
-      imageUrl: "https://soundcloud.com/img.jpg",
-    });
-
-    // First selection - Spotify
-    const context1: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
-    const update1 = mergeCandidateSelection(
-      context1,
-      spotifyCandidate,
-      "spotify",
-    );
-
-    // Second selection - SoundCloud
-    const context2: MergeContext = {
-      artist,
-      stagedUpdates: update1,
-    };
-    const update2 = mergeCandidateSelection(
-      context2,
-      soundcloudCandidate,
-      "soundcloud",
-    );
-
-    // Spotify's image wins because it was set first
-    expect(update1.image_url).toBe("https://spotify.com/img.jpg");
-    expect(update2.image_url).toBeUndefined();
-  });
-
-  it("fills description if not already set on artist", () => {
-    const artist = makeArtist({ id: "a1", description: null });
+  it("sets description when description is selected", () => {
     const candidate = makeCandidate({ description: "A great artist." });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
 
-    const update = mergeCandidateSelection(context, candidate, "spotify");
+    const update = mergeCandidateSelection(candidate, "spotify", [
+      "description",
+    ]);
 
     expect(update.description).toBe(candidate.description);
   });
 
-  it("does not overwrite existing description on artist", () => {
-    const artist = makeArtist({
-      id: "a1",
-      description: "Existing bio.",
-    });
-    const candidate = makeCandidate({ description: "A great artist." });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
+  it("does not set description when the candidate has none", () => {
+    const candidate = makeCandidate({ description: null });
 
-    const update = mergeCandidateSelection(context, candidate, "spotify");
+    const update = mergeCandidateSelection(candidate, "spotify", [
+      "description",
+    ]);
 
     expect(update.description).toBeUndefined();
   });
 
-  it("does not overwrite staged description", () => {
-    const artist = makeArtist({ id: "a1", description: null });
-    const candidate = makeCandidate({ description: "A great artist." });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: { description: "Staged bio." },
-    };
-
-    const update = mergeCandidateSelection(context, candidate, "spotify");
-
-    expect(update.description).toBeUndefined();
-  });
-
-  it("first provider selection wins shared description when both providers selected", () => {
-    const artist = makeArtist({ id: "a1" });
-    const spotifyCandidate = makeCandidate({
-      url: "https://spotify.com/artist/123",
-      description: "Spotify bio.",
-    });
-    const soundcloudCandidate = makeCandidate({
-      url: "https://soundcloud.com/artist",
-      description: "SoundCloud bio.",
+  it("sets all requested fields when multiple are selected", () => {
+    const candidate = makeCandidate({
+      imageUrl: "https://example.com/img.jpg",
+      description: "A great artist.",
     });
 
-    const context1: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
-    const update1 = mergeCandidateSelection(
-      context1,
-      spotifyCandidate,
-      "spotify",
-    );
+    const update = mergeCandidateSelection(candidate, "spotify", [
+      "url",
+      "image",
+      "description",
+    ]);
 
-    const context2: MergeContext = {
-      artist,
-      stagedUpdates: update1,
-    };
-    const update2 = mergeCandidateSelection(
-      context2,
-      soundcloudCandidate,
-      "soundcloud",
-    );
-
-    expect(update1.description).toBe("Spotify bio.");
-    expect(update2.description).toBeUndefined();
+    expect(update.spotify_url).toBe(candidate.url);
+    expect(update.image_url).toBe(candidate.imageUrl);
+    expect(update.description).toBe(candidate.description);
   });
 
   it("never writes genres to updates", () => {
-    const artist = makeArtist({ id: "a1" });
     const candidate = makeCandidate({ genres: ["rock", "pop"] });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
 
-    const update = mergeCandidateSelection(context, candidate, "spotify");
+    const update = mergeCandidateSelection(candidate, "spotify", [
+      "url",
+      "image",
+      "description",
+    ]);
 
     expect(update).not.toHaveProperty("genres");
   });
 });
-
-function makeArtist(overrides: Partial<Artist> & { id: string }): Artist {
-  return {
-    name: overrides.name ?? overrides.id,
-    slug: overrides.slug ?? overrides.id,
-    description: null,
-    estimated_date: null,
-    image_url: null,
-    spotify_url: null,
-    soundcloud_url: null,
-    stage: null,
-    time_start: null,
-    time_end: null,
-    archived: false,
-    added_by: "user-1",
-    created_at: "2024-01-01T00:00:00Z",
-    updated_at: "2024-01-01T00:00:00Z",
-    artist_music_genres: [],
-    ...overrides,
-  };
-}
 
 function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
   return {

--- a/src/api/artistSearch/mergeCandidateSelection.test.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.test.ts
@@ -95,6 +95,47 @@ describe("mergeCandidateSelection", () => {
 
     expect(update).not.toHaveProperty("genres");
   });
+
+  it("does not overwrite an already-staged image_url", () => {
+    const candidate = makeCandidate({
+      imageUrl: "https://example.com/other-image.jpg",
+    });
+
+    const update = mergeCandidateSelection(candidate, "spotify", ["image"], {
+      image_url: "https://example.com/first-image.jpg",
+    });
+
+    expect(update.image_url).toBeUndefined();
+  });
+
+  it("does not overwrite an already-staged description", () => {
+    const candidate = makeCandidate({ description: "Another bio." });
+
+    const update = mergeCandidateSelection(
+      candidate,
+      "spotify",
+      ["description"],
+      { description: "First staged bio." },
+    );
+
+    expect(update.description).toBeUndefined();
+  });
+
+  it("still sets providerUrl even when other fields are already staged", () => {
+    const candidate = makeCandidate();
+
+    const update = mergeCandidateSelection(
+      candidate,
+      "spotify",
+      ["url", "image", "description"],
+      {
+        image_url: "https://example.com/first-image.jpg",
+        description: "First staged bio.",
+      },
+    );
+
+    expect(update.providerUrl).toEqual({ spotify: candidate.url });
+  });
 });
 
 function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {

--- a/src/api/artistSearch/mergeCandidateSelection.test.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.test.ts
@@ -115,48 +115,6 @@ describe("mergeCandidateSelection", () => {
     expect(update.image_url).toBeUndefined();
   });
 
-  it("fills description if not already set on artist", () => {
-    const artist = makeArtist({ id: "a1", description: null });
-    const candidate = makeCandidate({ name: "Test Band" });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
-
-    const update = mergeCandidateSelection(context, candidate, "spotify");
-
-    expect(update.description).toBe("Test Band");
-  });
-
-  it("does not overwrite existing description on artist", () => {
-    const artist = makeArtist({
-      id: "a1",
-      description: "Existing description",
-    });
-    const candidate = makeCandidate({ name: "Test Band" });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: {},
-    };
-
-    const update = mergeCandidateSelection(context, candidate, "spotify");
-
-    expect(update.description).toBeUndefined();
-  });
-
-  it("does not overwrite staged description", () => {
-    const artist = makeArtist({ id: "a1", description: null });
-    const candidate = makeCandidate({ name: "Test Band" });
-    const context: MergeContext = {
-      artist,
-      stagedUpdates: { description: "Staged description" },
-    };
-
-    const update = mergeCandidateSelection(context, candidate, "spotify");
-
-    expect(update.description).toBeUndefined();
-  });
-
   it("first provider selection wins shared image_url when both providers selected", () => {
     const artist = makeArtist({ id: "a1" });
     const spotifyCandidate = makeCandidate({

--- a/src/api/artistSearch/mergeCandidateSelection.test.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeCandidateSelection,
+  type MergeContext,
+} from "./mergeCandidateSelection";
+import type { Candidate } from "./types";
+import type { Artist } from "@/api/artists/types";
+
+function makeArtist(overrides: Partial<Artist> & { id: string }): Artist {
+  return {
+    name: overrides.name ?? overrides.id,
+    slug: overrides.slug ?? overrides.id,
+    description: null,
+    estimated_date: null,
+    image_url: null,
+    spotify_url: null,
+    soundcloud_url: null,
+    stage: null,
+    time_start: null,
+    time_end: null,
+    archived: false,
+    added_by: "user-1",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    artist_music_genres: [],
+    ...overrides,
+  };
+}
+
+function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
+  return {
+    name: "Test Artist",
+    url: "https://spotify.com/artist/123",
+    imageUrl: "https://example.com/image.jpg",
+    followers: 1000,
+    genres: ["rock", "pop"],
+    ...overrides,
+  };
+}
+
+describe("mergeCandidateSelection", () => {
+  it("always sets the provider URL field", () => {
+    const artist = makeArtist({ id: "a1" });
+    const candidate = makeCandidate();
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.spotify_url).toBe(candidate.url);
+  });
+
+  it("sets soundcloud URL for soundcloud provider", () => {
+    const artist = makeArtist({ id: "a1" });
+    const candidate = makeCandidate({
+      url: "https://soundcloud.com/artist",
+    });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "soundcloud");
+
+    expect(update.soundcloud_url).toBe(candidate.url);
+  });
+
+  it("fills image_url if not already set on artist", () => {
+    const artist = makeArtist({ id: "a1", image_url: null });
+    const candidate = makeCandidate({
+      imageUrl: "https://example.com/img.jpg",
+    });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.image_url).toBe(candidate.imageUrl);
+  });
+
+  it("does not overwrite existing image_url on artist", () => {
+    const artist = makeArtist({
+      id: "a1",
+      image_url: "https://existing.com/img.jpg",
+    });
+    const candidate = makeCandidate({
+      imageUrl: "https://example.com/img.jpg",
+    });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.image_url).toBeUndefined();
+  });
+
+  it("does not overwrite staged image_url", () => {
+    const artist = makeArtist({ id: "a1", image_url: null });
+    const candidate = makeCandidate({
+      imageUrl: "https://example.com/img.jpg",
+    });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: { image_url: "https://staged.com/img.jpg" },
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.image_url).toBeUndefined();
+  });
+
+  it("fills description if not already set on artist", () => {
+    const artist = makeArtist({ id: "a1", description: null });
+    const candidate = makeCandidate({ name: "Test Band" });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.description).toBe("Test Band");
+  });
+
+  it("does not overwrite existing description on artist", () => {
+    const artist = makeArtist({
+      id: "a1",
+      description: "Existing description",
+    });
+    const candidate = makeCandidate({ name: "Test Band" });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.description).toBeUndefined();
+  });
+
+  it("does not overwrite staged description", () => {
+    const artist = makeArtist({ id: "a1", description: null });
+    const candidate = makeCandidate({ name: "Test Band" });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: { description: "Staged description" },
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update.description).toBeUndefined();
+  });
+
+  it("first provider selection wins shared image_url when both providers selected", () => {
+    const artist = makeArtist({ id: "a1" });
+    const spotifyCandidate = makeCandidate({
+      url: "https://spotify.com/artist/123",
+      imageUrl: "https://spotify.com/img.jpg",
+    });
+    const soundcloudCandidate = makeCandidate({
+      url: "https://soundcloud.com/artist",
+      imageUrl: "https://soundcloud.com/img.jpg",
+    });
+
+    // First selection - Spotify
+    const context1: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+    const update1 = mergeCandidateSelection(
+      context1,
+      spotifyCandidate,
+      "spotify",
+    );
+
+    // Second selection - SoundCloud
+    const context2: MergeContext = {
+      artist,
+      stagedUpdates: update1,
+    };
+    const update2 = mergeCandidateSelection(
+      context2,
+      soundcloudCandidate,
+      "soundcloud",
+    );
+
+    // Spotify's image wins because it was set first
+    expect(update1.image_url).toBe("https://spotify.com/img.jpg");
+    expect(update2.image_url).toBeUndefined();
+  });
+
+  it("never writes genres to updates", () => {
+    const artist = makeArtist({ id: "a1" });
+    const candidate = makeCandidate({ genres: ["rock", "pop"] });
+    const context: MergeContext = {
+      artist,
+      stagedUpdates: {},
+    };
+
+    const update = mergeCandidateSelection(context, candidate, "spotify");
+
+    expect(update).not.toHaveProperty("genres");
+  });
+});

--- a/src/api/artistSearch/mergeCandidateSelection.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.ts
@@ -5,7 +5,6 @@ export interface CandidateUpdate {
   spotify_url?: string | null;
   soundcloud_url?: string | null;
   image_url?: string | null;
-  description?: string | null;
 }
 
 export interface MergeContext {
@@ -29,15 +28,9 @@ export function mergeCandidateSelection(
   }
 
   const existingImage = artist.image_url || stagedUpdates.image_url || null;
-  const existingDescription =
-    artist.description || stagedUpdates.description || null;
 
   if (!existingImage && candidate.imageUrl) {
     updates.image_url = candidate.imageUrl;
-  }
-
-  if (!existingDescription && candidate.name) {
-    updates.description = candidate.name;
   }
 
   return updates;

--- a/src/api/artistSearch/mergeCandidateSelection.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.ts
@@ -5,6 +5,7 @@ export interface CandidateUpdate {
   spotify_url?: string | null;
   soundcloud_url?: string | null;
   image_url?: string | null;
+  description?: string | null;
 }
 
 export interface MergeContext {
@@ -31,6 +32,13 @@ export function mergeCandidateSelection(
 
   if (!existingImage && candidate.imageUrl) {
     updates.image_url = candidate.imageUrl;
+  }
+
+  const existingDescription =
+    artist.description || stagedUpdates.description || null;
+
+  if (!existingDescription && candidate.description) {
+    updates.description = candidate.description;
   }
 
   return updates;

--- a/src/api/artistSearch/mergeCandidateSelection.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.ts
@@ -8,10 +8,16 @@ export interface CandidateUpdate {
 
 export type SelectableField = "url" | "image" | "description";
 
+export interface StagedValues {
+  image_url?: string | null | undefined;
+  description?: string | null | undefined;
+}
+
 export function mergeCandidateSelection(
   candidate: Candidate,
   provider: Provider,
   fields: SelectableField[],
+  staged: StagedValues = {},
 ): CandidateUpdate {
   const updates: CandidateUpdate = {};
 
@@ -19,11 +25,15 @@ export function mergeCandidateSelection(
     updates.providerUrl = { [provider]: candidate.url };
   }
 
-  if (fields.includes("image") && candidate.imageUrl) {
+  if (fields.includes("image") && candidate.imageUrl && !staged.image_url) {
     updates.image_url = candidate.imageUrl;
   }
 
-  if (fields.includes("description") && candidate.description) {
+  if (
+    fields.includes("description") &&
+    candidate.description &&
+    !staged.description
+  ) {
     updates.description = candidate.description;
   }
 

--- a/src/api/artistSearch/mergeCandidateSelection.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.ts
@@ -1,8 +1,7 @@
 import type { Candidate, Provider } from "./types";
 
 export interface CandidateUpdate {
-  spotify_url?: string | null;
-  soundcloud_url?: string | null;
+  providerUrl?: Partial<Record<Provider, string>>;
   image_url?: string | null;
   description?: string | null;
 }
@@ -17,11 +16,7 @@ export function mergeCandidateSelection(
   const updates: CandidateUpdate = {};
 
   if (fields.includes("url")) {
-    if (provider === "spotify") {
-      updates.spotify_url = candidate.url;
-    } else {
-      updates.soundcloud_url = candidate.url;
-    }
+    updates.providerUrl = { [provider]: candidate.url };
   }
 
   if (fields.includes("image") && candidate.imageUrl) {

--- a/src/api/artistSearch/mergeCandidateSelection.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.ts
@@ -1,0 +1,44 @@
+import type { Artist } from "@/api/artists/types";
+import type { Candidate, Provider } from "./types";
+
+export interface CandidateUpdate {
+  spotify_url?: string | null;
+  soundcloud_url?: string | null;
+  image_url?: string | null;
+  description?: string | null;
+}
+
+export interface MergeContext {
+  artist: Artist;
+  stagedUpdates: CandidateUpdate;
+}
+
+export function mergeCandidateSelection(
+  context: MergeContext,
+  candidate: Candidate,
+  provider: Provider,
+): CandidateUpdate {
+  const { artist, stagedUpdates } = context;
+
+  const updates: CandidateUpdate = {};
+
+  if (provider === "spotify") {
+    updates.spotify_url = candidate.url;
+  } else if (provider === "soundcloud") {
+    updates.soundcloud_url = candidate.url;
+  }
+
+  const existingImage = artist.image_url || stagedUpdates.image_url || null;
+  const existingDescription =
+    artist.description || stagedUpdates.description || null;
+
+  if (!existingImage && candidate.imageUrl) {
+    updates.image_url = candidate.imageUrl;
+  }
+
+  if (!existingDescription && candidate.name) {
+    updates.description = candidate.name;
+  }
+
+  return updates;
+}

--- a/src/api/artistSearch/mergeCandidateSelection.ts
+++ b/src/api/artistSearch/mergeCandidateSelection.ts
@@ -1,4 +1,3 @@
-import type { Artist } from "@/api/artists/types";
 import type { Candidate, Provider } from "./types";
 
 export interface CandidateUpdate {
@@ -8,36 +7,28 @@ export interface CandidateUpdate {
   description?: string | null;
 }
 
-export interface MergeContext {
-  artist: Artist;
-  stagedUpdates: CandidateUpdate;
-}
+export type SelectableField = "url" | "image" | "description";
 
 export function mergeCandidateSelection(
-  context: MergeContext,
   candidate: Candidate,
   provider: Provider,
+  fields: SelectableField[],
 ): CandidateUpdate {
-  const { artist, stagedUpdates } = context;
-
   const updates: CandidateUpdate = {};
 
-  if (provider === "spotify") {
-    updates.spotify_url = candidate.url;
-  } else if (provider === "soundcloud") {
-    updates.soundcloud_url = candidate.url;
+  if (fields.includes("url")) {
+    if (provider === "spotify") {
+      updates.spotify_url = candidate.url;
+    } else {
+      updates.soundcloud_url = candidate.url;
+    }
   }
 
-  const existingImage = artist.image_url || stagedUpdates.image_url || null;
-
-  if (!existingImage && candidate.imageUrl) {
+  if (fields.includes("image") && candidate.imageUrl) {
     updates.image_url = candidate.imageUrl;
   }
 
-  const existingDescription =
-    artist.description || stagedUpdates.description || null;
-
-  if (!existingDescription && candidate.description) {
+  if (fields.includes("description") && candidate.description) {
     updates.description = candidate.description;
   }
 

--- a/src/api/artistSearch/types.ts
+++ b/src/api/artistSearch/types.ts
@@ -1,0 +1,26 @@
+export type Provider = "soundcloud" | "spotify";
+
+export interface Candidate {
+  name: string;
+  url: string;
+  imageUrl: string | null;
+  followers: number | null;
+  genres: string[];
+}
+
+export interface SearchResult {
+  artistName: string;
+  provider: Provider;
+  candidates: Candidate[];
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+}
+
+export const artistSearchKeys = {
+  all: ["artistSearch"] as const,
+  searches: () => [...artistSearchKeys.all, "search"] as const,
+  search: (batch: number) =>
+    [...artistSearchKeys.searches(), { batch }] as const,
+};

--- a/src/api/artistSearch/types.ts
+++ b/src/api/artistSearch/types.ts
@@ -1,24 +1,30 @@
-export type Provider = "soundcloud" | "spotify";
+import { z } from "zod";
 
-export interface Candidate {
-  name: string;
-  url: string;
-  imageUrl: string | null;
-  description: string | null;
-  followers: number | null;
-  genres: string[];
-}
+export const providerSchema = z.enum(["soundcloud", "spotify"]);
+export type Provider = z.infer<typeof providerSchema>;
 
-export interface SearchResult {
-  artistName: string;
-  provider: Provider;
-  candidates: Candidate[];
-  error?: string;
-}
+export const candidateSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  imageUrl: z.string().nullable(),
+  description: z.string().nullable(),
+  followers: z.number().nullable(),
+  genres: z.array(z.string()),
+});
+export type Candidate = z.infer<typeof candidateSchema>;
 
-export interface SearchResponse {
-  results: SearchResult[];
-}
+export const searchResultSchema = z.object({
+  artistName: z.string(),
+  provider: providerSchema,
+  candidates: z.array(candidateSchema),
+  error: z.string().optional(),
+});
+export type SearchResult = z.infer<typeof searchResultSchema>;
+
+export const searchResponseSchema = z.object({
+  results: z.array(searchResultSchema),
+});
+export type SearchResponse = z.infer<typeof searchResponseSchema>;
 
 export const artistSearchKeys = {
   all: ["artistSearch"] as const,

--- a/src/api/artistSearch/types.ts
+++ b/src/api/artistSearch/types.ts
@@ -4,6 +4,7 @@ export interface Candidate {
   name: string;
   url: string;
   imageUrl: string | null;
+  description: string | null;
   followers: number | null;
   genres: string[];
 }

--- a/src/api/artistSearch/types.ts
+++ b/src/api/artistSearch/types.ts
@@ -12,6 +12,7 @@ export interface SearchResult {
   artistName: string;
   provider: Provider;
   candidates: Candidate[];
+  error?: string;
 }
 
 export interface SearchResponse {

--- a/src/api/artistSearch/types.ts
+++ b/src/api/artistSearch/types.ts
@@ -21,6 +21,6 @@ export interface SearchResponse {
 export const artistSearchKeys = {
   all: ["artistSearch"] as const,
   searches: () => [...artistSearchKeys.all, "search"] as const,
-  search: (batch: number) =>
-    [...artistSearchKeys.searches(), { batch }] as const,
+  search: (artistNames: string[], provider?: Provider) =>
+    [...artistSearchKeys.searches(), { artistNames, provider }] as const,
 };

--- a/src/api/artistSearch/usePrefetchNextBatchLinks.ts
+++ b/src/api/artistSearch/usePrefetchNextBatchLinks.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { Artist } from "@/api/artists/types";
+import { searchArtistLinksQuery } from "./useSearchArtistLinksQuery";
+
+export function usePrefetchNextBatchLinks(
+  artists: Artist[],
+  currentArtistId: string | undefined,
+) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!currentArtistId || artists.length === 0) return;
+
+    const currentIdx = Math.max(
+      0,
+      artists.findIndex((a) => a.id === currentArtistId),
+    );
+    const positionInBatch = currentIdx % 10;
+
+    if (positionInBatch < 8) return;
+
+    const nextBatchStart = Math.floor(currentIdx / 10) * 10 + 10;
+    const nextBatchArtists = artists
+      .slice(nextBatchStart, nextBatchStart + 10)
+      .map((a) => a.name);
+
+    if (nextBatchArtists.length > 0) {
+      queryClient.prefetchQuery(searchArtistLinksQuery(nextBatchArtists));
+    }
+  }, [currentArtistId, artists, queryClient]);
+}

--- a/src/api/artistSearch/useSearchArtistLinksQuery.ts
+++ b/src/api/artistSearch/useSearchArtistLinksQuery.ts
@@ -1,0 +1,52 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { artistSearchKeys, type SearchResponse, type Provider } from "./types";
+
+async function fetchSearchArtistLinks(
+  artistNames: string[],
+  provider?: Provider,
+): Promise<SearchResponse> {
+  if (artistNames.length === 0) {
+    return { results: [] };
+  }
+
+  const { data, error } = await supabase.functions.invoke(
+    "search-artist-links",
+    {
+      body: {
+        artistNames,
+        provider,
+      },
+    },
+  );
+
+  if (error) {
+    console.error("Error searching artist links:", error);
+    throw new Error("Failed to search artist links");
+  }
+
+  return data as SearchResponse;
+}
+
+export function searchArtistLinksQuery(
+  artistNames: string[],
+  provider?: Provider,
+  batch?: number,
+) {
+  return queryOptions({
+    queryKey: artistSearchKeys.search(batch ?? 0),
+    queryFn: () => fetchSearchArtistLinks(artistNames, provider),
+    enabled: artistNames.length > 0,
+    staleTime: 1000 * 60 * 30,
+  });
+}
+
+export function useSearchArtistLinksQuery(
+  artistNames: string[],
+  provider?: Provider,
+  batch?: number,
+) {
+  return useQuery({
+    ...searchArtistLinksQuery(artistNames, provider, batch),
+  });
+}

--- a/src/api/artistSearch/useSearchArtistLinksQuery.ts
+++ b/src/api/artistSearch/useSearchArtistLinksQuery.ts
@@ -1,6 +1,11 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { artistSearchKeys, type SearchResponse, type Provider } from "./types";
+import {
+  artistSearchKeys,
+  searchResponseSchema,
+  type SearchResponse,
+  type Provider,
+} from "./types";
 
 async function fetchSearchArtistLinks(
   artistNames: string[],
@@ -25,7 +30,7 @@ async function fetchSearchArtistLinks(
     throw new Error("Failed to search artist links");
   }
 
-  return data as SearchResponse;
+  return searchResponseSchema.parse(data);
 }
 
 export function searchArtistLinksQuery(

--- a/src/api/artistSearch/useSearchArtistLinksQuery.ts
+++ b/src/api/artistSearch/useSearchArtistLinksQuery.ts
@@ -31,10 +31,9 @@ async function fetchSearchArtistLinks(
 export function searchArtistLinksQuery(
   artistNames: string[],
   provider?: Provider,
-  batch?: number,
 ) {
   return queryOptions({
-    queryKey: artistSearchKeys.search(batch ?? 0),
+    queryKey: artistSearchKeys.search(artistNames, provider),
     queryFn: () => fetchSearchArtistLinks(artistNames, provider),
     enabled: artistNames.length > 0,
     staleTime: 1000 * 60 * 30,
@@ -44,9 +43,8 @@ export function searchArtistLinksQuery(
 export function useSearchArtistLinksQuery(
   artistNames: string[],
   provider?: Provider,
-  batch?: number,
 ) {
   return useQuery({
-    ...searchArtistLinksQuery(artistNames, provider, batch),
+    ...searchArtistLinksQuery(artistNames, provider),
   });
 }

--- a/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Users } from "lucide-react";
+import type { Candidate } from "@/api/artistSearch/types";
+
+interface CandidateCardProps {
+  candidate: Candidate;
+  onSelect: (candidate: Candidate) => void;
+}
+
+export function CandidateCard({ candidate, onSelect }: CandidateCardProps) {
+  return (
+    <Card className="p-3">
+      <div className="space-y-2">
+        {candidate.imageUrl && (
+          <img
+            src={candidate.imageUrl}
+            alt={candidate.name}
+            className="w-full h-24 object-cover rounded"
+          />
+        )}
+        <div>
+          <p className="font-medium text-sm line-clamp-2">{candidate.name}</p>
+          {candidate.followers !== null && (
+            <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+              <Users className="h-3 w-3" />
+              {formatFollowers(candidate.followers)}
+            </div>
+          )}
+        </div>
+        {candidate.genres.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {candidate.genres.slice(0, 2).map((genre) => (
+              <Badge key={genre} variant="secondary" className="text-xs">
+                {genre}
+              </Badge>
+            ))}
+            {candidate.genres.length > 2 && (
+              <Badge variant="secondary" className="text-xs">
+                +{candidate.genres.length - 2}
+              </Badge>
+            )}
+          </div>
+        )}
+        <Button
+          type="button"
+          size="sm"
+          className="w-full mt-2"
+          onClick={() => onSelect(candidate)}
+        >
+          Select
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function formatFollowers(followers: number): string {
+  return followers < 1000
+    ? followers.toString()
+    : `${(followers / 1000).toFixed(1)}k`;
+}

--- a/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
@@ -3,13 +3,20 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Users } from "lucide-react";
 import type { Candidate } from "@/api/artistSearch/types";
+import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 
 interface CandidateCardProps {
   candidate: Candidate;
-  onSelect: (candidate: Candidate) => void;
+  onSelect: (candidate: Candidate, fields: SelectableField[]) => void;
 }
 
 export function CandidateCard({ candidate, onSelect }: CandidateCardProps) {
+  const availableFields: SelectableField[] = [
+    "url",
+    ...(candidate.imageUrl ? (["image"] as const) : []),
+    ...(candidate.description ? (["description"] as const) : []),
+  ];
+
   return (
     <Card className="p-3">
       <div className="space-y-2">
@@ -47,10 +54,43 @@ export function CandidateCard({ candidate, onSelect }: CandidateCardProps) {
           type="button"
           size="sm"
           className="w-full mt-2"
-          onClick={() => onSelect(candidate)}
+          onClick={() => onSelect(candidate, availableFields)}
         >
-          Select
+          Select all
         </Button>
+        <div className="flex gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="flex-1"
+            onClick={() => onSelect(candidate, ["url"])}
+          >
+            URL
+          </Button>
+          {candidate.imageUrl && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="flex-1"
+              onClick={() => onSelect(candidate, ["image"])}
+            >
+              Image
+            </Button>
+          )}
+          {candidate.description && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="flex-1"
+              onClick={() => onSelect(candidate, ["description"])}
+            >
+              Description
+            </Button>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -56,7 +56,7 @@ export function CandidateCards({
                 {candidate.followers !== null && (
                   <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
                     <Users className="h-3 w-3" />
-                    {(candidate.followers / 1000).toFixed(1)}k
+                    {formatFollowers(candidate.followers)}
                   </div>
                 )}
               </div>
@@ -87,4 +87,10 @@ export function CandidateCards({
       </div>
     </div>
   );
+}
+
+function formatFollowers(followers: number): string {
+  return followers < 1000
+    ? followers.toString()
+    : `${(followers / 1000).toFixed(1)}k`;
 }

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -75,6 +75,7 @@ export function CandidateCards({
                 </div>
               )}
               <Button
+                type="button"
                 size="sm"
                 className="w-full mt-2"
                 onClick={() => onSelectCandidate(candidate)}

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -1,13 +1,14 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Candidate } from "@/api/artistSearch/types";
 import type { Provider } from "@/api/artistSearch/types";
+import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 import { CandidateCard } from "./CandidateCard";
 
 interface CandidateCardsProps {
   candidates: Candidate[];
   provider: Provider;
   isLoading: boolean;
-  onSelectCandidate: (candidate: Candidate) => void;
+  onSelectCandidate: (candidate: Candidate, fields: SelectableField[]) => void;
 }
 
 export function CandidateCards({

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -40,14 +40,8 @@ export function CandidateCards({
       </p>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
         {candidates.slice(0, 3).map((candidate) => (
-          <Card
-            key={candidate.url}
-            className="p-3 cursor-pointer hover:shadow-md transition-shadow"
-          >
-            <div
-              onClick={() => onSelectCandidate(candidate)}
-              className="space-y-2"
-            >
+          <Card key={candidate.url} className="p-3">
+            <div className="space-y-2">
               {candidate.imageUrl && (
                 <img
                   src={candidate.imageUrl}
@@ -83,10 +77,7 @@ export function CandidateCards({
               <Button
                 size="sm"
                 className="w-full mt-2"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSelectCandidate(candidate);
-                }}
+                onClick={() => onSelectCandidate(candidate)}
               >
                 Select
               </Button>

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -1,19 +1,16 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Candidate } from "@/api/artistSearch/types";
-import type { Provider } from "@/api/artistSearch/types";
 import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 import { CandidateCard } from "./CandidateCard";
 
 interface CandidateCardsProps {
   candidates: Candidate[];
-  provider: Provider;
   isLoading: boolean;
   onSelectCandidate: (candidate: Candidate, fields: SelectableField[]) => void;
 }
 
 export function CandidateCards({
   candidates,
-  provider,
   isLoading,
   onSelectCandidate,
 }: CandidateCardsProps) {
@@ -32,19 +29,14 @@ export function CandidateCards({
   }
 
   return (
-    <div className="space-y-2">
-      <p className="text-sm font-medium">
-        {provider === "spotify" ? "Spotify" : "SoundCloud"} Candidates
-      </p>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        {candidates.slice(0, 3).map((candidate) => (
-          <CandidateCard
-            key={candidate.url}
-            candidate={candidate}
-            onSelect={onSelectCandidate}
-          />
-        ))}
-      </div>
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+      {candidates.slice(0, 3).map((candidate) => (
+        <CandidateCard
+          key={candidate.url}
+          candidate={candidate}
+          onSelect={onSelectCandidate}
+        />
+      ))}
     </div>
   );
 }

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -1,10 +1,7 @@
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Users } from "lucide-react";
 import type { Candidate } from "@/api/artistSearch/types";
 import type { Provider } from "@/api/artistSearch/types";
+import { CandidateCard } from "./CandidateCard";
 
 interface CandidateCardsProps {
   candidates: Candidate[];
@@ -40,58 +37,13 @@ export function CandidateCards({
       </p>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
         {candidates.slice(0, 3).map((candidate) => (
-          <Card key={candidate.url} className="p-3">
-            <div className="space-y-2">
-              {candidate.imageUrl && (
-                <img
-                  src={candidate.imageUrl}
-                  alt={candidate.name}
-                  className="w-full h-24 object-cover rounded"
-                />
-              )}
-              <div>
-                <p className="font-medium text-sm line-clamp-2">
-                  {candidate.name}
-                </p>
-                {candidate.followers !== null && (
-                  <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
-                    <Users className="h-3 w-3" />
-                    {formatFollowers(candidate.followers)}
-                  </div>
-                )}
-              </div>
-              {candidate.genres.length > 0 && (
-                <div className="flex flex-wrap gap-1">
-                  {candidate.genres.slice(0, 2).map((genre) => (
-                    <Badge key={genre} variant="secondary" className="text-xs">
-                      {genre}
-                    </Badge>
-                  ))}
-                  {candidate.genres.length > 2 && (
-                    <Badge variant="secondary" className="text-xs">
-                      +{candidate.genres.length - 2}
-                    </Badge>
-                  )}
-                </div>
-              )}
-              <Button
-                type="button"
-                size="sm"
-                className="w-full mt-2"
-                onClick={() => onSelectCandidate(candidate)}
-              >
-                Select
-              </Button>
-            </div>
-          </Card>
+          <CandidateCard
+            key={candidate.url}
+            candidate={candidate}
+            onSelect={onSelectCandidate}
+          />
         ))}
       </div>
     </div>
   );
-}
-
-function formatFollowers(followers: number): string {
-  return followers < 1000
-    ? followers.toString()
-    : `${(followers / 1000).toFixed(1)}k`;
 }

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -1,0 +1,99 @@
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Users } from "lucide-react";
+import type { Candidate } from "@/api/artistSearch/types";
+import type { Provider } from "@/api/artistSearch/types";
+
+interface CandidateCardsProps {
+  candidates: Candidate[];
+  provider: Provider;
+  isLoading: boolean;
+  onSelectCandidate: (candidate: Candidate) => void;
+}
+
+export function CandidateCards({
+  candidates,
+  provider,
+  isLoading,
+  onSelectCandidate,
+}: CandidateCardsProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-40 rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">
+        {provider === "spotify" ? "Spotify" : "SoundCloud"} Candidates
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {candidates.slice(0, 3).map((candidate) => (
+          <Card
+            key={candidate.url}
+            className="p-3 cursor-pointer hover:shadow-md transition-shadow"
+          >
+            <div
+              onClick={() => onSelectCandidate(candidate)}
+              className="space-y-2"
+            >
+              {candidate.imageUrl && (
+                <img
+                  src={candidate.imageUrl}
+                  alt={candidate.name}
+                  className="w-full h-24 object-cover rounded"
+                />
+              )}
+              <div>
+                <p className="font-medium text-sm line-clamp-2">
+                  {candidate.name}
+                </p>
+                {candidate.followers !== null && (
+                  <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+                    <Users className="h-3 w-3" />
+                    {(candidate.followers / 1000).toFixed(1)}k
+                  </div>
+                )}
+              </div>
+              {candidate.genres.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {candidate.genres.slice(0, 2).map((genre) => (
+                    <Badge key={genre} variant="secondary" className="text-xs">
+                      {genre}
+                    </Badge>
+                  ))}
+                  {candidate.genres.length > 2 && (
+                    <Badge variant="secondary" className="text-xs">
+                      +{candidate.genres.length - 2}
+                    </Badge>
+                  )}
+                </div>
+              )}
+              <Button
+                size="sm"
+                className="w-full mt-2"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSelectCandidate(candidate);
+                }}
+              >
+                Select
+              </Button>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/festivals/LinkWizard/LinkWizard.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizard.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Loader2, LinkIcon } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useArtistsMissingLinksByEditionQuery } from "@/api/artists/useArtistsMissingLinksByEdition";
+import { searchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
 import type { AdminArtistsPageSize } from "@/pages/admin/ArtistsManagement/searchSchema";
 import type { Artist } from "@/api/artists/types";
 import { LinkWizardStep } from "./LinkWizardStep";
@@ -12,12 +14,35 @@ interface LinkWizardProps {
 }
 
 export function LinkWizard({ editionId }: LinkWizardProps) {
+  const queryClient = useQueryClient();
   const artistsQuery = useArtistsMissingLinksByEditionQuery(editionId);
   const [currentArtistId, setCurrentArtistId] = useState<string | undefined>(
     undefined,
   );
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState<AdminArtistsPageSize>(10);
+
+  useEffect(() => {
+    const artists = artistsQuery.data ?? [];
+    if (!currentArtistId || artists.length === 0) return;
+
+    const currentIdx = Math.max(
+      0,
+      artists.findIndex((a) => a.id === currentArtistId),
+    );
+    const positionInBatch = currentIdx % 10;
+
+    if (positionInBatch >= 8) {
+      const nextBatchStart = Math.floor(currentIdx / 10) * 10 + 10;
+      const nextBatchArtists = artists
+        .slice(nextBatchStart, nextBatchStart + 10)
+        .map((a) => a.name);
+
+      if (nextBatchArtists.length > 0) {
+        queryClient.prefetchQuery(searchArtistLinksQuery(nextBatchArtists));
+      }
+    }
+  }, [currentArtistId, artistsQuery.data, queryClient]);
 
   if (artistsQuery.isLoading) {
     return (
@@ -71,6 +96,7 @@ export function LinkWizard({ editionId }: LinkWizardProps) {
                 artist={currentArtist}
                 position={currentIndex + 1}
                 total={artists.length}
+                artists={artists}
                 onPrev={() => goTo(currentIndex - 1)}
                 onNext={() => goTo(currentIndex + 1)}
               />

--- a/src/pages/admin/festivals/LinkWizard/LinkWizard.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizard.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Loader2, LinkIcon } from "lucide-react";
-import { useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useArtistsMissingLinksByEditionQuery } from "@/api/artists/useArtistsMissingLinksByEdition";
-import { searchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
+import { usePrefetchNextBatchLinks } from "@/api/artistSearch/usePrefetchNextBatchLinks";
 import type { AdminArtistsPageSize } from "@/pages/admin/ArtistsManagement/searchSchema";
 import type { Artist } from "@/api/artists/types";
 import { LinkWizardStep } from "./LinkWizardStep";
@@ -14,7 +13,6 @@ interface LinkWizardProps {
 }
 
 export function LinkWizard({ editionId }: LinkWizardProps) {
-  const queryClient = useQueryClient();
   const artistsQuery = useArtistsMissingLinksByEditionQuery(editionId);
   const [currentArtistId, setCurrentArtistId] = useState<string | undefined>(
     undefined,
@@ -22,27 +20,7 @@ export function LinkWizard({ editionId }: LinkWizardProps) {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState<AdminArtistsPageSize>(10);
 
-  useEffect(() => {
-    const artists = artistsQuery.data ?? [];
-    if (!currentArtistId || artists.length === 0) return;
-
-    const currentIdx = Math.max(
-      0,
-      artists.findIndex((a) => a.id === currentArtistId),
-    );
-    const positionInBatch = currentIdx % 10;
-
-    if (positionInBatch >= 8) {
-      const nextBatchStart = Math.floor(currentIdx / 10) * 10 + 10;
-      const nextBatchArtists = artists
-        .slice(nextBatchStart, nextBatchStart + 10)
-        .map((a) => a.name);
-
-      if (nextBatchArtists.length > 0) {
-        queryClient.prefetchQuery(searchArtistLinksQuery(nextBatchArtists));
-      }
-    }
-  }, [currentArtistId, artistsQuery.data, queryClient]);
+  usePrefetchNextBatchLinks(artistsQuery.data ?? [], currentArtistId);
 
   if (artistsQuery.isLoading) {
     return (

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -35,19 +35,6 @@ const linkStepSchema = z.object({
 
 type LinkStepData = z.infer<typeof linkStepSchema>;
 
-const URL_FIELDS = [
-  {
-    fieldName: "providerUrl.spotify",
-    label: "Spotify URL",
-    placeholder: "https://open.spotify.com/artist/...",
-  },
-  {
-    fieldName: "providerUrl.soundcloud",
-    label: "SoundCloud URL",
-    placeholder: "https://soundcloud.com/...",
-  },
-];
-
 interface LinkWizardStepProps {
   artist: Artist;
   position: number;
@@ -119,7 +106,7 @@ export function LinkWizardStep({
             />
           )}
 
-          <StagedFieldsPreview form={form} urlFields={URL_FIELDS} />
+          <StagedFieldsPreview form={form} />
 
           <div className="flex items-center justify-between gap-2 pt-2">
             <Button

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -146,7 +146,10 @@ export function LinkWizardStep({
     provider: Provider,
     fields: SelectableField[],
   ) {
-    const update = mergeCandidateSelection(candidate, provider, fields);
+    const update = mergeCandidateSelection(candidate, provider, fields, {
+      image_url: form.getValues("image_url"),
+      description: form.getValues("description"),
+    });
 
     if (update.providerUrl) {
       for (const [providerKey, url] of Object.entries(update.providerUrl)) {

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -9,7 +9,6 @@ import {
   useUpdateArtistMutation,
   type UpdateArtistUpdates,
 } from "@/api/artists/useUpdateArtist";
-import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
 import {
   mergeCandidateSelection,
   type SelectableField,
@@ -17,6 +16,7 @@ import {
 import type { Provider, Candidate } from "@/api/artistSearch/types";
 import { ProviderCandidatesPanel } from "./ProviderCandidatesPanel";
 import { StagedFieldsPreview } from "./StagedFieldsPreview";
+import { useArtistBatchQuery } from "./useArtistBatchQuery";
 
 const optionalUrlSchema = z
   .string()
@@ -53,14 +53,7 @@ export function LinkWizardStep({
   onNext,
 }: LinkWizardStepProps) {
   const updateArtistMutation = useUpdateArtistMutation();
-
-  const currentIndex = artists.findIndex((a) => a.id === artist.id);
-  const batchStart = Math.floor(currentIndex / 10) * 10;
-  const batchArtists = artists
-    .slice(batchStart, batchStart + 10)
-    .map((a) => a.name);
-
-  const batchQueryResult = useSearchArtistLinksQuery(batchArtists);
+  const batchQueryResult = useArtistBatchQuery(artist, artists);
 
   const form = useForm<LinkStepData>({
     resolver: zodResolver(linkStepSchema),

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -3,16 +3,8 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { ChevronLeft, ChevronRight, RotateCcw } from "lucide-react";
+import { Form } from "@/components/ui/form";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Artist } from "@/api/artists/types";
 import { useUpdateArtistMutation } from "@/api/artists/useUpdateArtist";
 import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
@@ -21,7 +13,7 @@ import {
   type CandidateUpdate,
 } from "@/api/artistSearch/mergeCandidateSelection";
 import type { Provider, Candidate } from "@/api/artistSearch/types";
-import { CandidateCards } from "./CandidateCards";
+import { ProviderLinkField } from "./ProviderLinkField";
 
 function requiredUrlSchema(isRequired: boolean) {
   return isRequired
@@ -42,6 +34,7 @@ interface LinkWizardStepProps {
   artist: Artist;
   position: number;
   total: number;
+  artists: Artist[];
   onPrev: () => void;
   onNext: () => void;
 }
@@ -50,21 +43,31 @@ export function LinkWizardStep({
   artist,
   position,
   total,
+  artists,
   onPrev,
   onNext,
 }: LinkWizardStepProps) {
   const updateArtistMutation = useUpdateArtistMutation();
   const [stagedUpdates, setStagedUpdates] = useState<CandidateUpdate>({});
-  const [customQuery, setCustomQuery] = useState<{
-    provider: Provider;
-    query: string;
-  } | null>(null);
+  const [customSpotifySearch, setCustomSpotifySearch] = useState("");
+  const [customSoundcloudSearch, setCustomSoundcloudSearch] = useState("");
 
-  const searchQuery = customQuery ? customQuery.query : artist.name;
+  const currentIndex = artists.findIndex((a) => a.id === artist.id);
+  const batchStart = Math.floor(currentIndex / 10) * 10;
+  const batchArtists = artists
+    .slice(batchStart, batchStart + 10)
+    .map((a) => a.name);
 
-  const searchQueryResult = useSearchArtistLinksQuery(
-    searchQuery ? [searchQuery] : [],
-    customQuery?.provider,
+  const batchQueryResult = useSearchArtistLinksQuery(batchArtists);
+
+  const spotifyCustomResult = useSearchArtistLinksQuery(
+    customSpotifySearch ? [customSpotifySearch] : [],
+    "spotify",
+  );
+
+  const soundcloudCustomResult = useSearchArtistLinksQuery(
+    customSoundcloudSearch ? [customSoundcloudSearch] : [],
+    "soundcloud",
   );
 
   const form = useForm<LinkStepData>({
@@ -74,6 +77,21 @@ export function LinkWizardStep({
       soundcloudUrl: artist.soundcloud_url ?? "",
     },
   });
+
+  function getCandidates(provider: Provider): Candidate[] {
+    if (provider === "spotify" && customSpotifySearch) {
+      return spotifyCustomResult.data?.results[0]?.candidates ?? [];
+    }
+    if (provider === "soundcloud" && customSoundcloudSearch) {
+      return soundcloudCustomResult.data?.results[0]?.candidates ?? [];
+    }
+
+    return (
+      batchQueryResult.data?.results.find(
+        (r) => r.artistName === artist.name && r.provider === provider,
+      )?.candidates ?? []
+    );
+  }
 
   function handleCandidateSelect(candidate: Candidate, provider: Provider) {
     const update = mergeCandidateSelection(
@@ -91,6 +109,14 @@ export function LinkWizardStep({
     }
   }
 
+  function handleSearchAgain(provider: Provider, query: string) {
+    if (provider === "spotify") {
+      setCustomSpotifySearch(query);
+    } else {
+      setCustomSoundcloudSearch(query);
+    }
+  }
+
   function onSubmit(data: LinkStepData) {
     updateArtistMutation.mutate(
       {
@@ -105,23 +131,16 @@ export function LinkWizardStep({
           ...(stagedUpdates.image_url && {
             image_url: stagedUpdates.image_url,
           }),
-          ...(stagedUpdates.description && {
-            description: stagedUpdates.description,
-          }),
         },
       },
       { onSuccess: onNext },
     );
   }
 
-  function handleSearchAgain(
-    provider: Provider,
-    currentUrl: string | undefined,
-  ) {
-    if (currentUrl) {
-      setCustomQuery({ provider, query: currentUrl });
-    }
-  }
+  const isLoadingCandidates =
+    batchQueryResult.isLoading ||
+    spotifyCustomResult.isLoading ||
+    soundcloudCustomResult.isLoading;
 
   return (
     <div className="space-y-4">
@@ -134,99 +153,35 @@ export function LinkWizardStep({
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           {!artist.spotify_url && (
-            <div className="space-y-3">
-              <CandidateCards
-                candidates={
-                  searchQueryResult.data?.results.find(
-                    (r) => r.provider === "spotify",
-                  )?.candidates ?? []
-                }
-                provider="spotify"
-                isLoading={searchQueryResult.isLoading}
-                onSelectCandidate={(candidate) =>
-                  handleCandidateSelect(candidate, "spotify")
-                }
-              />
-              <FormField
-                control={form.control}
-                name="spotifyUrl"
-                render={({ field }) => (
-                  <FormItem>
-                    <div className="flex items-center justify-between">
-                      <FormLabel>Spotify URL</FormLabel>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() =>
-                          handleSearchAgain("spotify", field.value)
-                        }
-                        disabled={searchQueryResult.isLoading}
-                      >
-                        <RotateCcw className="h-3 w-3 mr-1" />
-                        Search Again
-                      </Button>
-                    </div>
-                    <FormControl>
-                      <Input
-                        type="url"
-                        placeholder="https://open.spotify.com/artist/..."
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+            <ProviderLinkField
+              provider="spotify"
+              fieldName="spotifyUrl"
+              label="Spotify URL"
+              placeholder="https://open.spotify.com/artist/..."
+              candidates={getCandidates("spotify")}
+              isLoadingCandidates={isLoadingCandidates}
+              form={form}
+              onSelectCandidate={(candidate) =>
+                handleCandidateSelect(candidate, "spotify")
+              }
+              onSearchAgain={(query) => handleSearchAgain("spotify", query)}
+            />
           )}
 
           {!artist.soundcloud_url && (
-            <div className="space-y-3">
-              <CandidateCards
-                candidates={
-                  searchQueryResult.data?.results.find(
-                    (r) => r.provider === "soundcloud",
-                  )?.candidates ?? []
-                }
-                provider="soundcloud"
-                isLoading={searchQueryResult.isLoading}
-                onSelectCandidate={(candidate) =>
-                  handleCandidateSelect(candidate, "soundcloud")
-                }
-              />
-              <FormField
-                control={form.control}
-                name="soundcloudUrl"
-                render={({ field }) => (
-                  <FormItem>
-                    <div className="flex items-center justify-between">
-                      <FormLabel>SoundCloud URL</FormLabel>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() =>
-                          handleSearchAgain("soundcloud", field.value)
-                        }
-                        disabled={searchQueryResult.isLoading}
-                      >
-                        <RotateCcw className="h-3 w-3 mr-1" />
-                        Search Again
-                      </Button>
-                    </div>
-                    <FormControl>
-                      <Input
-                        type="url"
-                        placeholder="https://soundcloud.com/..."
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+            <ProviderLinkField
+              provider="soundcloud"
+              fieldName="soundcloudUrl"
+              label="SoundCloud URL"
+              placeholder="https://soundcloud.com/..."
+              candidates={getCandidates("soundcloud")}
+              isLoadingCandidates={isLoadingCandidates}
+              form={form}
+              onSelectCandidate={(candidate) =>
+                handleCandidateSelect(candidate, "soundcloud")
+              }
+              onSearchAgain={(query) => handleSearchAgain("soundcloud", query)}
+            />
           )}
 
           <div className="flex items-center justify-between gap-2 pt-2">

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -170,23 +170,23 @@ export function LinkWizardStep({
   ) {
     const update = mergeCandidateSelection(candidate, provider, fields);
 
-    setStagedUpdates((prev) => ({ ...prev, ...update }));
-
-    if (provider === "spotify" && update.spotify_url) {
-      form.setValue("spotifyUrl", update.spotify_url);
-    } else if (provider === "soundcloud" && update.soundcloud_url) {
-      form.setValue("soundcloudUrl", update.soundcloud_url);
-    }
+    setStagedUpdates((prev) => ({
+      ...prev,
+      ...update,
+      providerUrl: { ...prev.providerUrl, ...update.providerUrl },
+    }));
   }
 
   function onSubmit(data: LinkStepData) {
     const updates: UpdateArtistUpdates = {};
 
     if (!artist.spotify_url) {
-      updates.spotify_url = data.spotifyUrl || null;
+      updates.spotify_url =
+        stagedUpdates.providerUrl?.spotify ?? (data.spotifyUrl || null);
     }
     if (!artist.soundcloud_url) {
-      updates.soundcloud_url = data.soundcloudUrl || null;
+      updates.soundcloud_url =
+        stagedUpdates.providerUrl?.soundcloud ?? (data.soundcloudUrl || null);
     }
     if (stagedUpdates.image_url) {
       updates.image_url = stagedUpdates.image_url;

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -2,10 +2,8 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import type { UseQueryResult } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
-import { Textarea } from "@/components/ui/textarea";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Artist } from "@/api/artists/types";
 import { useUpdateArtistMutation } from "@/api/artists/useUpdateArtist";
@@ -15,12 +13,10 @@ import {
   type CandidateUpdate,
   type SelectableField,
 } from "@/api/artistSearch/mergeCandidateSelection";
-import type {
-  Provider,
-  Candidate,
-  SearchResponse,
-} from "@/api/artistSearch/types";
+import type { Provider, Candidate } from "@/api/artistSearch/types";
 import { ProviderLinkField } from "./ProviderLinkField";
+import { StagedFieldsPreview } from "./StagedFieldsPreview";
+import { useProviderCandidates } from "./useProviderCandidates";
 
 const optionalUrlSchema = z
   .string()
@@ -54,8 +50,6 @@ export function LinkWizardStep({
 }: LinkWizardStepProps) {
   const updateArtistMutation = useUpdateArtistMutation();
   const [stagedUpdates, setStagedUpdates] = useState<CandidateUpdate>({});
-  const [customSpotifySearch, setCustomSpotifySearch] = useState("");
-  const [customSoundcloudSearch, setCustomSoundcloudSearch] = useState("");
 
   const currentIndex = artists.findIndex((a) => a.id === artist.id);
   const batchStart = Math.floor(currentIndex / 10) * 10;
@@ -65,14 +59,15 @@ export function LinkWizardStep({
 
   const batchQueryResult = useSearchArtistLinksQuery(batchArtists);
 
-  const spotifyCustomResult = useSearchArtistLinksQuery(
-    customSpotifySearch ? [customSpotifySearch] : [],
+  const spotify = useProviderCandidates(
     "spotify",
+    artist.name,
+    batchQueryResult,
   );
-
-  const soundcloudCustomResult = useSearchArtistLinksQuery(
-    customSoundcloudSearch ? [customSoundcloudSearch] : [],
+  const soundcloud = useProviderCandidates(
     "soundcloud",
+    artist.name,
+    batchQueryResult,
   );
 
   const form = useForm<LinkStepData>({
@@ -82,14 +77,6 @@ export function LinkWizardStep({
       soundcloudUrl: artist.soundcloud_url ?? "",
     },
   });
-
-  const isLoadingSpotify =
-    batchQueryResult.isLoading || spotifyCustomResult.isLoading;
-  const isLoadingSoundcloud =
-    batchQueryResult.isLoading || soundcloudCustomResult.isLoading;
-
-  const spotifyResult = getSpotifyResult();
-  const soundcloudResult = getSoundcloudResult();
 
   return (
     <div className="space-y-4">
@@ -107,14 +94,14 @@ export function LinkWizardStep({
               fieldName="spotifyUrl"
               label="Spotify URL"
               placeholder="https://open.spotify.com/artist/..."
-              candidates={spotifyResult.candidates}
-              searchError={spotifyResult.error}
-              isLoadingCandidates={isLoadingSpotify}
+              candidates={spotify.candidates}
+              searchError={spotify.error}
+              isLoadingCandidates={spotify.isLoading}
               form={form}
               onSelectCandidate={(candidate, fields) =>
                 handleCandidateSelect(candidate, "spotify", fields)
               }
-              onSearchAgain={(query) => handleSearchAgain("spotify", query)}
+              onSearchAgain={spotify.search}
             />
           )}
 
@@ -124,48 +111,23 @@ export function LinkWizardStep({
               fieldName="soundcloudUrl"
               label="SoundCloud URL"
               placeholder="https://soundcloud.com/..."
-              candidates={soundcloudResult.candidates}
-              searchError={soundcloudResult.error}
-              isLoadingCandidates={isLoadingSoundcloud}
+              candidates={soundcloud.candidates}
+              searchError={soundcloud.error}
+              isLoadingCandidates={soundcloud.isLoading}
               form={form}
               onSelectCandidate={(candidate, fields) =>
                 handleCandidateSelect(candidate, "soundcloud", fields)
               }
-              onSearchAgain={(query) => handleSearchAgain("soundcloud", query)}
+              onSearchAgain={soundcloud.search}
             />
           )}
 
-          {(stagedUpdates.image_url ||
-            stagedUpdates.description !== undefined) && (
-            <div className="flex items-start gap-3 rounded-lg border p-3 text-sm">
-              {stagedUpdates.image_url && (
-                <img
-                  src={stagedUpdates.image_url}
-                  alt=""
-                  className="h-12 w-12 rounded object-cover"
-                />
-              )}
-              <div className="flex-1 space-y-1">
-                <p className="font-medium">Also staged from candidate</p>
-                {stagedUpdates.image_url && (
-                  <p className="text-muted-foreground">Image</p>
-                )}
-                {stagedUpdates.description !== undefined && (
-                  <Textarea
-                    value={stagedUpdates.description ?? ""}
-                    onChange={(e) =>
-                      setStagedUpdates((prev) => ({
-                        ...prev,
-                        description: e.target.value,
-                      }))
-                    }
-                    rows={2}
-                    className="text-sm"
-                  />
-                )}
-              </div>
-            </div>
-          )}
+          <StagedFieldsPreview
+            stagedUpdates={stagedUpdates}
+            onDescriptionChange={(description) =>
+              setStagedUpdates((prev) => ({ ...prev, description }))
+            }
+          />
 
           <div className="flex items-center justify-between gap-2 pt-2">
             <Button
@@ -198,28 +160,6 @@ export function LinkWizardStep({
     </div>
   );
 
-  function getSpotifyResult() {
-    return resolveProviderResult({
-      provider: "spotify",
-      providerLabel: "Spotify",
-      artistName: artist.name,
-      customSearch: customSpotifySearch,
-      customResult: spotifyCustomResult,
-      batchQueryResult,
-    });
-  }
-
-  function getSoundcloudResult() {
-    return resolveProviderResult({
-      provider: "soundcloud",
-      providerLabel: "SoundCloud",
-      artistName: artist.name,
-      customSearch: customSoundcloudSearch,
-      customResult: soundcloudCustomResult,
-      batchQueryResult,
-    });
-  }
-
   function handleCandidateSelect(
     candidate: Candidate,
     provider: Provider,
@@ -233,14 +173,6 @@ export function LinkWizardStep({
       form.setValue("spotifyUrl", update.spotify_url);
     } else if (provider === "soundcloud" && update.soundcloud_url) {
       form.setValue("soundcloudUrl", update.soundcloud_url);
-    }
-  }
-
-  function handleSearchAgain(provider: Provider, query: string) {
-    if (provider === "spotify") {
-      setCustomSpotifySearch(query);
-    } else {
-      setCustomSoundcloudSearch(query);
     }
   }
 
@@ -266,50 +198,4 @@ export function LinkWizardStep({
       { onSuccess: onNext },
     );
   }
-}
-
-interface ResolveProviderResultArgs {
-  provider: Provider;
-  providerLabel: string;
-  artistName: string;
-  customSearch: string;
-  customResult: UseQueryResult<SearchResponse>;
-  batchQueryResult: UseQueryResult<SearchResponse>;
-}
-
-function resolveProviderResult({
-  provider,
-  providerLabel,
-  artistName,
-  customSearch,
-  customResult,
-  batchQueryResult,
-}: ResolveProviderResultArgs): {
-  candidates: Candidate[];
-  error?: string | undefined;
-} {
-  if (customSearch) {
-    if (customResult.isError) {
-      return {
-        candidates: [],
-        error: `${providerLabel} search failed. Please try again.`,
-      };
-    }
-    const result = customResult.data?.results.find(
-      (r) => r.provider === provider,
-    );
-    return { candidates: result?.candidates ?? [], error: result?.error };
-  }
-
-  if (batchQueryResult.isError) {
-    return {
-      candidates: [],
-      error: `${providerLabel} search failed. Please try again.`,
-    };
-  }
-
-  const result = batchQueryResult.data?.results.find(
-    (r) => r.artistName === artistName && r.provider === provider,
-  );
-  return { candidates: result?.candidates ?? [], error: result?.error };
 }

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -20,20 +20,18 @@ import type {
 } from "@/api/artistSearch/types";
 import { ProviderLinkField } from "./ProviderLinkField";
 
-function requiredUrlSchema(isRequired: boolean) {
-  return isRequired
-    ? z.string().url("Enter a valid URL")
-    : z.string().url().optional().or(z.literal(""));
-}
+const optionalUrlSchema = z
+  .string()
+  .url("Enter a valid URL")
+  .optional()
+  .or(z.literal(""));
 
-function makeLinkStepSchema(artist: Artist) {
-  return z.object({
-    spotifyUrl: requiredUrlSchema(!artist.spotify_url),
-    soundcloudUrl: requiredUrlSchema(!artist.soundcloud_url),
-  });
-}
+const linkStepSchema = z.object({
+  spotifyUrl: optionalUrlSchema,
+  soundcloudUrl: optionalUrlSchema,
+});
 
-type LinkStepData = z.infer<ReturnType<typeof makeLinkStepSchema>>;
+type LinkStepData = z.infer<typeof linkStepSchema>;
 
 interface LinkWizardStepProps {
   artist: Artist;
@@ -76,7 +74,7 @@ export function LinkWizardStep({
   );
 
   const form = useForm<LinkStepData>({
-    resolver: zodResolver(makeLinkStepSchema(artist)),
+    resolver: zodResolver(linkStepSchema),
     defaultValues: {
       spotifyUrl: artist.spotify_url ?? "",
       soundcloudUrl: artist.soundcloud_url ?? "",
@@ -202,6 +200,29 @@ export function LinkWizardStep({
               }
               onSearchAgain={(query) => handleSearchAgain("soundcloud", query)}
             />
+          )}
+
+          {(stagedUpdates.image_url || stagedUpdates.description) && (
+            <div className="flex items-start gap-3 rounded-lg border p-3 text-sm">
+              {stagedUpdates.image_url && (
+                <img
+                  src={stagedUpdates.image_url}
+                  alt=""
+                  className="h-12 w-12 rounded object-cover"
+                />
+              )}
+              <div className="space-y-1">
+                <p className="font-medium">Also staged from candidate</p>
+                {stagedUpdates.image_url && (
+                  <p className="text-muted-foreground">Image</p>
+                )}
+                {stagedUpdates.description && (
+                  <p className="text-muted-foreground line-clamp-2">
+                    {stagedUpdates.description}
+                  </p>
+                )}
+              </div>
+            </div>
           )}
 
           <div className="flex items-center justify-between gap-2 pt-2">

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -159,10 +159,10 @@ export function LinkWizardStep({
     );
   }
 
-  const isLoadingCandidates =
-    batchQueryResult.isLoading ||
-    spotifyCustomResult.isLoading ||
-    soundcloudCustomResult.isLoading;
+  const isLoadingSpotify =
+    batchQueryResult.isLoading || spotifyCustomResult.isLoading;
+  const isLoadingSoundcloud =
+    batchQueryResult.isLoading || soundcloudCustomResult.isLoading;
 
   const spotifyResult = getProviderResult("spotify");
   const soundcloudResult = getProviderResult("soundcloud");
@@ -185,7 +185,7 @@ export function LinkWizardStep({
               placeholder="https://open.spotify.com/artist/..."
               candidates={spotifyResult.candidates}
               searchError={spotifyResult.error}
-              isLoadingCandidates={isLoadingCandidates}
+              isLoadingCandidates={isLoadingSpotify}
               form={form}
               onSelectCandidate={(candidate) =>
                 handleCandidateSelect(candidate, "spotify")
@@ -202,7 +202,7 @@ export function LinkWizardStep({
               placeholder="https://soundcloud.com/..."
               candidates={soundcloudResult.candidates}
               searchError={soundcloudResult.error}
-              isLoadingCandidates={isLoadingCandidates}
+              isLoadingCandidates={isLoadingSoundcloud}
               form={form}
               onSelectCandidate={(candidate) =>
                 handleCandidateSelect(candidate, "soundcloud")

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -81,6 +81,23 @@ export function LinkWizardStep({
     },
   });
 
+  const urlFields = [
+    !artist.spotify_url && {
+      fieldName: "spotifyUrl",
+      label: "Spotify URL",
+      placeholder: "https://open.spotify.com/artist/...",
+    },
+    !artist.soundcloud_url && {
+      fieldName: "soundcloudUrl",
+      label: "SoundCloud URL",
+      placeholder: "https://soundcloud.com/...",
+    },
+  ].filter(Boolean) as {
+    fieldName: string;
+    label: string;
+    placeholder: string;
+  }[];
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-end">
@@ -94,13 +111,10 @@ export function LinkWizardStep({
           {!artist.spotify_url && (
             <ProviderLinkField
               provider="spotify"
-              fieldName="spotifyUrl"
-              label="Spotify URL"
-              placeholder="https://open.spotify.com/artist/..."
+              label="Spotify Candidates"
               candidates={spotify.candidates}
               searchError={spotify.error}
               isLoadingCandidates={spotify.isLoading}
-              form={form}
               onSelectCandidate={(candidate, fields) =>
                 handleCandidateSelect(candidate, "spotify", fields)
               }
@@ -111,13 +125,10 @@ export function LinkWizardStep({
           {!artist.soundcloud_url && (
             <ProviderLinkField
               provider="soundcloud"
-              fieldName="soundcloudUrl"
-              label="SoundCloud URL"
-              placeholder="https://soundcloud.com/..."
+              label="SoundCloud Candidates"
               candidates={soundcloud.candidates}
               searchError={soundcloud.error}
               isLoadingCandidates={soundcloud.isLoading}
-              form={form}
               onSelectCandidate={(candidate, fields) =>
                 handleCandidateSelect(candidate, "soundcloud", fields)
               }
@@ -126,6 +137,8 @@ export function LinkWizardStep({
           )}
 
           <StagedFieldsPreview
+            form={form}
+            urlFields={urlFields}
             stagedUpdates={stagedUpdates}
             onDescriptionChange={(description) =>
               setStagedUpdates((prev) => ({ ...prev, description }))
@@ -170,24 +183,32 @@ export function LinkWizardStep({
   ) {
     const update = mergeCandidateSelection(candidate, provider, fields);
 
-    setStagedUpdates((prev) => ({
-      ...prev,
-      ...update,
-      providerUrl: { ...prev.providerUrl, ...update.providerUrl },
-    }));
+    if (update.providerUrl) {
+      for (const [providerKey, url] of Object.entries(update.providerUrl)) {
+        form.setValue(
+          `${providerKey}Url` as "spotifyUrl" | "soundcloudUrl",
+          url,
+        );
+      }
+    }
+
+    if (update.image_url !== undefined || update.description !== undefined) {
+      setStagedUpdates((prev) => ({
+        ...prev,
+        ...(update.image_url !== undefined && { image_url: update.image_url }),
+        ...(update.description !== undefined && {
+          description: update.description,
+        }),
+      }));
+    }
   }
 
   function onSubmit(data: LinkStepData) {
-    const updates: UpdateArtistUpdates = {};
+    const updates: UpdateArtistUpdates = {
+      spotify_url: data.spotifyUrl || null,
+      soundcloud_url: data.soundcloudUrl || null,
+    };
 
-    if (!artist.spotify_url) {
-      updates.spotify_url =
-        stagedUpdates.providerUrl?.spotify ?? (data.spotifyUrl || null);
-    }
-    if (!artist.soundcloud_url) {
-      updates.soundcloud_url =
-        stagedUpdates.providerUrl?.soundcloud ?? (data.soundcloudUrl || null);
-    }
     if (stagedUpdates.image_url) {
       updates.image_url = stagedUpdates.image_url;
     }

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -13,7 +12,6 @@ import {
 import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
 import {
   mergeCandidateSelection,
-  type CandidateUpdate,
   type SelectableField,
 } from "@/api/artistSearch/mergeCandidateSelection";
 import type { Provider, Candidate } from "@/api/artistSearch/types";
@@ -27,11 +25,28 @@ const optionalUrlSchema = z
   .or(z.literal(""));
 
 const linkStepSchema = z.object({
-  spotifyUrl: optionalUrlSchema,
-  soundcloudUrl: optionalUrlSchema,
+  providerUrl: z.object({
+    spotify: optionalUrlSchema,
+    soundcloud: optionalUrlSchema,
+  }),
+  image_url: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
 });
 
 type LinkStepData = z.infer<typeof linkStepSchema>;
+
+const URL_FIELDS = [
+  {
+    fieldName: "providerUrl.spotify",
+    label: "Spotify URL",
+    placeholder: "https://open.spotify.com/artist/...",
+  },
+  {
+    fieldName: "providerUrl.soundcloud",
+    label: "SoundCloud URL",
+    placeholder: "https://soundcloud.com/...",
+  },
+];
 
 interface LinkWizardStepProps {
   artist: Artist;
@@ -51,7 +66,6 @@ export function LinkWizardStep({
   onNext,
 }: LinkWizardStepProps) {
   const updateArtistMutation = useUpdateArtistMutation();
-  const [stagedUpdates, setStagedUpdates] = useState<CandidateUpdate>({});
 
   const currentIndex = artists.findIndex((a) => a.id === artist.id);
   const batchStart = Math.floor(currentIndex / 10) * 10;
@@ -64,27 +78,12 @@ export function LinkWizardStep({
   const form = useForm<LinkStepData>({
     resolver: zodResolver(linkStepSchema),
     defaultValues: {
-      spotifyUrl: artist.spotify_url ?? "",
-      soundcloudUrl: artist.soundcloud_url ?? "",
+      providerUrl: {
+        spotify: artist.spotify_url ?? "",
+        soundcloud: artist.soundcloud_url ?? "",
+      },
     },
   });
-
-  const urlFields = [
-    !artist.spotify_url && {
-      fieldName: "spotifyUrl",
-      label: "Spotify URL",
-      placeholder: "https://open.spotify.com/artist/...",
-    },
-    !artist.soundcloud_url && {
-      fieldName: "soundcloudUrl",
-      label: "SoundCloud URL",
-      placeholder: "https://soundcloud.com/...",
-    },
-  ].filter(Boolean) as {
-    fieldName: string;
-    label: string;
-    placeholder: string;
-  }[];
 
   return (
     <div className="space-y-4">
@@ -120,14 +119,7 @@ export function LinkWizardStep({
             />
           )}
 
-          <StagedFieldsPreview
-            form={form}
-            urlFields={urlFields}
-            stagedUpdates={stagedUpdates}
-            onDescriptionChange={(description) =>
-              setStagedUpdates((prev) => ({ ...prev, description }))
-            }
-          />
+          <StagedFieldsPreview form={form} urlFields={URL_FIELDS} />
 
           <div className="flex items-center justify-between gap-2 pt-2">
             <Button
@@ -170,34 +162,33 @@ export function LinkWizardStep({
     if (update.providerUrl) {
       for (const [providerKey, url] of Object.entries(update.providerUrl)) {
         form.setValue(
-          `${providerKey}Url` as "spotifyUrl" | "soundcloudUrl",
+          `providerUrl.${providerKey}` as
+            | "providerUrl.spotify"
+            | "providerUrl.soundcloud",
           url,
         );
       }
     }
 
-    if (update.image_url !== undefined || update.description !== undefined) {
-      setStagedUpdates((prev) => ({
-        ...prev,
-        ...(update.image_url !== undefined && { image_url: update.image_url }),
-        ...(update.description !== undefined && {
-          description: update.description,
-        }),
-      }));
+    if (update.image_url !== undefined) {
+      form.setValue("image_url", update.image_url);
+    }
+    if (update.description !== undefined) {
+      form.setValue("description", update.description);
     }
   }
 
   function onSubmit(data: LinkStepData) {
     const updates: UpdateArtistUpdates = {
-      spotify_url: data.spotifyUrl || null,
-      soundcloud_url: data.soundcloudUrl || null,
+      spotify_url: data.providerUrl.spotify || null,
+      soundcloud_url: data.providerUrl.soundcloud || null,
     };
 
-    if (stagedUpdates.image_url) {
-      updates.image_url = stagedUpdates.image_url;
+    if (data.image_url) {
+      updates.image_url = data.image_url;
     }
-    if (stagedUpdates.description !== undefined) {
-      updates.description = stagedUpdates.description;
+    if (data.description !== undefined) {
+      updates.description = data.description;
     }
 
     updateArtistMutation.mutate(

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -81,75 +81,6 @@ export function LinkWizardStep({
     },
   });
 
-  function getSpotifyResult() {
-    return resolveProviderResult({
-      provider: "spotify",
-      providerLabel: "Spotify",
-      artistName: artist.name,
-      customSearch: customSpotifySearch,
-      customResult: spotifyCustomResult,
-      batchQueryResult,
-    });
-  }
-
-  function getSoundcloudResult() {
-    return resolveProviderResult({
-      provider: "soundcloud",
-      providerLabel: "SoundCloud",
-      artistName: artist.name,
-      customSearch: customSoundcloudSearch,
-      customResult: soundcloudCustomResult,
-      batchQueryResult,
-    });
-  }
-
-  function handleCandidateSelect(candidate: Candidate, provider: Provider) {
-    const update = mergeCandidateSelection(
-      { artist, stagedUpdates },
-      candidate,
-      provider,
-    );
-
-    setStagedUpdates((prev) => ({ ...prev, ...update }));
-
-    if (provider === "spotify" && update.spotify_url) {
-      form.setValue("spotifyUrl", update.spotify_url);
-    } else if (provider === "soundcloud" && update.soundcloud_url) {
-      form.setValue("soundcloudUrl", update.soundcloud_url);
-    }
-  }
-
-  function handleSearchAgain(provider: Provider, query: string) {
-    if (provider === "spotify") {
-      setCustomSpotifySearch(query);
-    } else {
-      setCustomSoundcloudSearch(query);
-    }
-  }
-
-  function onSubmit(data: LinkStepData) {
-    updateArtistMutation.mutate(
-      {
-        id: artist.id,
-        updates: {
-          ...(!artist.spotify_url && {
-            spotify_url: data.spotifyUrl || null,
-          }),
-          ...(!artist.soundcloud_url && {
-            soundcloud_url: data.soundcloudUrl || null,
-          }),
-          ...(stagedUpdates.image_url && {
-            image_url: stagedUpdates.image_url,
-          }),
-          ...(stagedUpdates.description && {
-            description: stagedUpdates.description,
-          }),
-        },
-      },
-      { onSuccess: onNext },
-    );
-  }
-
   const isLoadingSpotify =
     batchQueryResult.isLoading || spotifyCustomResult.isLoading;
   const isLoadingSoundcloud =
@@ -255,6 +186,75 @@ export function LinkWizardStep({
       </Form>
     </div>
   );
+
+  function getSpotifyResult() {
+    return resolveProviderResult({
+      provider: "spotify",
+      providerLabel: "Spotify",
+      artistName: artist.name,
+      customSearch: customSpotifySearch,
+      customResult: spotifyCustomResult,
+      batchQueryResult,
+    });
+  }
+
+  function getSoundcloudResult() {
+    return resolveProviderResult({
+      provider: "soundcloud",
+      providerLabel: "SoundCloud",
+      artistName: artist.name,
+      customSearch: customSoundcloudSearch,
+      customResult: soundcloudCustomResult,
+      batchQueryResult,
+    });
+  }
+
+  function handleCandidateSelect(candidate: Candidate, provider: Provider) {
+    const update = mergeCandidateSelection(
+      { artist, stagedUpdates },
+      candidate,
+      provider,
+    );
+
+    setStagedUpdates((prev) => ({ ...prev, ...update }));
+
+    if (provider === "spotify" && update.spotify_url) {
+      form.setValue("spotifyUrl", update.spotify_url);
+    } else if (provider === "soundcloud" && update.soundcloud_url) {
+      form.setValue("soundcloudUrl", update.soundcloud_url);
+    }
+  }
+
+  function handleSearchAgain(provider: Provider, query: string) {
+    if (provider === "spotify") {
+      setCustomSpotifySearch(query);
+    } else {
+      setCustomSoundcloudSearch(query);
+    }
+  }
+
+  function onSubmit(data: LinkStepData) {
+    updateArtistMutation.mutate(
+      {
+        id: artist.id,
+        updates: {
+          ...(!artist.spotify_url && {
+            spotify_url: data.spotifyUrl || null,
+          }),
+          ...(!artist.soundcloud_url && {
+            soundcloud_url: data.soundcloudUrl || null,
+          }),
+          ...(stagedUpdates.image_url && {
+            image_url: stagedUpdates.image_url,
+          }),
+          ...(stagedUpdates.description && {
+            description: stagedUpdates.description,
+          }),
+        },
+      },
+      { onSuccess: onNext },
+    );
+  }
 }
 
 interface ResolveProviderResultArgs {

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -69,6 +69,8 @@ export function LinkWizardStep({
         spotify: artist.spotify_url ?? "",
         soundcloud: artist.soundcloud_url ?? "",
       },
+      image_url: artist.image_url ?? undefined,
+      description: artist.description ?? undefined,
     },
   });
 

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -78,19 +78,41 @@ export function LinkWizardStep({
     },
   });
 
-  function getCandidates(provider: Provider): Candidate[] {
-    if (provider === "spotify" && customSpotifySearch) {
-      return spotifyCustomResult.data?.results[0]?.candidates ?? [];
-    }
-    if (provider === "soundcloud" && customSoundcloudSearch) {
-      return soundcloudCustomResult.data?.results[0]?.candidates ?? [];
+  function getProviderResult(provider: Provider): {
+    candidates: Candidate[];
+    error?: string | undefined;
+  } {
+    const customSearch =
+      provider === "spotify" ? customSpotifySearch : customSoundcloudSearch;
+    const customResult =
+      provider === "spotify" ? spotifyCustomResult : soundcloudCustomResult;
+
+    const providerLabel = provider === "spotify" ? "Spotify" : "SoundCloud";
+
+    if (customSearch) {
+      if (customResult.isError) {
+        return {
+          candidates: [],
+          error: `${providerLabel} search failed. Please try again.`,
+        };
+      }
+      const result = customResult.data?.results.find(
+        (r) => r.provider === provider,
+      );
+      return { candidates: result?.candidates ?? [], error: result?.error };
     }
 
-    return (
-      batchQueryResult.data?.results.find(
-        (r) => r.artistName === artist.name && r.provider === provider,
-      )?.candidates ?? []
+    if (batchQueryResult.isError) {
+      return {
+        candidates: [],
+        error: `${providerLabel} search failed. Please try again.`,
+      };
+    }
+
+    const result = batchQueryResult.data?.results.find(
+      (r) => r.artistName === artist.name && r.provider === provider,
     );
+    return { candidates: result?.candidates ?? [], error: result?.error };
   }
 
   function handleCandidateSelect(candidate: Candidate, provider: Provider) {
@@ -142,6 +164,9 @@ export function LinkWizardStep({
     spotifyCustomResult.isLoading ||
     soundcloudCustomResult.isLoading;
 
+  const spotifyResult = getProviderResult("spotify");
+  const soundcloudResult = getProviderResult("soundcloud");
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-end">
@@ -158,7 +183,8 @@ export function LinkWizardStep({
               fieldName="spotifyUrl"
               label="Spotify URL"
               placeholder="https://open.spotify.com/artist/..."
-              candidates={getCandidates("spotify")}
+              candidates={spotifyResult.candidates}
+              searchError={spotifyResult.error}
               isLoadingCandidates={isLoadingCandidates}
               form={form}
               onSelectCandidate={(candidate) =>
@@ -174,7 +200,8 @@ export function LinkWizardStep({
               fieldName="soundcloudUrl"
               label="SoundCloud URL"
               placeholder="https://soundcloud.com/..."
-              candidates={getCandidates("soundcloud")}
+              candidates={soundcloudResult.candidates}
+              searchError={soundcloudResult.error}
               isLoadingCandidates={isLoadingCandidates}
               form={form}
               onSelectCandidate={(candidate) =>

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -6,7 +6,10 @@ import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Artist } from "@/api/artists/types";
-import { useUpdateArtistMutation } from "@/api/artists/useUpdateArtist";
+import {
+  useUpdateArtistMutation,
+  type UpdateArtistUpdates,
+} from "@/api/artists/useUpdateArtist";
 import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
 import {
   mergeCandidateSelection,
@@ -177,24 +180,23 @@ export function LinkWizardStep({
   }
 
   function onSubmit(data: LinkStepData) {
+    const updates: UpdateArtistUpdates = {};
+
+    if (!artist.spotify_url) {
+      updates.spotify_url = data.spotifyUrl || null;
+    }
+    if (!artist.soundcloud_url) {
+      updates.soundcloud_url = data.soundcloudUrl || null;
+    }
+    if (stagedUpdates.image_url) {
+      updates.image_url = stagedUpdates.image_url;
+    }
+    if (stagedUpdates.description !== undefined) {
+      updates.description = stagedUpdates.description;
+    }
+
     updateArtistMutation.mutate(
-      {
-        id: artist.id,
-        updates: {
-          ...(!artist.spotify_url && {
-            spotify_url: data.spotifyUrl || null,
-          }),
-          ...(!artist.soundcloud_url && {
-            soundcloud_url: data.soundcloudUrl || null,
-          }),
-          ...(stagedUpdates.image_url && {
-            image_url: stagedUpdates.image_url,
-          }),
-          ...(stagedUpdates.description !== undefined && {
-            description: stagedUpdates.description,
-          }),
-        },
-      },
+      { id: artist.id, updates },
       { onSuccess: onNext },
     );
   }

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Artist } from "@/api/artists/types";
 import { useUpdateArtistMutation } from "@/api/artists/useUpdateArtist";
@@ -12,6 +13,7 @@ import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLin
 import {
   mergeCandidateSelection,
   type CandidateUpdate,
+  type SelectableField,
 } from "@/api/artistSearch/mergeCandidateSelection";
 import type {
   Provider,
@@ -109,8 +111,8 @@ export function LinkWizardStep({
               searchError={spotifyResult.error}
               isLoadingCandidates={isLoadingSpotify}
               form={form}
-              onSelectCandidate={(candidate) =>
-                handleCandidateSelect(candidate, "spotify")
+              onSelectCandidate={(candidate, fields) =>
+                handleCandidateSelect(candidate, "spotify", fields)
               }
               onSearchAgain={(query) => handleSearchAgain("spotify", query)}
             />
@@ -126,14 +128,15 @@ export function LinkWizardStep({
               searchError={soundcloudResult.error}
               isLoadingCandidates={isLoadingSoundcloud}
               form={form}
-              onSelectCandidate={(candidate) =>
-                handleCandidateSelect(candidate, "soundcloud")
+              onSelectCandidate={(candidate, fields) =>
+                handleCandidateSelect(candidate, "soundcloud", fields)
               }
               onSearchAgain={(query) => handleSearchAgain("soundcloud", query)}
             />
           )}
 
-          {(stagedUpdates.image_url || stagedUpdates.description) && (
+          {(stagedUpdates.image_url ||
+            stagedUpdates.description !== undefined) && (
             <div className="flex items-start gap-3 rounded-lg border p-3 text-sm">
               {stagedUpdates.image_url && (
                 <img
@@ -142,15 +145,23 @@ export function LinkWizardStep({
                   className="h-12 w-12 rounded object-cover"
                 />
               )}
-              <div className="space-y-1">
+              <div className="flex-1 space-y-1">
                 <p className="font-medium">Also staged from candidate</p>
                 {stagedUpdates.image_url && (
                   <p className="text-muted-foreground">Image</p>
                 )}
-                {stagedUpdates.description && (
-                  <p className="text-muted-foreground line-clamp-2">
-                    {stagedUpdates.description}
-                  </p>
+                {stagedUpdates.description !== undefined && (
+                  <Textarea
+                    value={stagedUpdates.description ?? ""}
+                    onChange={(e) =>
+                      setStagedUpdates((prev) => ({
+                        ...prev,
+                        description: e.target.value,
+                      }))
+                    }
+                    rows={2}
+                    className="text-sm"
+                  />
                 )}
               </div>
             </div>
@@ -209,12 +220,12 @@ export function LinkWizardStep({
     });
   }
 
-  function handleCandidateSelect(candidate: Candidate, provider: Provider) {
-    const update = mergeCandidateSelection(
-      { artist, stagedUpdates },
-      candidate,
-      provider,
-    );
+  function handleCandidateSelect(
+    candidate: Candidate,
+    provider: Provider,
+    fields: SelectableField[],
+  ) {
+    const update = mergeCandidateSelection(candidate, provider, fields);
 
     setStagedUpdates((prev) => ({ ...prev, ...update }));
 
@@ -247,7 +258,7 @@ export function LinkWizardStep({
           ...(stagedUpdates.image_url && {
             image_url: stagedUpdates.image_url,
           }),
-          ...(stagedUpdates.description && {
+          ...(stagedUpdates.description !== undefined && {
             description: stagedUpdates.description,
           }),
         },

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import type { UseQueryResult } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -12,7 +13,11 @@ import {
   mergeCandidateSelection,
   type CandidateUpdate,
 } from "@/api/artistSearch/mergeCandidateSelection";
-import type { Provider, Candidate } from "@/api/artistSearch/types";
+import type {
+  Provider,
+  Candidate,
+  SearchResponse,
+} from "@/api/artistSearch/types";
 import { ProviderLinkField } from "./ProviderLinkField";
 
 function requiredUrlSchema(isRequired: boolean) {
@@ -78,41 +83,26 @@ export function LinkWizardStep({
     },
   });
 
-  function getProviderResult(provider: Provider): {
-    candidates: Candidate[];
-    error?: string | undefined;
-  } {
-    const customSearch =
-      provider === "spotify" ? customSpotifySearch : customSoundcloudSearch;
-    const customResult =
-      provider === "spotify" ? spotifyCustomResult : soundcloudCustomResult;
+  function getSpotifyResult() {
+    return resolveProviderResult({
+      provider: "spotify",
+      providerLabel: "Spotify",
+      artistName: artist.name,
+      customSearch: customSpotifySearch,
+      customResult: spotifyCustomResult,
+      batchQueryResult,
+    });
+  }
 
-    const providerLabel = provider === "spotify" ? "Spotify" : "SoundCloud";
-
-    if (customSearch) {
-      if (customResult.isError) {
-        return {
-          candidates: [],
-          error: `${providerLabel} search failed. Please try again.`,
-        };
-      }
-      const result = customResult.data?.results.find(
-        (r) => r.provider === provider,
-      );
-      return { candidates: result?.candidates ?? [], error: result?.error };
-    }
-
-    if (batchQueryResult.isError) {
-      return {
-        candidates: [],
-        error: `${providerLabel} search failed. Please try again.`,
-      };
-    }
-
-    const result = batchQueryResult.data?.results.find(
-      (r) => r.artistName === artist.name && r.provider === provider,
-    );
-    return { candidates: result?.candidates ?? [], error: result?.error };
+  function getSoundcloudResult() {
+    return resolveProviderResult({
+      provider: "soundcloud",
+      providerLabel: "SoundCloud",
+      artistName: artist.name,
+      customSearch: customSoundcloudSearch,
+      customResult: soundcloudCustomResult,
+      batchQueryResult,
+    });
   }
 
   function handleCandidateSelect(candidate: Candidate, provider: Provider) {
@@ -167,8 +157,8 @@ export function LinkWizardStep({
   const isLoadingSoundcloud =
     batchQueryResult.isLoading || soundcloudCustomResult.isLoading;
 
-  const spotifyResult = getProviderResult("spotify");
-  const soundcloudResult = getProviderResult("soundcloud");
+  const spotifyResult = getSpotifyResult();
+  const soundcloudResult = getSoundcloudResult();
 
   return (
     <div className="space-y-4">
@@ -244,4 +234,50 @@ export function LinkWizardStep({
       </Form>
     </div>
   );
+}
+
+interface ResolveProviderResultArgs {
+  provider: Provider;
+  providerLabel: string;
+  artistName: string;
+  customSearch: string;
+  customResult: UseQueryResult<SearchResponse>;
+  batchQueryResult: UseQueryResult<SearchResponse>;
+}
+
+function resolveProviderResult({
+  provider,
+  providerLabel,
+  artistName,
+  customSearch,
+  customResult,
+  batchQueryResult,
+}: ResolveProviderResultArgs): {
+  candidates: Candidate[];
+  error?: string | undefined;
+} {
+  if (customSearch) {
+    if (customResult.isError) {
+      return {
+        candidates: [],
+        error: `${providerLabel} search failed. Please try again.`,
+      };
+    }
+    const result = customResult.data?.results.find(
+      (r) => r.provider === provider,
+    );
+    return { candidates: result?.candidates ?? [], error: result?.error };
+  }
+
+  if (batchQueryResult.isError) {
+    return {
+      candidates: [],
+      error: `${providerLabel} search failed. Please try again.`,
+    };
+  }
+
+  const result = batchQueryResult.data?.results.find(
+    (r) => r.artistName === artistName && r.provider === provider,
+  );
+  return { candidates: result?.candidates ?? [], error: result?.error };
 }

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -33,7 +33,7 @@ const linkStepSchema = z.object({
   description: z.string().nullable().optional(),
 });
 
-type LinkStepData = z.infer<typeof linkStepSchema>;
+export type LinkStepData = z.infer<typeof linkStepSchema>;
 
 interface LinkWizardStepProps {
   artist: Artist;

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -17,9 +17,8 @@ import {
   type SelectableField,
 } from "@/api/artistSearch/mergeCandidateSelection";
 import type { Provider, Candidate } from "@/api/artistSearch/types";
-import { ProviderLinkField } from "./ProviderLinkField";
+import { ProviderCandidatesPanel } from "./ProviderCandidatesPanel";
 import { StagedFieldsPreview } from "./StagedFieldsPreview";
-import { useProviderCandidates } from "./useProviderCandidates";
 
 const optionalUrlSchema = z
   .string()
@@ -62,17 +61,6 @@ export function LinkWizardStep({
 
   const batchQueryResult = useSearchArtistLinksQuery(batchArtists);
 
-  const spotify = useProviderCandidates(
-    "spotify",
-    artist.name,
-    batchQueryResult,
-  );
-  const soundcloud = useProviderCandidates(
-    "soundcloud",
-    artist.name,
-    batchQueryResult,
-  );
-
   const form = useForm<LinkStepData>({
     resolver: zodResolver(linkStepSchema),
     defaultValues: {
@@ -109,28 +97,26 @@ export function LinkWizardStep({
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           {!artist.spotify_url && (
-            <ProviderLinkField
+            <ProviderCandidatesPanel
+              provider="spotify"
               label="Spotify Candidates"
-              candidates={spotify.candidates}
-              searchError={spotify.error}
-              isLoadingCandidates={spotify.isLoading}
+              artistName={artist.name}
+              batchQueryResult={batchQueryResult}
               onSelectCandidate={(candidate, fields) =>
                 handleCandidateSelect(candidate, "spotify", fields)
               }
-              onSearchAgain={spotify.search}
             />
           )}
 
           {!artist.soundcloud_url && (
-            <ProviderLinkField
+            <ProviderCandidatesPanel
+              provider="soundcloud"
               label="SoundCloud Candidates"
-              candidates={soundcloud.candidates}
-              searchError={soundcloud.error}
-              isLoadingCandidates={soundcloud.isLoading}
+              artistName={artist.name}
+              batchQueryResult={batchQueryResult}
               onSelectCandidate={(candidate, fields) =>
                 handleCandidateSelect(candidate, "soundcloud", fields)
               }
-              onSearchAgain={soundcloud.search}
             />
           )}
 

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -11,9 +12,16 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, RotateCcw } from "lucide-react";
 import type { Artist } from "@/api/artists/types";
 import { useUpdateArtistMutation } from "@/api/artists/useUpdateArtist";
+import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
+import {
+  mergeCandidateSelection,
+  type CandidateUpdate,
+} from "@/api/artistSearch/mergeCandidateSelection";
+import type { Provider, Candidate } from "@/api/artistSearch/types";
+import { CandidateCards } from "./CandidateCards";
 
 function requiredUrlSchema(isRequired: boolean) {
   return isRequired
@@ -46,6 +54,18 @@ export function LinkWizardStep({
   onNext,
 }: LinkWizardStepProps) {
   const updateArtistMutation = useUpdateArtistMutation();
+  const [stagedUpdates, setStagedUpdates] = useState<CandidateUpdate>({});
+  const [customQuery, setCustomQuery] = useState<{
+    provider: Provider;
+    query: string;
+  } | null>(null);
+
+  const searchQuery = customQuery ? customQuery.query : artist.name;
+
+  const searchQueryResult = useSearchArtistLinksQuery(
+    searchQuery ? [searchQuery] : [],
+    customQuery?.provider,
+  );
 
   const form = useForm<LinkStepData>({
     resolver: zodResolver(makeLinkStepSchema(artist)),
@@ -54,6 +74,22 @@ export function LinkWizardStep({
       soundcloudUrl: artist.soundcloud_url ?? "",
     },
   });
+
+  function handleCandidateSelect(candidate: Candidate, provider: Provider) {
+    const update = mergeCandidateSelection(
+      { artist, stagedUpdates },
+      candidate,
+      provider,
+    );
+
+    setStagedUpdates((prev) => ({ ...prev, ...update }));
+
+    if (provider === "spotify" && update.spotify_url) {
+      form.setValue("spotifyUrl", update.spotify_url);
+    } else if (provider === "soundcloud" && update.soundcloud_url) {
+      form.setValue("soundcloudUrl", update.soundcloud_url);
+    }
+  }
 
   function onSubmit(data: LinkStepData) {
     updateArtistMutation.mutate(
@@ -66,10 +102,25 @@ export function LinkWizardStep({
           ...(!artist.soundcloud_url && {
             soundcloud_url: data.soundcloudUrl || null,
           }),
+          ...(stagedUpdates.image_url && {
+            image_url: stagedUpdates.image_url,
+          }),
+          ...(stagedUpdates.description && {
+            description: stagedUpdates.description,
+          }),
         },
       },
       { onSuccess: onNext },
     );
+  }
+
+  function handleSearchAgain(
+    provider: Provider,
+    currentUrl: string | undefined,
+  ) {
+    if (currentUrl) {
+      setCustomQuery({ provider, query: currentUrl });
+    }
   }
 
   return (
@@ -83,43 +134,99 @@ export function LinkWizardStep({
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           {!artist.spotify_url && (
-            <FormField
-              control={form.control}
-              name="spotifyUrl"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Spotify URL</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="url"
-                      placeholder="https://open.spotify.com/artist/..."
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className="space-y-3">
+              <CandidateCards
+                candidates={
+                  searchQueryResult.data?.results.find(
+                    (r) => r.provider === "spotify",
+                  )?.candidates ?? []
+                }
+                provider="spotify"
+                isLoading={searchQueryResult.isLoading}
+                onSelectCandidate={(candidate) =>
+                  handleCandidateSelect(candidate, "spotify")
+                }
+              />
+              <FormField
+                control={form.control}
+                name="spotifyUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex items-center justify-between">
+                      <FormLabel>Spotify URL</FormLabel>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          handleSearchAgain("spotify", field.value)
+                        }
+                        disabled={searchQueryResult.isLoading}
+                      >
+                        <RotateCcw className="h-3 w-3 mr-1" />
+                        Search Again
+                      </Button>
+                    </div>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="https://open.spotify.com/artist/..."
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
           )}
 
           {!artist.soundcloud_url && (
-            <FormField
-              control={form.control}
-              name="soundcloudUrl"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>SoundCloud URL</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="url"
-                      placeholder="https://soundcloud.com/..."
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className="space-y-3">
+              <CandidateCards
+                candidates={
+                  searchQueryResult.data?.results.find(
+                    (r) => r.provider === "soundcloud",
+                  )?.candidates ?? []
+                }
+                provider="soundcloud"
+                isLoading={searchQueryResult.isLoading}
+                onSelectCandidate={(candidate) =>
+                  handleCandidateSelect(candidate, "soundcloud")
+                }
+              />
+              <FormField
+                control={form.control}
+                name="soundcloudUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex items-center justify-between">
+                      <FormLabel>SoundCloud URL</FormLabel>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          handleSearchAgain("soundcloud", field.value)
+                        }
+                        disabled={searchQueryResult.isLoading}
+                      >
+                        <RotateCcw className="h-3 w-3 mr-1" />
+                        Search Again
+                      </Button>
+                    </div>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="https://soundcloud.com/..."
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
           )}
 
           <div className="flex items-center justify-between gap-2 pt-2">

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -153,6 +153,9 @@ export function LinkWizardStep({
           ...(stagedUpdates.image_url && {
             image_url: stagedUpdates.image_url,
           }),
+          ...(stagedUpdates.description && {
+            description: stagedUpdates.description,
+          }),
         },
       },
       { onSuccess: onNext },

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -110,7 +110,6 @@ export function LinkWizardStep({
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           {!artist.spotify_url && (
             <ProviderLinkField
-              provider="spotify"
               label="Spotify Candidates"
               candidates={spotify.candidates}
               searchError={spotify.error}
@@ -124,7 +123,6 @@ export function LinkWizardStep({
 
           {!artist.soundcloud_url && (
             <ProviderLinkField
-              provider="soundcloud"
               label="SoundCloud Candidates"
               candidates={soundcloud.candidates}
               searchError={soundcloud.error}

--- a/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
+++ b/src/pages/admin/festivals/LinkWizard/LinkWizardStep.tsx
@@ -151,19 +151,27 @@ export function LinkWizardStep({
             | "providerUrl.spotify"
             | "providerUrl.soundcloud",
           url,
+          { shouldDirty: true },
         );
       }
     }
 
     if (update.image_url !== undefined) {
-      form.setValue("image_url", update.image_url);
+      form.setValue("image_url", update.image_url, { shouldDirty: true });
     }
     if (update.description !== undefined) {
-      form.setValue("description", update.description);
+      form.setValue("description", update.description, {
+        shouldDirty: true,
+      });
     }
   }
 
   function onSubmit(data: LinkStepData) {
+    if (!form.formState.isDirty) {
+      onNext();
+      return;
+    }
+
     const updates: UpdateArtistUpdates = {
       spotify_url: data.providerUrl.spotify || null,
       soundcloud_url: data.providerUrl.soundcloud || null,

--- a/src/pages/admin/festivals/LinkWizard/ProviderCandidatesPanel.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderCandidatesPanel.tsx
@@ -1,29 +1,39 @@
 import { useState } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, RotateCcw } from "lucide-react";
-import type { Candidate } from "@/api/artistSearch/types";
+import type {
+  Candidate,
+  Provider,
+  SearchResponse,
+} from "@/api/artistSearch/types";
 import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 import { CandidateCards } from "./CandidateCards";
+import { useProviderCandidates } from "./useProviderCandidates";
 
-interface ProviderLinkFieldProps {
+interface ProviderCandidatesPanelProps {
+  provider: Provider;
   label: string;
-  candidates: Candidate[];
-  searchError?: string | undefined;
-  isLoadingCandidates: boolean;
+  artistName: string;
+  batchQueryResult: UseQueryResult<SearchResponse>;
   onSelectCandidate: (candidate: Candidate, fields: SelectableField[]) => void;
-  onSearchAgain: (query: string) => void;
 }
 
-export function ProviderLinkField({
+export function ProviderCandidatesPanel({
+  provider,
   label,
-  candidates,
-  searchError,
-  isLoadingCandidates,
+  artistName,
+  batchQueryResult,
   onSelectCandidate,
-  onSearchAgain,
-}: ProviderLinkFieldProps) {
+}: ProviderCandidatesPanelProps) {
+  const { candidates, error, isLoading, search } = useProviderCandidates(
+    provider,
+    artistName,
+    batchQueryResult,
+  );
+
   const [showCustomSearch, setShowCustomSearch] = useState(false);
   const [customSearchQuery, setCustomSearchQuery] = useState("");
 
@@ -33,7 +43,7 @@ export function ProviderLinkField({
 
   function handleCustomSearch() {
     if (customSearchQuery.trim()) {
-      onSearchAgain(customSearchQuery);
+      search(customSearchQuery);
       setCustomSearchQuery("");
     }
   }
@@ -47,7 +57,7 @@ export function ProviderLinkField({
           variant="ghost"
           size="sm"
           onClick={handleSearchClick}
-          disabled={isLoadingCandidates}
+          disabled={isLoading}
         >
           <RotateCcw className="h-3 w-3 mr-1" />
           Search Again
@@ -67,29 +77,29 @@ export function ProviderLinkField({
                 handleCustomSearch();
               }
             }}
-            disabled={isLoadingCandidates}
+            disabled={isLoading}
           />
           <Button
             type="button"
             size="sm"
             onClick={handleCustomSearch}
-            disabled={!customSearchQuery.trim() || isLoadingCandidates}
+            disabled={!customSearchQuery.trim() || isLoading}
           >
             Search
           </Button>
         </div>
       )}
 
-      {searchError && !isLoadingCandidates && (
+      {error && !isLoading && (
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
-          <AlertDescription>{searchError}</AlertDescription>
+          <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
 
       <CandidateCards
         candidates={candidates}
-        isLoading={isLoadingCandidates}
+        isLoading={isLoading}
         onSelectCandidate={onSelectCandidate}
       />
     </div>

--- a/src/pages/admin/festivals/LinkWizard/ProviderCandidatesPanel.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderCandidatesPanel.tsx
@@ -68,6 +68,7 @@ export function ProviderCandidatesPanel({
         <div className="flex gap-2">
           <Input
             type="text"
+            aria-label={`Search ${label}`}
             placeholder="Enter artist name..."
             value={customSearchQuery}
             onChange={(e) => setCustomSearchQuery(e.target.value)}

--- a/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
@@ -99,7 +99,6 @@ export function ProviderLinkField({
                     }
                   }}
                   disabled={isLoadingCandidates}
-                  autoFocus
                 />
                 <Button
                   type="button"

--- a/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
@@ -3,12 +3,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, RotateCcw } from "lucide-react";
-import type { Candidate, Provider } from "@/api/artistSearch/types";
+import type { Candidate } from "@/api/artistSearch/types";
 import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 import { CandidateCards } from "./CandidateCards";
 
 interface ProviderLinkFieldProps {
-  provider: Provider;
   label: string;
   candidates: Candidate[];
   searchError?: string | undefined;
@@ -18,7 +17,6 @@ interface ProviderLinkFieldProps {
 }
 
 export function ProviderLinkField({
-  provider,
   label,
   candidates,
   searchError,
@@ -91,7 +89,6 @@ export function ProviderLinkField({
 
       <CandidateCards
         candidates={candidates}
-        provider={provider}
         isLoading={isLoadingCandidates}
         onSelectCandidate={onSelectCandidate}
       />

--- a/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
@@ -1,42 +1,28 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, RotateCcw } from "lucide-react";
-import type { UseFormReturn } from "react-hook-form";
 import type { Candidate, Provider } from "@/api/artistSearch/types";
 import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 import { CandidateCards } from "./CandidateCards";
 
 interface ProviderLinkFieldProps {
   provider: Provider;
-  fieldName: string;
   label: string;
-  placeholder: string;
   candidates: Candidate[];
   searchError?: string | undefined;
   isLoadingCandidates: boolean;
-  form: UseFormReturn<Record<string, unknown>>;
   onSelectCandidate: (candidate: Candidate, fields: SelectableField[]) => void;
   onSearchAgain: (query: string) => void;
 }
 
 export function ProviderLinkField({
   provider,
-  fieldName,
   label,
-  placeholder,
   candidates,
   searchError,
   isLoadingCandidates,
-  form,
   onSelectCandidate,
   onSearchAgain,
 }: ProviderLinkFieldProps) {
@@ -56,75 +42,58 @@ export function ProviderLinkField({
 
   return (
     <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">{label}</p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleSearchClick}
+          disabled={isLoadingCandidates}
+        >
+          <RotateCcw className="h-3 w-3 mr-1" />
+          Search Again
+        </Button>
+      </div>
+
+      {showCustomSearch && (
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            placeholder="Enter artist name..."
+            value={customSearchQuery}
+            onChange={(e) => setCustomSearchQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleCustomSearch();
+              }
+            }}
+            disabled={isLoadingCandidates}
+          />
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleCustomSearch}
+            disabled={!customSearchQuery.trim() || isLoadingCandidates}
+          >
+            Search
+          </Button>
+        </div>
+      )}
+
       {searchError && !isLoadingCandidates && (
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>{searchError}</AlertDescription>
         </Alert>
       )}
+
       <CandidateCards
         candidates={candidates}
         provider={provider}
         isLoading={isLoadingCandidates}
         onSelectCandidate={onSelectCandidate}
-      />
-      <FormField
-        control={form.control}
-        name={fieldName}
-        render={({ field }) => (
-          <FormItem>
-            <div className="flex items-center justify-between">
-              <FormLabel>{label}</FormLabel>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={handleSearchClick}
-                disabled={isLoadingCandidates}
-              >
-                <RotateCcw className="h-3 w-3 mr-1" />
-                Search Again
-              </Button>
-            </div>
-            {showCustomSearch && (
-              <div className="flex gap-2 mb-2">
-                <Input
-                  type="text"
-                  placeholder="Enter artist name..."
-                  value={customSearchQuery}
-                  onChange={(e) => setCustomSearchQuery(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      handleCustomSearch();
-                    }
-                  }}
-                  disabled={isLoadingCandidates}
-                />
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={handleCustomSearch}
-                  disabled={!customSearchQuery.trim() || isLoadingCandidates}
-                >
-                  Search
-                </Button>
-              </div>
-            )}
-            <FormControl>
-              <Input
-                type="url"
-                placeholder={placeholder}
-                value={(field.value as string) || ""}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-                name={field.name}
-                ref={field.ref}
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
       />
     </div>
   );

--- a/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
@@ -94,6 +94,7 @@ export function ProviderLinkField({
                   onChange={(e) => setCustomSearchQuery(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
+                      e.preventDefault();
                       handleCustomSearch();
                     }
                   }}

--- a/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { RotateCcw } from "lucide-react";
+import type { UseFormReturn } from "react-hook-form";
+import type { Candidate, Provider } from "@/api/artistSearch/types";
+import { CandidateCards } from "./CandidateCards";
+
+interface ProviderLinkFieldProps {
+  provider: Provider;
+  fieldName: string;
+  label: string;
+  placeholder: string;
+  candidates: Candidate[];
+  isLoadingCandidates: boolean;
+  form: UseFormReturn<Record<string, unknown>>;
+  onSelectCandidate: (candidate: Candidate) => void;
+  onSearchAgain: (query: string) => void;
+}
+
+export function ProviderLinkField({
+  provider,
+  fieldName,
+  label,
+  placeholder,
+  candidates,
+  isLoadingCandidates,
+  form,
+  onSelectCandidate,
+  onSearchAgain,
+}: ProviderLinkFieldProps) {
+  const [showCustomSearch, setShowCustomSearch] = useState(false);
+  const [customSearchQuery, setCustomSearchQuery] = useState("");
+
+  function handleSearchClick() {
+    setShowCustomSearch(!showCustomSearch);
+  }
+
+  function handleCustomSearch() {
+    if (customSearchQuery.trim()) {
+      onSearchAgain(customSearchQuery);
+      setCustomSearchQuery("");
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <CandidateCards
+        candidates={candidates}
+        provider={provider}
+        isLoading={isLoadingCandidates}
+        onSelectCandidate={onSelectCandidate}
+      />
+      <FormField
+        control={form.control}
+        name={fieldName}
+        render={({ field }) => (
+          <FormItem>
+            <div className="flex items-center justify-between">
+              <FormLabel>{label}</FormLabel>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleSearchClick}
+                disabled={isLoadingCandidates}
+              >
+                <RotateCcw className="h-3 w-3 mr-1" />
+                Search Again
+              </Button>
+            </div>
+            {showCustomSearch && (
+              <div className="flex gap-2 mb-2">
+                <Input
+                  type="text"
+                  placeholder="Enter artist name..."
+                  value={customSearchQuery}
+                  onChange={(e) => setCustomSearchQuery(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      handleCustomSearch();
+                    }
+                  }}
+                  disabled={isLoadingCandidates}
+                  autoFocus
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={handleCustomSearch}
+                  disabled={!customSearchQuery.trim() || isLoadingCandidates}
+                >
+                  Search
+                </Button>
+              </div>
+            )}
+            <FormControl>
+              <Input
+                type="url"
+                placeholder={placeholder}
+                value={(field.value as string) || ""}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                name={field.name}
+                ref={field.ref}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+}

--- a/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
@@ -12,6 +12,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, RotateCcw } from "lucide-react";
 import type { UseFormReturn } from "react-hook-form";
 import type { Candidate, Provider } from "@/api/artistSearch/types";
+import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 import { CandidateCards } from "./CandidateCards";
 
 interface ProviderLinkFieldProps {
@@ -23,7 +24,7 @@ interface ProviderLinkFieldProps {
   searchError?: string | undefined;
   isLoadingCandidates: boolean;
   form: UseFormReturn<Record<string, unknown>>;
-  onSelectCandidate: (candidate: Candidate) => void;
+  onSelectCandidate: (candidate: Candidate, fields: SelectableField[]) => void;
   onSearchAgain: (query: string) => void;
 }
 

--- a/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
+++ b/src/pages/admin/festivals/LinkWizard/ProviderLinkField.tsx
@@ -8,7 +8,8 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { RotateCcw } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, RotateCcw } from "lucide-react";
 import type { UseFormReturn } from "react-hook-form";
 import type { Candidate, Provider } from "@/api/artistSearch/types";
 import { CandidateCards } from "./CandidateCards";
@@ -19,6 +20,7 @@ interface ProviderLinkFieldProps {
   label: string;
   placeholder: string;
   candidates: Candidate[];
+  searchError?: string | undefined;
   isLoadingCandidates: boolean;
   form: UseFormReturn<Record<string, unknown>>;
   onSelectCandidate: (candidate: Candidate) => void;
@@ -31,6 +33,7 @@ export function ProviderLinkField({
   label,
   placeholder,
   candidates,
+  searchError,
   isLoadingCandidates,
   form,
   onSelectCandidate,
@@ -52,6 +55,12 @@ export function ProviderLinkField({
 
   return (
     <div className="space-y-3">
+      {searchError && !isLoadingCandidates && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{searchError}</AlertDescription>
+        </Alert>
+      )}
       <CandidateCards
         candidates={candidates}
         provider={provider}

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -80,6 +80,7 @@ export function StagedFieldsPreview({ form }: StagedFieldsPreviewProps) {
                 name="description"
                 render={({ field }) => (
                   <FormItem>
+                    <FormLabel>Description</FormLabel>
                     <FormControl>
                       <Textarea
                         value={field.value ?? ""}

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -9,22 +9,25 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 
-interface UrlFieldConfig {
-  fieldName: string;
-  label: string;
-  placeholder: string;
-}
+const URL_FIELDS = [
+  {
+    fieldName: "providerUrl.spotify",
+    label: "Spotify URL",
+    placeholder: "https://open.spotify.com/artist/...",
+  },
+  {
+    fieldName: "providerUrl.soundcloud",
+    label: "SoundCloud URL",
+    placeholder: "https://soundcloud.com/...",
+  },
+];
 
 interface StagedFieldsPreviewProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   form: UseFormReturn<any>;
-  urlFields: UrlFieldConfig[];
 }
 
-export function StagedFieldsPreview({
-  form,
-  urlFields,
-}: StagedFieldsPreviewProps) {
+export function StagedFieldsPreview({ form }: StagedFieldsPreviewProps) {
   const imageUrl = form.watch("image_url") as string | null | undefined;
   const description = form.watch("description") as string | null | undefined;
 
@@ -32,7 +35,7 @@ export function StagedFieldsPreview({
     <div className="space-y-3 rounded-lg border p-3">
       <p className="text-sm font-medium">Staged</p>
 
-      {urlFields.map(({ fieldName, label, placeholder }) => (
+      {URL_FIELDS.map(({ fieldName, label, placeholder }) => (
         <FormField
           key={fieldName}
           control={form.control}

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -1,5 +1,11 @@
 import { Textarea } from "@/components/ui/textarea";
 import type { CandidateUpdate } from "@/api/artistSearch/mergeCandidateSelection";
+import type { Provider } from "@/api/artistSearch/types";
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+  spotify: "Spotify",
+  soundcloud: "SoundCloud",
+};
 
 interface StagedFieldsPreviewProps {
   stagedUpdates: CandidateUpdate;
@@ -10,7 +16,13 @@ export function StagedFieldsPreview({
   stagedUpdates,
   onDescriptionChange,
 }: StagedFieldsPreviewProps) {
-  if (!stagedUpdates.image_url && stagedUpdates.description === undefined) {
+  const providerUrls = Object.entries(stagedUpdates.providerUrl ?? {});
+
+  if (
+    providerUrls.length === 0 &&
+    !stagedUpdates.image_url &&
+    stagedUpdates.description === undefined
+  ) {
     return null;
   }
 
@@ -24,7 +36,12 @@ export function StagedFieldsPreview({
         />
       )}
       <div className="flex-1 space-y-1">
-        <p className="font-medium">Also staged from candidate</p>
+        <p className="font-medium">Staged</p>
+        {providerUrls.map(([provider, url]) => (
+          <p key={provider} className="truncate text-muted-foreground">
+            {PROVIDER_LABELS[provider as Provider]} URL: {url}
+          </p>
+        ))}
         {stagedUpdates.image_url && (
           <p className="text-muted-foreground">Image</p>
         )}

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -1,0 +1,42 @@
+import { Textarea } from "@/components/ui/textarea";
+import type { CandidateUpdate } from "@/api/artistSearch/mergeCandidateSelection";
+
+interface StagedFieldsPreviewProps {
+  stagedUpdates: CandidateUpdate;
+  onDescriptionChange: (description: string) => void;
+}
+
+export function StagedFieldsPreview({
+  stagedUpdates,
+  onDescriptionChange,
+}: StagedFieldsPreviewProps) {
+  if (!stagedUpdates.image_url && stagedUpdates.description === undefined) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-start gap-3 rounded-lg border p-3 text-sm">
+      {stagedUpdates.image_url && (
+        <img
+          src={stagedUpdates.image_url}
+          alt=""
+          className="h-12 w-12 rounded object-cover"
+        />
+      )}
+      <div className="flex-1 space-y-1">
+        <p className="font-medium">Also staged from candidate</p>
+        {stagedUpdates.image_url && (
+          <p className="text-muted-foreground">Image</p>
+        )}
+        {stagedUpdates.description !== undefined && (
+          <Textarea
+            value={stagedUpdates.description ?? ""}
+            onChange={(e) => onDescriptionChange(e.target.value)}
+            rows={2}
+            className="text-sm"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -1,59 +1,89 @@
+import type { UseFormReturn } from "react-hook-form";
+import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import type { CandidateUpdate } from "@/api/artistSearch/mergeCandidateSelection";
-import type { Provider } from "@/api/artistSearch/types";
 
-const PROVIDER_LABELS: Record<Provider, string> = {
-  spotify: "Spotify",
-  soundcloud: "SoundCloud",
-};
+interface UrlFieldConfig {
+  fieldName: string;
+  label: string;
+  placeholder: string;
+}
 
 interface StagedFieldsPreviewProps {
+  form: UseFormReturn<Record<string, unknown>>;
+  urlFields: UrlFieldConfig[];
   stagedUpdates: CandidateUpdate;
   onDescriptionChange: (description: string) => void;
 }
 
 export function StagedFieldsPreview({
+  form,
+  urlFields,
   stagedUpdates,
   onDescriptionChange,
 }: StagedFieldsPreviewProps) {
-  const providerUrls = Object.entries(stagedUpdates.providerUrl ?? {});
-
-  if (
-    providerUrls.length === 0 &&
-    !stagedUpdates.image_url &&
-    stagedUpdates.description === undefined
-  ) {
-    return null;
-  }
-
   return (
-    <div className="flex items-start gap-3 rounded-lg border p-3 text-sm">
-      {stagedUpdates.image_url && (
-        <img
-          src={stagedUpdates.image_url}
-          alt=""
-          className="h-12 w-12 rounded object-cover"
+    <div className="space-y-3 rounded-lg border p-3">
+      <p className="text-sm font-medium">Staged</p>
+
+      {urlFields.map(({ fieldName, label, placeholder }) => (
+        <FormField
+          key={fieldName}
+          control={form.control}
+          name={fieldName}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{label}</FormLabel>
+              <FormControl>
+                <Input
+                  type="url"
+                  placeholder={placeholder}
+                  value={(field.value as string) || ""}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  name={field.name}
+                  ref={field.ref}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
         />
+      ))}
+
+      {(stagedUpdates.image_url || stagedUpdates.description !== undefined) && (
+        <div className="flex items-start gap-3 text-sm">
+          {stagedUpdates.image_url && (
+            <img
+              src={stagedUpdates.image_url}
+              alt=""
+              className="h-12 w-12 rounded object-cover"
+            />
+          )}
+          <div className="flex-1 space-y-1">
+            {stagedUpdates.image_url && (
+              <p className="text-muted-foreground">
+                Image staged from candidate
+              </p>
+            )}
+            {stagedUpdates.description !== undefined && (
+              <Textarea
+                value={stagedUpdates.description ?? ""}
+                onChange={(e) => onDescriptionChange(e.target.value)}
+                rows={2}
+                className="text-sm"
+              />
+            )}
+          </div>
+        </div>
       )}
-      <div className="flex-1 space-y-1">
-        <p className="font-medium">Staged</p>
-        {providerUrls.map(([provider, url]) => (
-          <p key={provider} className="truncate text-muted-foreground">
-            {PROVIDER_LABELS[provider as Provider]} URL: {url}
-          </p>
-        ))}
-        {stagedUpdates.image_url && (
-          <p className="text-muted-foreground">Image</p>
-        )}
-        {stagedUpdates.description !== undefined && (
-          <Textarea
-            value={stagedUpdates.description ?? ""}
-            onChange={(e) => onDescriptionChange(e.target.value)}
-            rows={2}
-            className="text-sm"
-          />
-        )}
-      </div>
     </div>
   );
 }

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -70,11 +70,6 @@ export function StagedFieldsPreview({ form }: StagedFieldsPreviewProps) {
             />
           )}
           <div className="flex-1 space-y-1">
-            {imageUrl && (
-              <p className="text-muted-foreground">
-                Image staged from candidate
-              </p>
-            )}
             {description !== undefined && (
               <FormField
                 control={form.control}

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -8,8 +8,13 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import type { LinkStepData } from "./LinkWizardStep";
 
-const URL_FIELDS = [
+const URL_FIELDS: {
+  fieldName: "providerUrl.spotify" | "providerUrl.soundcloud";
+  label: string;
+  placeholder: string;
+}[] = [
   {
     fieldName: "providerUrl.spotify",
     label: "Spotify URL",
@@ -23,13 +28,12 @@ const URL_FIELDS = [
 ];
 
 interface StagedFieldsPreviewProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  form: UseFormReturn<any>;
+  form: UseFormReturn<LinkStepData>;
 }
 
 export function StagedFieldsPreview({ form }: StagedFieldsPreviewProps) {
-  const imageUrl = form.watch("image_url") as string | null | undefined;
-  const description = form.watch("description") as string | null | undefined;
+  const imageUrl = form.watch("image_url");
+  const description = form.watch("description");
 
   return (
     <div className="space-y-3 rounded-lg border p-3">
@@ -47,7 +51,7 @@ export function StagedFieldsPreview({ form }: StagedFieldsPreviewProps) {
                 <Input
                   type="url"
                   placeholder={placeholder}
-                  value={(field.value as string) || ""}
+                  value={field.value || ""}
                   onChange={field.onChange}
                   onBlur={field.onBlur}
                   name={field.name}
@@ -78,7 +82,7 @@ export function StagedFieldsPreview({ form }: StagedFieldsPreviewProps) {
                   <FormItem>
                     <FormControl>
                       <Textarea
-                        value={(field.value as string) ?? ""}
+                        value={field.value ?? ""}
                         onChange={field.onChange}
                         onBlur={field.onBlur}
                         name={field.name}

--- a/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
+++ b/src/pages/admin/festivals/LinkWizard/StagedFieldsPreview.tsx
@@ -8,7 +8,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import type { CandidateUpdate } from "@/api/artistSearch/mergeCandidateSelection";
 
 interface UrlFieldConfig {
   fieldName: string;
@@ -17,18 +16,18 @@ interface UrlFieldConfig {
 }
 
 interface StagedFieldsPreviewProps {
-  form: UseFormReturn<Record<string, unknown>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: UseFormReturn<any>;
   urlFields: UrlFieldConfig[];
-  stagedUpdates: CandidateUpdate;
-  onDescriptionChange: (description: string) => void;
 }
 
 export function StagedFieldsPreview({
   form,
   urlFields,
-  stagedUpdates,
-  onDescriptionChange,
 }: StagedFieldsPreviewProps) {
+  const imageUrl = form.watch("image_url") as string | null | undefined;
+  const description = form.watch("description") as string | null | undefined;
+
   return (
     <div className="space-y-3 rounded-lg border p-3">
       <p className="text-sm font-medium">Staged</p>
@@ -58,27 +57,40 @@ export function StagedFieldsPreview({
         />
       ))}
 
-      {(stagedUpdates.image_url || stagedUpdates.description !== undefined) && (
+      {(imageUrl || description !== undefined) && (
         <div className="flex items-start gap-3 text-sm">
-          {stagedUpdates.image_url && (
+          {imageUrl && (
             <img
-              src={stagedUpdates.image_url}
+              src={imageUrl}
               alt=""
               className="h-12 w-12 rounded object-cover"
             />
           )}
           <div className="flex-1 space-y-1">
-            {stagedUpdates.image_url && (
+            {imageUrl && (
               <p className="text-muted-foreground">
                 Image staged from candidate
               </p>
             )}
-            {stagedUpdates.description !== undefined && (
-              <Textarea
-                value={stagedUpdates.description ?? ""}
-                onChange={(e) => onDescriptionChange(e.target.value)}
-                rows={2}
-                className="text-sm"
+            {description !== undefined && (
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Textarea
+                        value={(field.value as string) ?? ""}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
+                        rows={2}
+                        className="text-sm"
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
               />
             )}
           </div>

--- a/src/pages/admin/festivals/LinkWizard/useArtistBatchQuery.ts
+++ b/src/pages/admin/festivals/LinkWizard/useArtistBatchQuery.ts
@@ -1,0 +1,12 @@
+import type { Artist } from "@/api/artists/types";
+import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
+
+export function useArtistBatchQuery(artist: Artist, artists: Artist[]) {
+  const currentIndex = artists.findIndex((a) => a.id === artist.id);
+  const batchStart = Math.floor(currentIndex / 10) * 10;
+  const batchArtists = artists
+    .slice(batchStart, batchStart + 10)
+    .map((a) => a.name);
+
+  return useSearchArtistLinksQuery(batchArtists);
+}

--- a/src/pages/admin/festivals/LinkWizard/useProviderCandidates.ts
+++ b/src/pages/admin/festivals/LinkWizard/useProviderCandidates.ts
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useSearchArtistLinksQuery } from "@/api/artistSearch/useSearchArtistLinksQuery";
+import type {
+  Candidate,
+  Provider,
+  SearchResponse,
+} from "@/api/artistSearch/types";
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+  spotify: "Spotify",
+  soundcloud: "SoundCloud",
+};
+
+export function useProviderCandidates(
+  provider: Provider,
+  artistName: string,
+  batchQueryResult: UseQueryResult<SearchResponse>,
+) {
+  const [customSearch, setCustomSearch] = useState("");
+
+  const customResult = useSearchArtistLinksQuery(
+    customSearch ? [customSearch] : [],
+    provider,
+  );
+
+  const isLoading = batchQueryResult.isLoading || customResult.isLoading;
+
+  const { candidates, error } = resolveProviderResult({
+    provider,
+    artistName,
+    customSearch,
+    customResult,
+    batchQueryResult,
+  });
+
+  return { candidates, error, isLoading, search: setCustomSearch };
+}
+
+interface ResolveProviderResultArgs {
+  provider: Provider;
+  artistName: string;
+  customSearch: string;
+  customResult: UseQueryResult<SearchResponse>;
+  batchQueryResult: UseQueryResult<SearchResponse>;
+}
+
+function resolveProviderResult({
+  provider,
+  artistName,
+  customSearch,
+  customResult,
+  batchQueryResult,
+}: ResolveProviderResultArgs): {
+  candidates: Candidate[];
+  error?: string | undefined;
+} {
+  const providerLabel = PROVIDER_LABELS[provider];
+
+  if (customSearch) {
+    if (customResult.isError) {
+      return {
+        candidates: [],
+        error: `${providerLabel} search failed. Please try again.`,
+      };
+    }
+    const result = customResult.data?.results.find(
+      (r) => r.provider === provider,
+    );
+    return { candidates: result?.candidates ?? [], error: result?.error };
+  }
+
+  if (batchQueryResult.isError) {
+    return {
+      candidates: [],
+      error: `${providerLabel} search failed. Please try again.`,
+    };
+  }
+
+  const result = batchQueryResult.data?.results.find(
+    (r) => r.artistName === artistName && r.provider === provider,
+  );
+  return { candidates: result?.candidates ?? [], error: result?.error };
+}

--- a/src/pages/admin/festivals/LinkWizard/useProviderCandidates.ts
+++ b/src/pages/admin/festivals/LinkWizard/useProviderCandidates.ts
@@ -34,7 +34,15 @@ export function useProviderCandidates(
     batchQueryResult,
   });
 
-  return { candidates, error, isLoading, search: setCustomSearch };
+  function search(query: string) {
+    if (query === customSearch) {
+      customResult.refetch();
+      return;
+    }
+    setCustomSearch(query);
+  }
+
+  return { candidates, error, isLoading, search };
 }
 
 interface ResolveProviderResultArgs {

--- a/supabase/functions/_shared/soundcloud-api/schemas.ts
+++ b/supabase/functions/_shared/soundcloud-api/schemas.ts
@@ -18,6 +18,7 @@ export const SoundCloudUserSchema = z.object({
   followers_count: z.number().optional(),
   full_name: z.string().nullable().optional(),
   display_name: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
 });
 
 export const SoundCloudTrackSchema = z.object({

--- a/supabase/functions/search-artist-links/normalize.test.ts
+++ b/supabase/functions/search-artist-links/normalize.test.ts
@@ -26,6 +26,22 @@ Deno.test(
   },
 );
 
+Deno.test(
+  "normalizeSoundCloudSearchResult strips tracking query params from permalink_url",
+  () => {
+    const user: SoundCloudUser = {
+      id: 12345,
+      username: "testartist",
+      permalink_url:
+        "https://soundcloud.com/testartist?utm_medium=api&utm_campaign=social_sharing&utm_source=id_318328",
+    };
+
+    const result = normalizeSoundCloudSearchResult(user);
+
+    assertEquals(result.url, "https://soundcloud.com/testartist");
+  },
+);
+
 Deno.test("normalizeSoundCloudSearchResult handles missing description", () => {
   const user: SoundCloudUser = {
     id: 12345,

--- a/supabase/functions/search-artist-links/normalize.test.ts
+++ b/supabase/functions/search-artist-links/normalize.test.ts
@@ -12,6 +12,7 @@ Deno.test(
       avatar_url: "https://example.com/avatar.jpg",
       followers_count: 1500,
       display_name: "Test Artist",
+      description: "A test artist bio.",
     };
 
     const result = normalizeSoundCloudSearchResult(user);
@@ -19,10 +20,23 @@ Deno.test(
     assertEquals(result.name, "Test Artist");
     assertEquals(result.url, "https://soundcloud.com/testartist");
     assertEquals(result.imageUrl, "https://example.com/avatar.jpg");
+    assertEquals(result.description, "A test artist bio.");
     assertEquals(result.followers, 1500);
     assertEquals(result.genres, []);
   },
 );
+
+Deno.test("normalizeSoundCloudSearchResult handles missing description", () => {
+  const user: SoundCloudUser = {
+    id: 12345,
+    username: "testartist",
+    permalink_url: "https://soundcloud.com/testartist",
+  };
+
+  const result = normalizeSoundCloudSearchResult(user);
+
+  assertEquals(result.description, null);
+});
 
 Deno.test(
   "normalizeSoundCloudSearchResult uses username when display_name is null",

--- a/supabase/functions/search-artist-links/normalize.ts
+++ b/supabase/functions/search-artist-links/normalize.ts
@@ -1,6 +1,16 @@
 import type { SoundCloudUser } from "../_shared/soundcloud-api/schemas.ts";
 import type { Candidate } from "./types.ts";
 
+function stripTrackingParams(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.search = "";
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 export function normalizeSoundCloudSearchResult(
   user: SoundCloudUser,
 ): Candidate {
@@ -8,7 +18,7 @@ export function normalizeSoundCloudSearchResult(
 
   return {
     name,
-    url: user.permalink_url,
+    url: stripTrackingParams(user.permalink_url),
     imageUrl: user.avatar_url || null,
     description: user.description || null,
     followers: user.followers_count ?? null,

--- a/supabase/functions/search-artist-links/normalize.ts
+++ b/supabase/functions/search-artist-links/normalize.ts
@@ -10,6 +10,7 @@ export function normalizeSoundCloudSearchResult(
     name,
     url: user.permalink_url,
     imageUrl: user.avatar_url || null,
+    description: user.description || null,
     followers: user.followers_count ?? null,
     genres: [],
   };

--- a/supabase/functions/search-artist-links/types.ts
+++ b/supabase/functions/search-artist-links/types.ts
@@ -9,6 +9,7 @@ export interface Candidate {
   name: string;
   url: string;
   imageUrl: string | null;
+  description: string | null;
   followers: number | null;
   genres: string[];
 }


### PR DESCRIPTION
Adds search-based candidate suggestions in LinkWizard with smart data merging, custom query support, and per-provider error alerts.
Candidates appear as 3-card selection UI per provider with follower counts and genre tags; failed searches show a destructive alert instead of silently showing no candidates.

## Verification
- Open LinkWizard and see candidate cards appear with images, follower counts, and genres for missing links
- Select a candidate card; URL field populates and image stages for commit
- Two selections (Spotify + SoundCloud) on same artist; first provider's image wins
- Click "Search Again" and enter custom artist name; new candidates load for that query
- Save & Next commits the staged image along with the URL
- Skip artist with no candidates found; falls back to plain manual URL input
- Break provider credentials (or search while offline); a per-provider error alert appears above the URL field instead of an empty candidate list
- Verify candidates don't overwrite existing image on artist

Closes #335

Stacked on #337 (search-artist-links edge function)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdP5NDJLLG5jBERrPbhvHT)_