### PR TITLE
feat(search-artist-links): implement Spotify adapter

### DIFF
--- a/supabase/functions/_shared/spotify-api/auth.ts
+++ b/supabase/functions/_shared/spotify-api/auth.ts
@@ -1,0 +1,83 @@
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+
+const SpotifyTokenResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.string(),
+  expires_in: z.number(),
+});
+
+let cachedToken: {
+  token: string;
+  expiresAt: number;
+} | null = null;
+
+export async function getSpotifyAccessToken(
+  clientId: string,
+  clientSecret: string,
+): Promise<string> {
+  if (
+    cachedToken &&
+    cachedToken.expiresAt > Date.now() + 60 * 1000 // 1 minute buffer
+  ) {
+    console.log("[getSpotifyAccessToken] Using cached access token");
+    return cachedToken.token;
+  }
+
+  console.log("[getSpotifyAccessToken] Requesting access token...");
+
+  const tokenUrl = "https://accounts.spotify.com/api/token";
+  try {
+    const response = await fetch(tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+      },
+      body: "grant_type=client_credentials",
+    });
+
+    console.log(
+      `[getSpotifyAccessToken] Token response status: ${response.status} ${response.statusText}`,
+    );
+
+    if (!response.ok) {
+      const errorBody = await response
+        .text()
+        .catch(() => "Unable to read error response");
+      console.error("[getSpotifyAccessToken] Failed to get access token:", {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorBody,
+      });
+      throw new Error(
+        `Failed to get Spotify access token: ${response.statusText}`,
+      );
+    }
+
+    const rawData = await response.json();
+
+    try {
+      const tokenData = SpotifyTokenResponseSchema.parse(rawData);
+      console.log(
+        "[getSpotifyAccessToken] Successfully obtained and validated access token",
+      );
+      const token = tokenData.access_token;
+      const expiresIn = tokenData.expires_in || 3600; // Default to 1 hour if not provided
+      const expiresAt = Date.now() + expiresIn * 1000;
+
+      cachedToken = { token, expiresAt };
+      return token;
+    } catch (validationError) {
+      console.error("[getSpotifyAccessToken] Invalid token response format:", {
+        error: validationError,
+        rawData: JSON.stringify(rawData).slice(0, 200) + "...",
+      });
+      throw new Error("Invalid access token response from Spotify");
+    }
+  } catch (error) {
+    console.error("[getSpotifyAccessToken] Error obtaining access token:", {
+      error,
+    });
+    throw error;
+  }
+}

--- a/supabase/functions/_shared/spotify-api/auth.ts
+++ b/supabase/functions/_shared/spotify-api/auth.ts
@@ -11,10 +11,13 @@ let cachedToken: {
   expiresAt: number;
 } | null = null;
 
-export async function getSpotifyAccessToken(
-  clientId: string,
-  clientSecret: string,
-): Promise<string> {
+export async function getSpotifyAccessToken(): Promise<string> {
+  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
+  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
+  if (!clientId || !clientSecret) {
+    throw new Error("Spotify credentials are not configured");
+  }
+
   if (
     cachedToken &&
     cachedToken.expiresAt > Date.now() + 60 * 1000 // 1 minute buffer
@@ -62,7 +65,7 @@ export async function getSpotifyAccessToken(
         "[getSpotifyAccessToken] Successfully obtained and validated access token",
       );
       const token = tokenData.access_token;
-      const expiresIn = tokenData.expires_in || 3600; // Default to 1 hour if not provided
+      const expiresIn = tokenData.expires_in ?? 3600; // Default to 1 hour if not provided
       const expiresAt = Date.now() + expiresIn * 1000;
 
       cachedToken = { token, expiresAt };
@@ -70,7 +73,11 @@ export async function getSpotifyAccessToken(
     } catch (validationError) {
       console.error("[getSpotifyAccessToken] Invalid token response format:", {
         error: validationError,
-        rawData: JSON.stringify(rawData).slice(0, 200) + "...",
+        rawData:
+          JSON.stringify({ ...rawData, access_token: "[REDACTED]" }).slice(
+            0,
+            200,
+          ) + "...",
       });
       throw new Error("Invalid access token response from Spotify");
     }

--- a/supabase/functions/_shared/spotify-api/schemas.ts
+++ b/supabase/functions/_shared/spotify-api/schemas.ts
@@ -1,0 +1,34 @@
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+
+export const SpotifyImageSchema = z.object({
+  url: z.string(),
+  height: z.number().nullable().optional(),
+  width: z.number().nullable().optional(),
+});
+
+export const SpotifyArtistSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  genres: z.array(z.string()).optional(),
+  followers: z
+    .object({
+      total: z.number(),
+    })
+    .optional(),
+  images: z.array(SpotifyImageSchema).optional(),
+  external_urls: z.object({
+    spotify: z.string(),
+  }),
+});
+
+export const SpotifySearchResponseSchema = z.object({
+  artists: z
+    .object({
+      items: z.array(SpotifyArtistSchema).optional(),
+    })
+    .optional(),
+});
+
+export type SpotifyImage = z.infer<typeof SpotifyImageSchema>;
+export type SpotifyArtist = z.infer<typeof SpotifyArtistSchema>;
+export type SpotifySearchResponse = z.infer<typeof SpotifySearchResponseSchema>;

--- a/supabase/functions/search-artist-links/normalize.test.ts
+++ b/supabase/functions/search-artist-links/normalize.test.ts
@@ -1,6 +1,10 @@
 import { assertEquals } from "jsr:@std/assert@1";
 import type { SoundCloudUser } from "../_shared/soundcloud-api/schemas.ts";
-import { normalizeSoundCloudSearchResult } from "./normalize.ts";
+import type { SpotifyArtist } from "../_shared/spotify-api/schemas.ts";
+import {
+  normalizeSoundCloudSearchResult,
+  normalizeSpotifySearchResult,
+} from "./normalize.ts";
 
 Deno.test(
   "normalizeSoundCloudSearchResult converts SoundCloud user to Candidate",
@@ -135,3 +139,89 @@ Deno.test(
     assertEquals(result.followers, 5000);
   },
 );
+
+Deno.test(
+  "normalizeSpotifySearchResult converts Spotify artist to Candidate",
+  () => {
+    const artist: SpotifyArtist = {
+      id: "123abc",
+      name: "Test Artist",
+      genres: ["pop", "rock"],
+      followers: { total: 1500 },
+      images: [{ url: "https://example.com/image.jpg" }],
+      external_urls: { spotify: "https://open.spotify.com/artist/123abc" },
+    };
+
+    const result = normalizeSpotifySearchResult(artist);
+
+    assertEquals(result.name, "Test Artist");
+    assertEquals(result.url, "https://open.spotify.com/artist/123abc");
+    assertEquals(result.imageUrl, "https://example.com/image.jpg");
+    assertEquals(result.followers, 1500);
+    assertEquals(result.genres, ["pop", "rock"]);
+  },
+);
+
+Deno.test("normalizeSpotifySearchResult handles missing images", () => {
+  const artist: SpotifyArtist = {
+    id: "456def",
+    name: "Artist Without Image",
+    external_urls: { spotify: "https://open.spotify.com/artist/456def" },
+  };
+
+  const result = normalizeSpotifySearchResult(artist);
+
+  assertEquals(result.imageUrl, null);
+});
+
+Deno.test("normalizeSpotifySearchResult handles empty images array", () => {
+  const artist: SpotifyArtist = {
+    id: "789ghi",
+    name: "Artist With Empty Images",
+    images: [],
+    external_urls: { spotify: "https://open.spotify.com/artist/789ghi" },
+  };
+
+  const result = normalizeSpotifySearchResult(artist);
+
+  assertEquals(result.imageUrl, null);
+});
+
+Deno.test("normalizeSpotifySearchResult handles missing followers", () => {
+  const artist: SpotifyArtist = {
+    id: "101112",
+    name: "Artist Without Followers",
+    images: [{ url: "https://example.com/art.jpg" }],
+    external_urls: { spotify: "https://open.spotify.com/artist/101112" },
+  };
+
+  const result = normalizeSpotifySearchResult(artist);
+
+  assertEquals(result.followers, null);
+});
+
+Deno.test("normalizeSpotifySearchResult preserves followers count of 0", () => {
+  const artist: SpotifyArtist = {
+    id: "131415",
+    name: "New Artist",
+    followers: { total: 0 },
+    external_urls: { spotify: "https://open.spotify.com/artist/131415" },
+  };
+
+  const result = normalizeSpotifySearchResult(artist);
+
+  assertEquals(result.followers, 0);
+});
+
+Deno.test("normalizeSpotifySearchResult handles missing genres", () => {
+  const artist: SpotifyArtist = {
+    id: "161718",
+    name: "Artist Without Genres",
+    followers: { total: 500 },
+    external_urls: { spotify: "https://open.spotify.com/artist/161718" },
+  };
+
+  const result = normalizeSpotifySearchResult(artist);
+
+  assertEquals(result.genres, []);
+});

--- a/supabase/functions/search-artist-links/normalize.ts
+++ b/supabase/functions/search-artist-links/normalize.ts
@@ -1,4 +1,5 @@
 import type { SoundCloudUser } from "../_shared/soundcloud-api/schemas.ts";
+import type { SpotifyArtist } from "../_shared/spotify-api/schemas.ts";
 import type { Candidate } from "./types.ts";
 
 function stripTrackingParams(url: string): string {
@@ -23,5 +24,20 @@ export function normalizeSoundCloudSearchResult(
     description: user.description || null,
     followers: user.followers_count ?? null,
     genres: [],
+  };
+}
+
+export function normalizeSpotifySearchResult(artist: SpotifyArtist): Candidate {
+  const imageUrl =
+    artist.images && artist.images.length > 0 ? artist.images[0].url : null;
+  const followers = artist.followers?.total ?? null;
+
+  return {
+    name: artist.name,
+    url: artist.external_urls.spotify,
+    imageUrl,
+    description: null,
+    followers,
+    genres: artist.genres || [],
   };
 }

--- a/supabase/functions/search-artist-links/spotify-adapter.ts
+++ b/supabase/functions/search-artist-links/spotify-adapter.ts
@@ -8,20 +8,7 @@ export async function searchSpotify(
 ): Promise<Map<string, ProviderSearchOutcome>> {
   const results = new Map<string, ProviderSearchOutcome>();
 
-  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
-  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
-
-  if (!clientId || !clientSecret) {
-    console.warn(
-      "[searchSpotify] Missing Spotify credentials, skipping Spotify search",
-    );
-    for (const name of artistNames) {
-      results.set(name, { candidates: [] });
-    }
-    return results;
-  }
-
-  const accessToken = await getSpotifyAccessToken(clientId, clientSecret);
+  const accessToken = await getSpotifyAccessToken();
 
   for (const artistName of artistNames) {
     try {

--- a/supabase/functions/search-artist-links/spotify-adapter.ts
+++ b/supabase/functions/search-artist-links/spotify-adapter.ts
@@ -1,3 +1,6 @@
+import { getSpotifyAccessToken } from "../_shared/spotify-api/auth.ts";
+import { SpotifySearchResponseSchema } from "../_shared/spotify-api/schemas.ts";
+import { normalizeSpotifySearchResult } from "./normalize.ts";
 import type { ProviderSearchOutcome } from "./types.ts";
 
 export async function searchSpotify(
@@ -5,11 +8,90 @@ export async function searchSpotify(
 ): Promise<Map<string, ProviderSearchOutcome>> {
   const results = new Map<string, ProviderSearchOutcome>();
 
-  for (const artistName of artistNames) {
-    console.log(
-      `[searchSpotify] Spotify search stub - no results for: ${artistName}`,
+  const clientId = Deno.env.get("SPOTIFY_CLIENT_ID");
+  const clientSecret = Deno.env.get("SPOTIFY_CLIENT_SECRET");
+
+  if (!clientId || !clientSecret) {
+    console.warn(
+      "[searchSpotify] Missing Spotify credentials, skipping Spotify search",
     );
-    results.set(artistName, { candidates: [] });
+    for (const name of artistNames) {
+      results.set(name, { candidates: [] });
+    }
+    return results;
+  }
+
+  const accessToken = await getSpotifyAccessToken(clientId, clientSecret);
+
+  for (const artistName of artistNames) {
+    try {
+      console.log(`[searchSpotify] Searching for artist: ${artistName}`);
+
+      const query = encodeURIComponent(artistName);
+      const endpoint = `https://api.spotify.com/v1/search?type=artist&q=${query}&limit=3`;
+
+      const response = await fetch(endpoint, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response
+          .text()
+          .catch(() => "Unable to read error response");
+        console.error(
+          `[searchSpotify] Error searching for artist ${artistName}:`,
+          {
+            status: response.status,
+            statusText: response.statusText,
+            body: errorText,
+          },
+        );
+        results.set(artistName, {
+          candidates: [],
+          error: `Spotify search failed (${response.status})`,
+        });
+        continue;
+      }
+
+      const rawData = await response.json();
+
+      const parseResponse = SpotifySearchResponseSchema.safeParse(rawData);
+      if (!parseResponse.success) {
+        console.error(
+          `[searchSpotify] Validation error for artist ${artistName}:`,
+          {
+            error: parseResponse.error,
+          },
+        );
+        results.set(artistName, {
+          candidates: [],
+          error: "Spotify search failed",
+        });
+        continue;
+      }
+
+      const searchData = parseResponse.data;
+      const candidates = (searchData.artists?.items || []).map(
+        normalizeSpotifySearchResult,
+      );
+
+      results.set(artistName, { candidates });
+      console.log(
+        `[searchSpotify] Found ${candidates.length} candidates for ${artistName}`,
+      );
+    } catch (error) {
+      console.error(
+        `[searchSpotify] Error searching for artist ${artistName}:`,
+        error,
+      );
+      results.set(artistName, {
+        candidates: [],
+        error: error instanceof Error ? error.message : "Spotify search failed",
+      });
+    }
   }
 
   return results;


### PR DESCRIPTION
Adds a complete Spotify artist search implementation with Client Credentials auth, API search, and normalization.
Search failures for individual artists don't affect results for other artists.

## Verification

**Preconditions**: Set Supabase secrets `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` in the edge function environment.

- Call `/search-artist-links` with `provider: "spotify"` and multiple artist names; verify all artists return up to 3 candidates each.
- Call with one artist that has no results; verify other artists' results are returned.
- Verify normalized candidates have correct shape: `{ name, url, imageUrl, followers, genres }`.
- Verify a Spotify artist with 0 followers preserves the count as 0, not null.
- Verify missing images return `imageUrl: null`.
- Verify missing genres return empty array.

Stacked on #337.

Closes #336

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdP5NDJLLG5jBERrPbhvHT)_