### PR TITLE
refactor(admin): simplify festival navigation and settings

### DIFF
--- a/src/pages/admin/festivals/EditionNavLink.tsx
+++ b/src/pages/admin/festivals/EditionNavLink.tsx
@@ -1,18 +1,13 @@
 import { Link } from "@tanstack/react-router";
-import { cn } from "@/lib/utils";
+
+const EDITION_ROOT = "/admin/festivals/$festivalSlug/editions/$editionSlug";
 
 interface EditionNavLinkProps {
-  to:
-    | "/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
-    | "/admin/festivals/$festivalSlug/editions/$editionSlug/sets"
-    | "/admin/festivals/$festivalSlug/editions/$editionSlug/import"
-    | "/admin/festivals/$festivalSlug/editions/$editionSlug/links"
-    | "/admin/festivals/$festivalSlug/editions/$editionSlug/settings";
+  to: "stages" | "sets" | "import" | "links" | "settings";
   festivalSlug: string;
   editionSlug: string;
   icon: React.ReactNode;
   label: string;
-  isActive: boolean;
 }
 
 export function EditionNavLink({
@@ -21,17 +16,15 @@ export function EditionNavLink({
   editionSlug,
   icon,
   label,
-  isActive,
 }: EditionNavLinkProps) {
   return (
     <Link
+      from={EDITION_ROOT}
       to={to}
       params={{ festivalSlug, editionSlug }}
-      className={cn(
-        "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
-        "text-white font-medium",
-        isActive ? "bg-purple-600" : "hover:bg-white/10",
-      )}
+      className="flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors text-white font-medium"
+      activeProps={{ className: "bg-purple-600" }}
+      inactiveProps={{ className: "hover:bg-white/10" }}
     >
       {icon}
       {label}

--- a/src/pages/admin/festivals/EditionNavLink.tsx
+++ b/src/pages/admin/festivals/EditionNavLink.tsx
@@ -1,0 +1,40 @@
+import { Link } from "@tanstack/react-router";
+import { cn } from "@/lib/utils";
+
+interface EditionNavLinkProps {
+  to:
+    | "/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
+    | "/admin/festivals/$festivalSlug/editions/$editionSlug/sets"
+    | "/admin/festivals/$festivalSlug/editions/$editionSlug/import"
+    | "/admin/festivals/$festivalSlug/editions/$editionSlug/links"
+    | "/admin/festivals/$festivalSlug/editions/$editionSlug/settings";
+  festivalSlug: string;
+  editionSlug: string;
+  icon: React.ReactNode;
+  label: string;
+  isActive: boolean;
+}
+
+export function EditionNavLink({
+  to,
+  festivalSlug,
+  editionSlug,
+  icon,
+  label,
+  isActive,
+}: EditionNavLinkProps) {
+  return (
+    <Link
+      to={to}
+      params={{ festivalSlug, editionSlug }}
+      className={cn(
+        "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
+        "text-white font-medium",
+        isActive ? "bg-purple-600" : "hover:bg-white/10",
+      )}
+    >
+      {icon}
+      {label}
+    </Link>
+  );
+}

--- a/src/pages/admin/festivals/FestivalBreadcrumb.tsx
+++ b/src/pages/admin/festivals/FestivalBreadcrumb.tsx
@@ -1,0 +1,47 @@
+import { Link } from "@tanstack/react-router";
+import { ChevronRight } from "lucide-react";
+
+interface FestivalBreadcrumbProps {
+  festivalSlug: string;
+  festivalName: string;
+  editionSlug?: string | undefined;
+  editionName?: string | undefined;
+}
+
+export function FestivalBreadcrumb({
+  festivalSlug,
+  festivalName,
+  editionSlug,
+  editionName,
+}: FestivalBreadcrumbProps) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground mb-6"
+    >
+      <Link to="/admin/festivals" className="font-medium hover:underline">
+        Festivals
+      </Link>
+      <ChevronRight className="h-4 w-4" />
+      {editionSlug ? (
+        <Link
+          to="/admin/festivals/$festivalSlug"
+          params={{ festivalSlug }}
+          className="font-medium hover:underline text-foreground"
+        >
+          {festivalName}
+        </Link>
+      ) : (
+        <span className="font-medium text-foreground">{festivalName}</span>
+      )}
+      {editionSlug && (
+        <>
+          <ChevronRight className="h-4 w-4" />
+          <span className="font-medium text-foreground">
+            {editionName ?? editionSlug}
+          </span>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/src/pages/admin/festivals/FestivalBreadcrumb.tsx
+++ b/src/pages/admin/festivals/FestivalBreadcrumb.tsx
@@ -1,18 +1,20 @@
 import { Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { ChevronRight } from "lucide-react";
+import { editionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 
 interface FestivalBreadcrumbProps {
   festivalSlug: string;
   festivalName: string;
+  festivalId: string;
   editionSlug?: string | undefined;
-  editionName?: string | undefined;
 }
 
 export function FestivalBreadcrumb({
   festivalSlug,
   festivalName,
+  festivalId,
   editionSlug,
-  editionName,
 }: FestivalBreadcrumbProps) {
   return (
     <nav
@@ -37,11 +39,23 @@ export function FestivalBreadcrumb({
       {editionSlug && (
         <>
           <ChevronRight className="h-4 w-4" />
-          <span className="font-medium text-foreground">
-            {editionName ?? editionSlug}
-          </span>
+          <EditionCrumb festivalId={festivalId} editionSlug={editionSlug} />
         </>
       )}
     </nav>
   );
+}
+
+function EditionCrumb({
+  festivalId,
+  editionSlug,
+}: {
+  festivalId: string;
+  editionSlug: string;
+}) {
+  const { data: edition } = useSuspenseQuery(
+    editionBySlugQuery({ festivalId, editionSlug }),
+  );
+
+  return <span className="font-medium text-foreground">{edition.name}</span>;
 }

--- a/src/pages/admin/festivals/FestivalInfoDialog.tsx
+++ b/src/pages/admin/festivals/FestivalInfoDialog.tsx
@@ -1,0 +1,42 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Info } from "lucide-react";
+import { Festival } from "@/api/festivals/types";
+import { FestivalInfoDetails } from "./info/FestivalInfoDetails";
+
+interface FestivalInfoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  festival: Festival | null;
+}
+
+export function FestivalInfoDialog({
+  open,
+  onOpenChange,
+  festival,
+}: FestivalInfoDialogProps) {
+  if (!festival) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Info className="h-5 w-5" />
+            Festival Info
+          </DialogTitle>
+          <DialogDescription>
+            Manage the map, description, socials, and links shown on "
+            {festival.name}"'s public Info tab.
+          </DialogDescription>
+        </DialogHeader>
+        <FestivalInfoDetails festivalId={festival.id} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/admin/festivals/FestivalManagementSection.tsx
+++ b/src/pages/admin/festivals/FestivalManagementSection.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Calendar, Plus } from "lucide-react";
+import { Festival } from "@/api/festivals/types";
+import { FestivalDialog } from "./FestivalDialog";
+import { FestivalManagementTable } from "./FestivalManagementTable";
+
+interface FestivalManagementSectionProps {
+  selected: string;
+  onSelect: (festival: Festival) => void;
+}
+
+export function FestivalManagementSection({
+  selected,
+  onSelect,
+}: FestivalManagementSectionProps) {
+  const [editingFestival, setEditingFestival] = useState<Festival | null>(null);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+
+  function handleCreate() {
+    setEditingFestival(null);
+    setIsEditDialogOpen(true);
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span className="flex items-center gap-2">
+              <Calendar className="h-5 w-5" />
+              Festival Management
+            </span>
+
+            <Button
+              onClick={handleCreate}
+              className="bg-purple-600 hover:bg-purple-700"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add Festival
+            </Button>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <FestivalManagementTable
+            onEdit={(festival) => {
+              setEditingFestival(festival);
+              setIsEditDialogOpen(true);
+            }}
+            onSelect={onSelect}
+            selected={selected}
+          />
+        </CardContent>
+      </Card>
+
+      <FestivalDialog
+        open={isEditDialogOpen}
+        onOpenChange={() => {
+          setEditingFestival(null);
+          setIsEditDialogOpen(false);
+        }}
+        editingFestival={editingFestival}
+      />
+    </>
+  );
+}

--- a/src/pages/admin/festivals/FestivalManagementSection.tsx
+++ b/src/pages/admin/festivals/FestivalManagementSection.tsx
@@ -15,12 +15,12 @@ export function FestivalManagementSection({
   selected,
   onSelect,
 }: FestivalManagementSectionProps) {
-  const [editingFestival, setEditingFestival] = useState<Festival | null>(null);
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [editingFestival, setEditingFestival] = useState<
+    Festival | "new" | null
+  >(null);
 
   function handleCreate() {
-    setEditingFestival(null);
-    setIsEditDialogOpen(true);
+    setEditingFestival("new");
   }
 
   return (
@@ -46,7 +46,6 @@ export function FestivalManagementSection({
           <FestivalManagementTable
             onEdit={(festival) => {
               setEditingFestival(festival);
-              setIsEditDialogOpen(true);
             }}
             onSelect={onSelect}
             selected={selected}
@@ -54,14 +53,15 @@ export function FestivalManagementSection({
         </CardContent>
       </Card>
 
-      <FestivalDialog
-        open={isEditDialogOpen}
-        onOpenChange={() => {
-          setEditingFestival(null);
-          setIsEditDialogOpen(false);
-        }}
-        editingFestival={editingFestival}
-      />
+      {editingFestival && (
+        <FestivalDialog
+          open
+          onOpenChange={() => {
+            setEditingFestival(null);
+          }}
+          editingFestival={editingFestival === "new" ? null : editingFestival}
+        />
+      )}
     </>
   );
 }

--- a/src/pages/admin/festivals/FestivalManagementTable.tsx
+++ b/src/pages/admin/festivals/FestivalManagementTable.tsx
@@ -12,9 +12,11 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { confirm } from "@/hooks/use-confirm";
-import { Edit2, Trash2, Image as ImageIcon } from "lucide-react";
+import { Edit2, Trash2, Image as ImageIcon, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FestivalLogoDialog } from "./FestivalLogoDialog";
+import { FestivalInfoDialog } from "./FestivalInfoDialog";
+import { FestivalMissingInfoBadge } from "./FestivalMissingInfoBadge";
 import { useState } from "react";
 
 export function FestivalManagementTable({
@@ -32,6 +34,9 @@ export function FestivalManagementTable({
   const [logoDialogOpen, setLogoDialogOpen] = useState(false);
   const [selectedFestivalForLogo, setSelectedFestivalForLogo] =
     useState<Festival | null>(null);
+  const [infoDialogOpen, setInfoDialogOpen] = useState(false);
+  const [selectedFestivalForInfo, setSelectedFestivalForInfo] =
+    useState<Festival | null>(null);
 
   async function handleDeleteRequest(festival: Festival) {
     const confirmed = await confirm({
@@ -47,6 +52,11 @@ export function FestivalManagementTable({
   function handleLogoManagement(festival: Festival) {
     setSelectedFestivalForLogo(festival);
     setLogoDialogOpen(true);
+  }
+
+  function handleInfoManagement(festival: Festival) {
+    setSelectedFestivalForInfo(festival);
+    setInfoDialogOpen(true);
   }
 
   return (
@@ -82,7 +92,12 @@ export function FestivalManagementTable({
                   </div>
                 )}
               </TableCell>
-              <TableCell className="font-medium">{festival.name}</TableCell>
+              <TableCell className="font-medium">
+                <div className="flex items-center gap-2">
+                  {festival.name}
+                  <FestivalMissingInfoBadge festivalId={festival.id} />
+                </div>
+              </TableCell>
 
               <TableCell>
                 <div className="flex gap-1">
@@ -97,6 +112,18 @@ export function FestivalManagementTable({
                     title="Manage logo"
                   >
                     <ImageIcon className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleInfoManagement(festival);
+                    }}
+                    title="Festival info"
+                  >
+                    <Info className="h-4 w-4" />
                   </Button>
                   <Button
                     size="sm"
@@ -139,6 +166,11 @@ export function FestivalManagementTable({
         open={logoDialogOpen}
         onOpenChange={setLogoDialogOpen}
         festival={selectedFestivalForLogo}
+      />
+      <FestivalInfoDialog
+        open={infoDialogOpen}
+        onOpenChange={setInfoDialogOpen}
+        festival={selectedFestivalForInfo}
       />
     </>
   );

--- a/src/pages/admin/festivals/PhaseOverrideControl.tsx
+++ b/src/pages/admin/festivals/PhaseOverrideControl.tsx
@@ -51,7 +51,7 @@ export function PhaseOverrideControl({
         else if (isFestivalPhase(value)) setOverride(value);
       }}
     >
-      <SelectTrigger className="w-[180px]">
+      <SelectTrigger className="h-9 w-[180px]">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/src/pages/admin/festivals/ScheduleRevealControl.tsx
+++ b/src/pages/admin/festivals/ScheduleRevealControl.tsx
@@ -54,7 +54,7 @@ export function ScheduleRevealControl({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="inline-flex items-center gap-1 rounded-md bg-purple-100 text-purple-900 px-2 py-1 text-sm font-medium">
+      <span className="inline-flex h-9 items-center gap-1 rounded-md bg-purple-100 text-purple-900 px-3 text-sm font-medium">
         {level === "full" && <Check className="h-3 w-3" />}
         {STATUS_LABEL[level]}
       </span>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as FestivalsFestivalSlugEditionsEditionSlugScheduleTimelineRouteI
 import { Route as FestivalsFestivalSlugEditionsEditionSlugScheduleNowRouteImport } from './routes/festivals/$festivalSlug/editions/$editionSlug/schedule/now'
 import { Route as FestivalsFestivalSlugEditionsEditionSlugScheduleListRouteImport } from './routes/festivals/$festivalSlug/editions/$editionSlug/schedule/list'
 import { Route as AdminFestivalsFestivalSlugEditionsEditionSlugStagesRouteImport } from './routes/admin/festivals/$festivalSlug/editions/$editionSlug/stages'
+import { Route as AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRouteImport } from './routes/admin/festivals/$festivalSlug/editions/$editionSlug/settings'
 import { Route as AdminFestivalsFestivalSlugEditionsEditionSlugSetsRouteImport } from './routes/admin/festivals/$festivalSlug/editions/$editionSlug/sets'
 import { Route as AdminFestivalsFestivalSlugEditionsEditionSlugLinksRouteImport } from './routes/admin/festivals/$festivalSlug/editions/$editionSlug/links'
 import { Route as AdminFestivalsFestivalSlugEditionsEditionSlugImportRouteImport } from './routes/admin/festivals/$festivalSlug/editions/$editionSlug/import'
@@ -209,6 +210,12 @@ const AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute =
     path: '/stages',
     getParentRoute: () => AdminFestivalsFestivalSlugEditionsEditionSlugRoute,
   } as any)
+const AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute =
+  AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AdminFestivalsFestivalSlugEditionsEditionSlugRoute,
+  } as any)
 const AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute =
   AdminFestivalsFestivalSlugEditionsEditionSlugSetsRouteImport.update({
     id: '/sets',
@@ -256,6 +263,7 @@ export interface FileRoutesByFullPath {
   '/admin/festivals/$festivalSlug/editions/$editionSlug/import': typeof AdminFestivalsFestivalSlugEditionsEditionSlugImportRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/links': typeof AdminFestivalsFestivalSlugEditionsEditionSlugLinksRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/sets': typeof AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute
+  '/admin/festivals/$festivalSlug/editions/$editionSlug/settings': typeof AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/stages': typeof AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute
   '/festivals/$festivalSlug/editions/$editionSlug/schedule/list': typeof FestivalsFestivalSlugEditionsEditionSlugScheduleListRoute
   '/festivals/$festivalSlug/editions/$editionSlug/schedule/now': typeof FestivalsFestivalSlugEditionsEditionSlugScheduleNowRoute
@@ -289,6 +297,7 @@ export interface FileRoutesByTo {
   '/admin/festivals/$festivalSlug/editions/$editionSlug/import': typeof AdminFestivalsFestivalSlugEditionsEditionSlugImportRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/links': typeof AdminFestivalsFestivalSlugEditionsEditionSlugLinksRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/sets': typeof AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute
+  '/admin/festivals/$festivalSlug/editions/$editionSlug/settings': typeof AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/stages': typeof AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute
   '/festivals/$festivalSlug/editions/$editionSlug/schedule/list': typeof FestivalsFestivalSlugEditionsEditionSlugScheduleListRoute
   '/festivals/$festivalSlug/editions/$editionSlug/schedule/now': typeof FestivalsFestivalSlugEditionsEditionSlugScheduleNowRoute
@@ -325,6 +334,7 @@ export interface FileRoutesById {
   '/admin/festivals/$festivalSlug/editions/$editionSlug/import': typeof AdminFestivalsFestivalSlugEditionsEditionSlugImportRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/links': typeof AdminFestivalsFestivalSlugEditionsEditionSlugLinksRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/sets': typeof AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute
+  '/admin/festivals/$festivalSlug/editions/$editionSlug/settings': typeof AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute
   '/admin/festivals/$festivalSlug/editions/$editionSlug/stages': typeof AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute
   '/festivals/$festivalSlug/editions/$editionSlug/schedule/list': typeof FestivalsFestivalSlugEditionsEditionSlugScheduleListRoute
   '/festivals/$festivalSlug/editions/$editionSlug/schedule/now': typeof FestivalsFestivalSlugEditionsEditionSlugScheduleNowRoute
@@ -362,6 +372,7 @@ export interface FileRouteTypes {
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/import'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/links'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/sets'
+    | '/admin/festivals/$festivalSlug/editions/$editionSlug/settings'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/stages'
     | '/festivals/$festivalSlug/editions/$editionSlug/schedule/list'
     | '/festivals/$festivalSlug/editions/$editionSlug/schedule/now'
@@ -395,6 +406,7 @@ export interface FileRouteTypes {
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/import'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/links'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/sets'
+    | '/admin/festivals/$festivalSlug/editions/$editionSlug/settings'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/stages'
     | '/festivals/$festivalSlug/editions/$editionSlug/schedule/list'
     | '/festivals/$festivalSlug/editions/$editionSlug/schedule/now'
@@ -430,6 +442,7 @@ export interface FileRouteTypes {
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/import'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/links'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/sets'
+    | '/admin/festivals/$festivalSlug/editions/$editionSlug/settings'
     | '/admin/festivals/$festivalSlug/editions/$editionSlug/stages'
     | '/festivals/$festivalSlug/editions/$editionSlug/schedule/list'
     | '/festivals/$festivalSlug/editions/$editionSlug/schedule/now'
@@ -662,6 +675,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugStagesRouteImport
       parentRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugRoute
     }
+    '/admin/festivals/$festivalSlug/editions/$editionSlug/settings': {
+      id: '/admin/festivals/$festivalSlug/editions/$editionSlug/settings'
+      path: '/settings'
+      fullPath: '/admin/festivals/$festivalSlug/editions/$editionSlug/settings'
+      preLoaderRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRouteImport
+      parentRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugRoute
+    }
     '/admin/festivals/$festivalSlug/editions/$editionSlug/sets': {
       id: '/admin/festivals/$festivalSlug/editions/$editionSlug/sets'
       path: '/sets'
@@ -702,6 +722,7 @@ interface AdminFestivalsFestivalSlugEditionsEditionSlugRouteChildren {
   AdminFestivalsFestivalSlugEditionsEditionSlugImportRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugImportRoute
   AdminFestivalsFestivalSlugEditionsEditionSlugLinksRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugLinksRoute
   AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute
+  AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute
   AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute: typeof AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute
 }
 
@@ -713,6 +734,8 @@ const AdminFestivalsFestivalSlugEditionsEditionSlugRouteChildren: AdminFestivals
       AdminFestivalsFestivalSlugEditionsEditionSlugLinksRoute,
     AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute:
       AdminFestivalsFestivalSlugEditionsEditionSlugSetsRoute,
+    AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute:
+      AdminFestivalsFestivalSlugEditionsEditionSlugSettingsRoute,
     AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute:
       AdminFestivalsFestivalSlugEditionsEditionSlugStagesRoute,
   }

--- a/src/routes/admin/festivals.tsx
+++ b/src/routes/admin/festivals.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Outlet, useNavigate, useParams } from "@tanstack/react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, Plus } from "lucide-react";
@@ -8,7 +8,6 @@ import { FestivalManagementTable } from "@/pages/admin/festivals/FestivalManagem
 import { Festival } from "@/api/festivals/types";
 import { Button } from "@/components/ui/button";
 import { festivalsQuery } from "@/api/festivals/useFestivals";
-import { useFestivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { pageMeta } from "@/lib/pageHead";
 
 export const Route = createFileRoute("/admin/festivals")({
@@ -27,12 +26,6 @@ function AdminFestivals() {
 
   const navigate = useNavigate();
   const { festivalSlug = "" } = useParams({ strict: false });
-  const [showFestivalsList, setShowFestivalsList] = useState(!festivalSlug);
-  const selectedFestivalQuery = useFestivalBySlugQuery(festivalSlug);
-
-  useEffect(() => {
-    setShowFestivalsList(!festivalSlug);
-  }, [festivalSlug]);
 
   function handleFestivalChange(festivalSlug: string) {
     if (festivalSlug === "none") {
@@ -43,12 +36,11 @@ function AdminFestivals() {
         params: { festivalSlug },
       });
     }
-    setShowFestivalsList(false);
   }
 
   return (
     <div className="space-y-6">
-      {showFestivalsList ? (
+      {!festivalSlug && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
@@ -79,29 +71,9 @@ function AdminFestivals() {
             />
           </CardContent>
         </Card>
-      ) : (
-        <Card>
-          <CardContent className="flex items-center justify-between py-4">
-            <span className="flex items-center gap-2 text-sm">
-              <Calendar className="h-4 w-4" />
-              Festival:{" "}
-              <span className="font-medium">
-                {selectedFestivalQuery.data?.name ?? festivalSlug}
-              </span>
-            </span>
-            <Button
-              variant="outline"
-              onClick={() => setShowFestivalsList(true)}
-            >
-              Change Festival
-            </Button>
-          </CardContent>
-        </Card>
       )}
 
-      <div className="mt-4">
-        <Outlet />
-      </div>
+      <Outlet />
 
       <FestivalDialog
         open={isEditDialogOpen}

--- a/src/routes/admin/festivals.tsx
+++ b/src/routes/admin/festivals.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useParams } from "@tanstack/react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, Plus } from "lucide-react";
@@ -8,6 +8,7 @@ import { FestivalManagementTable } from "@/pages/admin/festivals/FestivalManagem
 import { Festival } from "@/api/festivals/types";
 import { Button } from "@/components/ui/button";
 import { festivalsQuery } from "@/api/festivals/useFestivals";
+import { useFestivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { pageMeta } from "@/lib/pageHead";
 
 export const Route = createFileRoute("/admin/festivals")({
@@ -26,6 +27,12 @@ function AdminFestivals() {
 
   const navigate = useNavigate();
   const { festivalSlug = "" } = useParams({ strict: false });
+  const [showFestivalsList, setShowFestivalsList] = useState(!festivalSlug);
+  const selectedFestivalQuery = useFestivalBySlugQuery(festivalSlug);
+
+  useEffect(() => {
+    setShowFestivalsList(!festivalSlug);
+  }, [festivalSlug]);
 
   function handleFestivalChange(festivalSlug: string) {
     if (festivalSlug === "none") {
@@ -36,40 +43,61 @@ function AdminFestivals() {
         params: { festivalSlug },
       });
     }
+    setShowFestivalsList(false);
   }
 
   return (
     <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            <span className="flex items-center gap-2">
-              <Calendar className="h-5 w-5" />
-              Festival Management
-            </span>
+      {showFestivalsList ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span className="flex items-center gap-2">
+                <Calendar className="h-5 w-5" />
+                Festival Management
+              </span>
 
+              <Button
+                onClick={handleCreate}
+                className="bg-purple-600 hover:bg-purple-700"
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add Festival
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <FestivalManagementTable
+              onEdit={(festival) => {
+                setEditingFestival(festival);
+                setIsEditDialogOpen(true);
+              }}
+              onSelect={(festival) => {
+                handleFestivalChange(festival.slug);
+              }}
+              selected={festivalSlug}
+            />
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="flex items-center justify-between py-4">
+            <span className="flex items-center gap-2 text-sm">
+              <Calendar className="h-4 w-4" />
+              Festival:{" "}
+              <span className="font-medium">
+                {selectedFestivalQuery.data?.name ?? festivalSlug}
+              </span>
+            </span>
             <Button
-              onClick={handleCreate}
-              className="bg-purple-600 hover:bg-purple-700"
+              variant="outline"
+              onClick={() => setShowFestivalsList(true)}
             >
-              <Plus className="h-4 w-4 mr-2" />
-              Add Festival
+              Change Festival
             </Button>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <FestivalManagementTable
-            onEdit={(festival) => {
-              setEditingFestival(festival);
-              setIsEditDialogOpen(true);
-            }}
-            onSelect={(festival) => {
-              handleFestivalChange(festival.slug);
-            }}
-            selected={festivalSlug}
-          />
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="mt-4">
         <Outlet />

--- a/src/routes/admin/festivals.tsx
+++ b/src/routes/admin/festivals.tsx
@@ -1,12 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { Outlet, useNavigate, useParams } from "@tanstack/react-router";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Calendar, Plus } from "lucide-react";
-import { FestivalDialog } from "@/pages/admin/festivals/FestivalDialog";
-import { FestivalManagementTable } from "@/pages/admin/festivals/FestivalManagementTable";
-import { Festival } from "@/api/festivals/types";
-import { Button } from "@/components/ui/button";
+import { FestivalManagementSection } from "@/pages/admin/festivals/FestivalManagementSection";
 import { festivalsQuery } from "@/api/festivals/useFestivals";
 import { pageMeta } from "@/lib/pageHead";
 
@@ -21,9 +15,6 @@ export const Route = createFileRoute("/admin/festivals")({
 });
 
 function AdminFestivals() {
-  const [editingFestival, setEditingFestival] = useState<Festival | null>(null);
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-
   const navigate = useNavigate();
   const { festivalSlug = "" } = useParams({ strict: false });
 
@@ -41,53 +32,13 @@ function AdminFestivals() {
   return (
     <div className="space-y-6">
       {!festivalSlug && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <span className="flex items-center gap-2">
-                <Calendar className="h-5 w-5" />
-                Festival Management
-              </span>
-
-              <Button
-                onClick={handleCreate}
-                className="bg-purple-600 hover:bg-purple-700"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Add Festival
-              </Button>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <FestivalManagementTable
-              onEdit={(festival) => {
-                setEditingFestival(festival);
-                setIsEditDialogOpen(true);
-              }}
-              onSelect={(festival) => {
-                handleFestivalChange(festival.slug);
-              }}
-              selected={festivalSlug}
-            />
-          </CardContent>
-        </Card>
+        <FestivalManagementSection
+          selected={festivalSlug}
+          onSelect={(festival) => handleFestivalChange(festival.slug)}
+        />
       )}
 
       <Outlet />
-
-      <FestivalDialog
-        open={isEditDialogOpen}
-        onOpenChange={() => {
-          setEditingFestival(null);
-          setIsEditDialogOpen(false);
-        }}
-        editingFestival={editingFestival}
-      />
     </div>
   );
-
-  function handleCreate() {
-    setEditingFestival(null);
-    setIsEditDialogOpen(true);
-  }
 }

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -35,6 +35,7 @@ function FestivalDetail() {
   const { festivalSlug } = Route.useParams();
   const { editionSlug = "" } = useParams({ strict: false });
   const [showFestivalInfo, setShowFestivalInfo] = useState(false);
+  const [showFestivalCard, setShowFestivalCard] = useState(!editionSlug);
   const [showEditionsList, setShowEditionsList] = useState(!editionSlug);
   const navigate = useNavigate();
 
@@ -47,6 +48,7 @@ function FestivalDetail() {
   });
 
   useEffect(() => {
+    setShowFestivalCard(!editionSlug);
     setShowEditionsList(!editionSlug);
   }, [editionSlug]);
 
@@ -56,6 +58,7 @@ function FestivalDetail() {
       to: "/admin/festivals/$festivalSlug/editions/$editionSlug/stages",
       params: { festivalSlug, editionSlug },
     });
+    setShowFestivalCard(false);
     setShowEditionsList(false);
   }
 
@@ -71,33 +74,47 @@ function FestivalDetail() {
         )}
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            <span className="flex items-center gap-2">
-              {festival.name}
+      {showFestivalCard ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span className="flex items-center gap-2">
+                {festival.name}
+                <FestivalMissingInfoBadge festivalId={festival.id} />
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setShowFestivalInfo(!showFestivalInfo)}
+              >
+                <Info className="h-4 w-4 mr-2" />
+                Festival Info
+                {showFestivalInfo ? (
+                  <ChevronUp className="h-4 w-4 ml-2" />
+                ) : (
+                  <ChevronDown className="h-4 w-4 ml-2" />
+                )}
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          {showFestivalInfo && (
+            <CardContent>
+              <FestivalInfoDetails festivalId={festival.id} />
+            </CardContent>
+          )}
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="flex items-center justify-between py-4">
+            <span className="flex items-center gap-2 text-sm">
+              <span className="font-medium">{festival.name}</span>
               <FestivalMissingInfoBadge festivalId={festival.id} />
             </span>
-            <Button
-              variant="outline"
-              onClick={() => setShowFestivalInfo(!showFestivalInfo)}
-            >
-              <Info className="h-4 w-4 mr-2" />
-              Festival Info
-              {showFestivalInfo ? (
-                <ChevronUp className="h-4 w-4 ml-2" />
-              ) : (
-                <ChevronDown className="h-4 w-4 ml-2" />
-              )}
+            <Button variant="outline" onClick={() => setShowFestivalCard(true)}>
+              Show Festival Info
             </Button>
-          </CardTitle>
-        </CardHeader>
-        {showFestivalInfo && (
-          <CardContent>
-            <FestivalInfoDetails festivalId={festival.id} />
           </CardContent>
-        )}
-      </Card>
+        </Card>
+      )}
 
       <div className="mt-6">
         {showEditionsList ? (

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -64,15 +64,20 @@ function FestivalDetail() {
 
   return (
     <>
-      <div className="flex items-center gap-1 text-sm text-muted-foreground mb-4">
+      <nav
+        aria-label="Breadcrumb"
+        className="flex items-center gap-1 text-sm text-muted-foreground mb-4"
+      >
         <span className="font-medium text-foreground">{festival.name}</span>
-        {editionSlug && editionQuery.data && (
+        {editionSlug && (
           <>
             <ChevronRight className="h-4 w-4" />
-            <span className="text-foreground">{editionQuery.data.name}</span>
+            <span className="text-foreground">
+              {editionQuery.data?.name ?? editionSlug}
+            </span>
           </>
         )}
-      </div>
+      </nav>
 
       {showFestivalCard ? (
         <Card>

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { useParams, useNavigate, Outlet, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionManagement } from "@/pages/admin/festivals/FestivalEditionManagement";
-import { FestivalMissingInfoBadge } from "@/pages/admin/festivals/FestivalMissingInfoBadge";
 import { FestivalInfoDetails } from "@/pages/admin/festivals/info/FestivalInfoDetails";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -69,7 +68,6 @@ function FestivalDetail() {
           ) : (
             <span className="font-medium text-foreground">{festival.name}</span>
           )}
-          <FestivalMissingInfoBadge festivalId={festival.id} />
           {editionSlug && (
             <>
               <ChevronRight className="h-4 w-4" />

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate, Outlet } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionManagement } from "@/pages/admin/festivals/FestivalEditionManagement";
@@ -7,8 +7,15 @@ import { FestivalMissingInfoBadge } from "@/pages/admin/festivals/FestivalMissin
 import { FestivalInfoDetails } from "@/pages/admin/festivals/info/FestivalInfoDetails";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Info, ChevronDown, ChevronUp } from "lucide-react";
+import {
+  Info,
+  ChevronDown,
+  ChevronUp,
+  ChevronRight,
+  CalendarDays,
+} from "lucide-react";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
+import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { pageMeta } from "@/lib/pageHead";
 
 export const Route = createFileRoute("/admin/festivals/$festivalSlug")({
@@ -28,11 +35,20 @@ function FestivalDetail() {
   const { festivalSlug } = Route.useParams();
   const { editionSlug = "" } = useParams({ strict: false });
   const [showFestivalInfo, setShowFestivalInfo] = useState(false);
+  const [showEditionsList, setShowEditionsList] = useState(!editionSlug);
   const navigate = useNavigate();
 
   const { data: festival } = useSuspenseQuery(
     festivalBySlugQuery(festivalSlug),
   );
+  const editionQuery = useFestivalEditionBySlugQuery({
+    editionSlug,
+    festivalId: festival.id,
+  });
+
+  useEffect(() => {
+    setShowEditionsList(!editionSlug);
+  }, [editionSlug]);
 
   function handleEditionSelect(editionSlug: string | undefined) {
     if (!editionSlug) return;
@@ -40,40 +56,51 @@ function FestivalDetail() {
       to: "/admin/festivals/$festivalSlug/editions/$editionSlug/stages",
       params: { festivalSlug, editionSlug },
     });
+    setShowEditionsList(false);
   }
 
   return (
     <>
-      <>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <span className="flex items-center gap-2">
-                {festival.name}
-                <FestivalMissingInfoBadge festivalId={festival.id} />
-              </span>
-              <Button
-                variant="outline"
-                onClick={() => setShowFestivalInfo(!showFestivalInfo)}
-              >
-                <Info className="h-4 w-4 mr-2" />
-                Festival Info
-                {showFestivalInfo ? (
-                  <ChevronUp className="h-4 w-4 ml-2" />
-                ) : (
-                  <ChevronDown className="h-4 w-4 ml-2" />
-                )}
-              </Button>
-            </CardTitle>
-          </CardHeader>
-          {showFestivalInfo && (
-            <CardContent>
-              <FestivalInfoDetails festivalId={festival.id} />
-            </CardContent>
-          )}
-        </Card>
+      <div className="flex items-center gap-1 text-sm text-muted-foreground mb-4">
+        <span className="font-medium text-foreground">{festival.name}</span>
+        {editionSlug && editionQuery.data && (
+          <>
+            <ChevronRight className="h-4 w-4" />
+            <span className="text-foreground">{editionQuery.data.name}</span>
+          </>
+        )}
+      </div>
 
-        <div className="mt-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span className="flex items-center gap-2">
+              {festival.name}
+              <FestivalMissingInfoBadge festivalId={festival.id} />
+            </span>
+            <Button
+              variant="outline"
+              onClick={() => setShowFestivalInfo(!showFestivalInfo)}
+            >
+              <Info className="h-4 w-4 mr-2" />
+              Festival Info
+              {showFestivalInfo ? (
+                <ChevronUp className="h-4 w-4 ml-2" />
+              ) : (
+                <ChevronDown className="h-4 w-4 ml-2" />
+              )}
+            </Button>
+          </CardTitle>
+        </CardHeader>
+        {showFestivalInfo && (
+          <CardContent>
+            <FestivalInfoDetails festivalId={festival.id} />
+          </CardContent>
+        )}
+      </Card>
+
+      <div className="mt-6">
+        {showEditionsList ? (
           <FestivalEditionManagement
             festivalSlug={festivalSlug}
             onSelect={(editionSlug) => {
@@ -81,8 +108,26 @@ function FestivalDetail() {
             }}
             selected={editionSlug}
           />
-        </div>
-      </>
+        ) : (
+          <Card>
+            <CardContent className="flex items-center justify-between py-4">
+              <span className="flex items-center gap-2 text-sm">
+                <CalendarDays className="h-4 w-4" />
+                Edition:{" "}
+                <span className="font-medium">
+                  {editionQuery.data?.name ?? editionSlug}
+                </span>
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setShowEditionsList(true)}
+              >
+                Change Edition
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </div>
 
       <div className="mt-6">
         <Outlet />

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -4,7 +4,6 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionManagement } from "@/pages/admin/festivals/FestivalEditionManagement";
 import { FestivalBreadcrumb } from "@/pages/admin/festivals/FestivalBreadcrumb";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
-import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { pageMeta } from "@/lib/pageHead";
 
 export const Route = createFileRoute("/admin/festivals/$festivalSlug")({
@@ -28,18 +27,14 @@ function FestivalDetail() {
   const { data: festival } = useSuspenseQuery(
     festivalBySlugQuery(festivalSlug),
   );
-  const editionQuery = useFestivalEditionBySlugQuery({
-    editionSlug,
-    festivalId: festival.id,
-  });
 
   return (
     <>
       <FestivalBreadcrumb
         festivalSlug={festivalSlug}
         festivalName={festival.name}
+        festivalId={festival.id}
         editionSlug={editionSlug || undefined}
-        editionName={editionQuery.data?.name}
       />
 
       {!editionSlug && (

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -1,19 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
-import { useParams, useNavigate, Outlet } from "@tanstack/react-router";
+import { useState } from "react";
+import { useParams, useNavigate, Outlet, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionManagement } from "@/pages/admin/festivals/FestivalEditionManagement";
 import { FestivalMissingInfoBadge } from "@/pages/admin/festivals/FestivalMissingInfoBadge";
 import { FestivalInfoDetails } from "@/pages/admin/festivals/info/FestivalInfoDetails";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import {
-  Info,
-  ChevronDown,
-  ChevronUp,
-  ChevronRight,
-  CalendarDays,
-} from "lucide-react";
+import { Info, ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { pageMeta } from "@/lib/pageHead";
@@ -35,8 +29,6 @@ function FestivalDetail() {
   const { festivalSlug } = Route.useParams();
   const { editionSlug = "" } = useParams({ strict: false });
   const [showFestivalInfo, setShowFestivalInfo] = useState(false);
-  const [showFestivalCard, setShowFestivalCard] = useState(!editionSlug);
-  const [showEditionsList, setShowEditionsList] = useState(!editionSlug);
   const navigate = useNavigate();
 
   const { data: festival } = useSuspenseQuery(
@@ -47,84 +39,72 @@ function FestivalDetail() {
     festivalId: festival.id,
   });
 
-  useEffect(() => {
-    setShowFestivalCard(!editionSlug);
-    setShowEditionsList(!editionSlug);
-  }, [editionSlug]);
-
   function handleEditionSelect(editionSlug: string | undefined) {
     if (!editionSlug) return;
     navigate({
       to: "/admin/festivals/$festivalSlug/editions/$editionSlug/stages",
       params: { festivalSlug, editionSlug },
     });
-    setShowFestivalCard(false);
-    setShowEditionsList(false);
   }
 
   return (
     <>
       <nav
         aria-label="Breadcrumb"
-        className="flex items-center gap-1 text-sm text-muted-foreground mb-4"
+        className="flex flex-wrap items-center justify-between gap-2 mb-6"
       >
-        <span className="font-medium text-foreground">Festivals</span>
-        <ChevronRight className="h-4 w-4" />
-        <span className="font-medium text-foreground">{festival.name}</span>
-        {editionSlug && (
-          <>
-            <ChevronRight className="h-4 w-4" />
-            <span className="text-foreground">
-              {editionQuery.data?.name ?? editionSlug}
-            </span>
-          </>
-        )}
+        <div className="flex items-center gap-1 text-sm text-muted-foreground">
+          <Link to="/admin/festivals" className="font-medium hover:underline">
+            Festivals
+          </Link>
+          <ChevronRight className="h-4 w-4" />
+          {editionSlug ? (
+            <Link
+              to="/admin/festivals/$festivalSlug"
+              params={{ festivalSlug }}
+              className="font-medium hover:underline text-foreground"
+            >
+              {festival.name}
+            </Link>
+          ) : (
+            <span className="font-medium text-foreground">{festival.name}</span>
+          )}
+          <FestivalMissingInfoBadge festivalId={festival.id} />
+          {editionSlug && (
+            <>
+              <ChevronRight className="h-4 w-4" />
+              <span className="font-medium text-foreground">
+                {editionQuery.data?.name ?? editionSlug}
+              </span>
+            </>
+          )}
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowFestivalInfo(!showFestivalInfo)}
+        >
+          <Info className="h-4 w-4 mr-2" />
+          Festival Info
+          {showFestivalInfo ? (
+            <ChevronUp className="h-4 w-4 ml-2" />
+          ) : (
+            <ChevronDown className="h-4 w-4 ml-2" />
+          )}
+        </Button>
       </nav>
 
-      {showFestivalCard ? (
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <span className="flex items-center gap-2">
-                {festival.name}
-                <FestivalMissingInfoBadge festivalId={festival.id} />
-              </span>
-              <Button
-                variant="outline"
-                onClick={() => setShowFestivalInfo(!showFestivalInfo)}
-              >
-                <Info className="h-4 w-4 mr-2" />
-                Festival Info
-                {showFestivalInfo ? (
-                  <ChevronUp className="h-4 w-4 ml-2" />
-                ) : (
-                  <ChevronDown className="h-4 w-4 ml-2" />
-                )}
-              </Button>
-            </CardTitle>
-          </CardHeader>
-          {showFestivalInfo && (
-            <CardContent>
-              <FestivalInfoDetails festivalId={festival.id} />
-            </CardContent>
-          )}
-        </Card>
-      ) : (
-        <Card>
-          <CardContent className="flex items-center justify-between py-4">
-            <span className="flex items-center gap-2 text-sm">
-              <span className="font-medium">{festival.name}</span>
-              <FestivalMissingInfoBadge festivalId={festival.id} />
-            </span>
-            <Button variant="outline" onClick={() => setShowFestivalCard(true)}>
-              Show Festival Info
-            </Button>
+      {showFestivalInfo && (
+        <Card className="mb-6">
+          <CardContent className="pt-6">
+            <FestivalInfoDetails festivalId={festival.id} />
           </CardContent>
         </Card>
       )}
 
-      <div className="mt-6">
-        {showEditionsList ? (
+      {!editionSlug && (
+        <div className="mb-6">
           <FestivalEditionManagement
             festivalSlug={festivalSlug}
             onSelect={(editionSlug) => {
@@ -132,30 +112,10 @@ function FestivalDetail() {
             }}
             selected={editionSlug}
           />
-        ) : (
-          <Card>
-            <CardContent className="flex items-center justify-between py-4">
-              <span className="flex items-center gap-2 text-sm">
-                <CalendarDays className="h-4 w-4" />
-                Edition:{" "}
-                <span className="font-medium">
-                  {editionQuery.data?.name ?? editionSlug}
-                </span>
-              </span>
-              <Button
-                variant="outline"
-                onClick={() => setShowEditionsList(true)}
-              >
-                Change Edition
-              </Button>
-            </CardContent>
-          </Card>
-        )}
-      </div>
+        </div>
+      )}
 
-      <div className="mt-6">
-        <Outlet />
-      </div>
+      <Outlet />
     </>
   );
 }

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -1,12 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { useParams, useNavigate, Outlet, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionManagement } from "@/pages/admin/festivals/FestivalEditionManagement";
-import { FestivalInfoDetails } from "@/pages/admin/festivals/info/FestivalInfoDetails";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Info, ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { pageMeta } from "@/lib/pageHead";
@@ -27,7 +23,6 @@ export const Route = createFileRoute("/admin/festivals/$festivalSlug")({
 function FestivalDetail() {
   const { festivalSlug } = Route.useParams();
   const { editionSlug = "" } = useParams({ strict: false });
-  const [showFestivalInfo, setShowFestivalInfo] = useState(false);
   const navigate = useNavigate();
 
   const { data: festival } = useSuspenseQuery(
@@ -38,68 +33,36 @@ function FestivalDetail() {
     festivalId: festival.id,
   });
 
-  function handleEditionSelect(editionSlug: string | undefined) {
-    if (!editionSlug) return;
-    navigate({
-      to: "/admin/festivals/$festivalSlug/editions/$editionSlug/stages",
-      params: { festivalSlug, editionSlug },
-    });
-  }
-
   return (
     <>
       <nav
         aria-label="Breadcrumb"
-        className="flex flex-wrap items-center justify-between gap-2 mb-6"
+        className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground mb-6"
       >
-        <div className="flex items-center gap-1 text-sm text-muted-foreground">
-          <Link to="/admin/festivals" className="font-medium hover:underline">
-            Festivals
+        <Link to="/admin/festivals" className="font-medium hover:underline">
+          Festivals
+        </Link>
+        <ChevronRight className="h-4 w-4" />
+        {editionSlug ? (
+          <Link
+            to="/admin/festivals/$festivalSlug"
+            params={{ festivalSlug }}
+            className="font-medium hover:underline text-foreground"
+          >
+            {festival.name}
           </Link>
-          <ChevronRight className="h-4 w-4" />
-          {editionSlug ? (
-            <Link
-              to="/admin/festivals/$festivalSlug"
-              params={{ festivalSlug }}
-              className="font-medium hover:underline text-foreground"
-            >
-              {festival.name}
-            </Link>
-          ) : (
-            <span className="font-medium text-foreground">{festival.name}</span>
-          )}
-          {editionSlug && (
-            <>
-              <ChevronRight className="h-4 w-4" />
-              <span className="font-medium text-foreground">
-                {editionQuery.data?.name ?? editionSlug}
-              </span>
-            </>
-          )}
-        </div>
-
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setShowFestivalInfo(!showFestivalInfo)}
-        >
-          <Info className="h-4 w-4 mr-2" />
-          Festival Info
-          {showFestivalInfo ? (
-            <ChevronUp className="h-4 w-4 ml-2" />
-          ) : (
-            <ChevronDown className="h-4 w-4 ml-2" />
-          )}
-        </Button>
+        ) : (
+          <span className="font-medium text-foreground">{festival.name}</span>
+        )}
+        {editionSlug && (
+          <>
+            <ChevronRight className="h-4 w-4" />
+            <span className="font-medium text-foreground">
+              {editionQuery.data?.name ?? editionSlug}
+            </span>
+          </>
+        )}
       </nav>
-
-      {showFestivalInfo && (
-        <Card className="mb-6">
-          <CardContent className="pt-6">
-            <FestivalInfoDetails festivalId={festival.id} />
-          </CardContent>
-        </Card>
-      )}
 
       {!editionSlug && (
         <div className="mb-6">
@@ -116,4 +79,12 @@ function FestivalDetail() {
       <Outlet />
     </>
   );
+
+  function handleEditionSelect(editionSlug: string | undefined) {
+    if (!editionSlug) return;
+    navigate({
+      to: "/admin/festivals/$festivalSlug/editions/$editionSlug/stages",
+      params: { festivalSlug, editionSlug },
+    });
+  }
 }

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -68,6 +68,8 @@ function FestivalDetail() {
         aria-label="Breadcrumb"
         className="flex items-center gap-1 text-sm text-muted-foreground mb-4"
       >
+        <span className="font-medium text-foreground">Festivals</span>
+        <ChevronRight className="h-4 w-4" />
         <span className="font-medium text-foreground">{festival.name}</span>
         {editionSlug && (
           <>

--- a/src/routes/admin/festivals/$festivalSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useParams, useNavigate, Outlet, Link } from "@tanstack/react-router";
+import { useParams, useNavigate, Outlet } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { FestivalEditionManagement } from "@/pages/admin/festivals/FestivalEditionManagement";
-import { ChevronRight } from "lucide-react";
+import { FestivalBreadcrumb } from "@/pages/admin/festivals/FestivalBreadcrumb";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { pageMeta } from "@/lib/pageHead";
@@ -35,34 +35,12 @@ function FestivalDetail() {
 
   return (
     <>
-      <nav
-        aria-label="Breadcrumb"
-        className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground mb-6"
-      >
-        <Link to="/admin/festivals" className="font-medium hover:underline">
-          Festivals
-        </Link>
-        <ChevronRight className="h-4 w-4" />
-        {editionSlug ? (
-          <Link
-            to="/admin/festivals/$festivalSlug"
-            params={{ festivalSlug }}
-            className="font-medium hover:underline text-foreground"
-          >
-            {festival.name}
-          </Link>
-        ) : (
-          <span className="font-medium text-foreground">{festival.name}</span>
-        )}
-        {editionSlug && (
-          <>
-            <ChevronRight className="h-4 w-4" />
-            <span className="font-medium text-foreground">
-              {editionQuery.data?.name ?? editionSlug}
-            </span>
-          </>
-        )}
-      </nav>
+      <FestivalBreadcrumb
+        festivalSlug={festivalSlug}
+        festivalName={festival.name}
+        editionSlug={editionSlug || undefined}
+        editionName={editionQuery.data?.name}
+      />
 
       {!editionSlug && (
         <div className="mb-6">

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useParams, useLocation, Outlet, Link } from "@tanstack/react-router";
+import { useParams, useLocation, Outlet } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link2, Loader2, MapPin, Music, Settings, Upload } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
-import { cn } from "@/lib/utils";
+import { EditionNavLink } from "@/pages/admin/festivals/EditionNavLink";
 import { editionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { pageMeta } from "@/lib/pageHead";
 
@@ -90,66 +90,46 @@ function FestivalEdition() {
     <div className="space-y-6">
       <div className="w-full">
         <div className="sticky top-16 md:top-20 z-10 grid w-full grid-cols-5 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
-          <Link
+          <EditionNavLink
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
-            params={{ festivalSlug, editionSlug }}
-            className={cn(
-              "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
-              "text-white font-medium",
-              isOnStages ? "bg-purple-600" : "hover:bg-white/10",
-            )}
-          >
-            <MapPin className="h-4 w-4" />
-            Stages
-          </Link>
-          <Link
+            festivalSlug={festivalSlug}
+            editionSlug={editionSlug}
+            icon={<MapPin className="h-4 w-4" />}
+            label="Stages"
+            isActive={isOnStages}
+          />
+          <EditionNavLink
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/sets"
-            params={{ festivalSlug, editionSlug }}
-            className={cn(
-              "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
-              "text-white font-medium",
-              isOnSets ? "bg-purple-600" : "hover:bg-white/10",
-            )}
-          >
-            <Music className="h-4 w-4" />
-            Sets
-          </Link>
-          <Link
+            festivalSlug={festivalSlug}
+            editionSlug={editionSlug}
+            icon={<Music className="h-4 w-4" />}
+            label="Sets"
+            isActive={isOnSets}
+          />
+          <EditionNavLink
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/import"
-            params={{ festivalSlug, editionSlug }}
-            className={cn(
-              "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
-              "text-white font-medium",
-              isOnImport ? "bg-purple-600" : "hover:bg-white/10",
-            )}
-          >
-            <Upload className="h-4 w-4" />
-            Import
-          </Link>
-          <Link
+            festivalSlug={festivalSlug}
+            editionSlug={editionSlug}
+            icon={<Upload className="h-4 w-4" />}
+            label="Import"
+            isActive={isOnImport}
+          />
+          <EditionNavLink
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/links"
-            params={{ festivalSlug, editionSlug }}
-            className={cn(
-              "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
-              "text-white font-medium",
-              isOnLinks ? "bg-purple-600" : "hover:bg-white/10",
-            )}
-          >
-            <Link2 className="h-4 w-4" />
-            Links
-          </Link>
-          <Link
+            festivalSlug={festivalSlug}
+            editionSlug={editionSlug}
+            icon={<Link2 className="h-4 w-4" />}
+            label="Links"
+            isActive={isOnLinks}
+          />
+          <EditionNavLink
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/settings"
-            params={{ festivalSlug, editionSlug }}
-            className={cn(
-              "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
-              "text-white font-medium",
-              isOnSettings ? "bg-purple-600" : "hover:bg-white/10",
-            )}
-          >
-            <Settings className="h-4 w-4" />
-            Settings
-          </Link>
+            festivalSlug={festivalSlug}
+            editionSlug={editionSlug}
+            icon={<Settings className="h-4 w-4" />}
+            label="Settings"
+            isActive={isOnSettings}
+          />
         </div>
 
         <div className="mt-6">

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -1,15 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useParams, useLocation, Outlet, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
 import { Link2, Loader2, MapPin, Music, Settings, Upload } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { cn } from "@/lib/utils";
-import { getFestivalPhase } from "@/lib/festivalPhase";
-import { ScheduleRevealControl } from "@/pages/admin/festivals/ScheduleRevealControl";
-import { PhaseOverrideControl } from "@/pages/admin/festivals/PhaseOverrideControl";
 import { editionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { pageMeta } from "@/lib/pageHead";
 
@@ -48,7 +44,6 @@ function FestivalEdition() {
     from: "/admin/festivals/$festivalSlug/editions/$editionSlug",
   });
   const location = useLocation();
-  const [showSettings, setShowSettings] = useState(false);
 
   const { data: festival } = useSuspenseQuery(
     festivalBySlugQuery(festivalSlug),
@@ -89,14 +84,7 @@ function FestivalEdition() {
   const isOnStages = location.pathname.includes("/stages");
   const isOnImport = location.pathname.includes("/import");
   const isOnLinks = location.pathname.includes("/links");
-
-  const derivedPhase = getFestivalPhase({
-    revealLevel: currentEdition.schedule_reveal_level ?? "draft",
-    startDate: currentEdition.start_date,
-    endDate: currentEdition.end_date,
-    timezone: festival.timezone,
-    now: new Date(),
-  });
+  const isOnSettings = location.pathname.includes("/settings");
 
   return (
     <div className="space-y-6">
@@ -105,13 +93,10 @@ function FestivalEdition() {
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
             params={{ festivalSlug, editionSlug }}
-            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              !showSettings && isOnStages
-                ? "bg-purple-600"
-                : "hover:bg-white/10",
+              isOnStages ? "bg-purple-600" : "hover:bg-white/10",
             )}
           >
             <MapPin className="h-4 w-4" />
@@ -120,11 +105,10 @@ function FestivalEdition() {
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/sets"
             params={{ festivalSlug, editionSlug }}
-            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              !showSettings && isOnSets ? "bg-purple-600" : "hover:bg-white/10",
+              isOnSets ? "bg-purple-600" : "hover:bg-white/10",
             )}
           >
             <Music className="h-4 w-4" />
@@ -133,13 +117,10 @@ function FestivalEdition() {
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/import"
             params={{ festivalSlug, editionSlug }}
-            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              !showSettings && isOnImport
-                ? "bg-purple-600"
-                : "hover:bg-white/10",
+              isOnImport ? "bg-purple-600" : "hover:bg-white/10",
             )}
           >
             <Upload className="h-4 w-4" />
@@ -148,51 +129,31 @@ function FestivalEdition() {
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/links"
             params={{ festivalSlug, editionSlug }}
-            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              !showSettings && isOnLinks
-                ? "bg-purple-600"
-                : "hover:bg-white/10",
+              isOnLinks ? "bg-purple-600" : "hover:bg-white/10",
             )}
           >
             <Link2 className="h-4 w-4" />
             Links
           </Link>
-          <button
-            type="button"
-            onClick={() => setShowSettings(true)}
+          <Link
+            to="/admin/festivals/$festivalSlug/editions/$editionSlug/settings"
+            params={{ festivalSlug, editionSlug }}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              showSettings ? "bg-purple-600" : "hover:bg-white/10",
+              isOnSettings ? "bg-purple-600" : "hover:bg-white/10",
             )}
           >
             <Settings className="h-4 w-4" />
             Settings
-          </button>
+          </Link>
         </div>
 
         <div className="mt-6">
-          {showSettings ? (
-            <Card>
-              <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
-                <ScheduleRevealControl
-                  editionId={currentEdition.id}
-                  level={currentEdition.schedule_reveal_level ?? "draft"}
-                  editionPublished={currentEdition.published ?? false}
-                />
-                <PhaseOverrideControl
-                  editionId={currentEdition.id}
-                  override={currentEdition.phase_override ?? null}
-                  derivedPhase={derivedPhase}
-                />
-              </CardContent>
-            </Card>
-          ) : (
-            <Outlet />
-          )}
+          <Outlet />
         </div>
       </div>
     </div>

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -120,7 +120,7 @@ function FestivalEdition() {
         </CardHeader>
       </Card>
       <div className="w-full">
-        <div className="sticky top-0 z-10 grid w-full grid-cols-4 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
+        <div className="sticky top-16 md:top-20 z-10 grid w-full grid-cols-4 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
             params={{ festivalSlug, editionSlug }}

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useParams, useLocation, Outlet, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Link2, Loader2, MapPin, Music, Upload } from "lucide-react";
+import { useState } from "react";
+import { Link2, Loader2, MapPin, Music, Settings, Upload } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
@@ -47,6 +48,7 @@ function FestivalEdition() {
     from: "/admin/festivals/$festivalSlug/editions/$editionSlug",
   });
   const location = useLocation();
+  const [showSettings, setShowSettings] = useState(false);
 
   const { data: festival } = useSuspenseQuery(
     festivalBySlugQuery(festivalSlug),
@@ -98,29 +100,18 @@ function FestivalEdition() {
 
   return (
     <div className="space-y-6">
-      <Card>
-        <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
-          <ScheduleRevealControl
-            editionId={currentEdition.id}
-            level={currentEdition.schedule_reveal_level ?? "draft"}
-            editionPublished={currentEdition.published ?? false}
-          />
-          <PhaseOverrideControl
-            editionId={currentEdition.id}
-            override={currentEdition.phase_override ?? null}
-            derivedPhase={derivedPhase}
-          />
-        </CardContent>
-      </Card>
       <div className="w-full">
-        <div className="sticky top-16 md:top-20 z-10 grid w-full grid-cols-4 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
+        <div className="sticky top-16 md:top-20 z-10 grid w-full grid-cols-5 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
             params={{ festivalSlug, editionSlug }}
+            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              isOnStages ? "bg-purple-600" : "hover:bg-white/10",
+              !showSettings && isOnStages
+                ? "bg-purple-600"
+                : "hover:bg-white/10",
             )}
           >
             <MapPin className="h-4 w-4" />
@@ -129,10 +120,11 @@ function FestivalEdition() {
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/sets"
             params={{ festivalSlug, editionSlug }}
+            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              isOnSets ? "bg-purple-600" : "hover:bg-white/10",
+              !showSettings && isOnSets ? "bg-purple-600" : "hover:bg-white/10",
             )}
           >
             <Music className="h-4 w-4" />
@@ -141,10 +133,13 @@ function FestivalEdition() {
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/import"
             params={{ festivalSlug, editionSlug }}
+            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              isOnImport ? "bg-purple-600" : "hover:bg-white/10",
+              !showSettings && isOnImport
+                ? "bg-purple-600"
+                : "hover:bg-white/10",
             )}
           >
             <Upload className="h-4 w-4" />
@@ -153,19 +148,51 @@ function FestivalEdition() {
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/links"
             params={{ festivalSlug, editionSlug }}
+            onClick={() => setShowSettings(false)}
             className={cn(
               "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
               "text-white font-medium",
-              isOnLinks ? "bg-purple-600" : "hover:bg-white/10",
+              !showSettings && isOnLinks
+                ? "bg-purple-600"
+                : "hover:bg-white/10",
             )}
           >
             <Link2 className="h-4 w-4" />
             Links
           </Link>
+          <button
+            type="button"
+            onClick={() => setShowSettings(true)}
+            className={cn(
+              "flex items-center justify-center gap-2 px-4 py-2 rounded-md transition-colors",
+              "text-white font-medium",
+              showSettings ? "bg-purple-600" : "hover:bg-white/10",
+            )}
+          >
+            <Settings className="h-4 w-4" />
+            Settings
+          </button>
         </div>
 
         <div className="mt-6">
-          <Outlet />
+          {showSettings ? (
+            <Card>
+              <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+                <ScheduleRevealControl
+                  editionId={currentEdition.id}
+                  level={currentEdition.schedule_reveal_level ?? "draft"}
+                  editionPublished={currentEdition.published ?? false}
+                />
+                <PhaseOverrideControl
+                  editionId={currentEdition.id}
+                  override={currentEdition.phase_override ?? null}
+                  derivedPhase={derivedPhase}
+                />
+              </CardContent>
+            </Card>
+          ) : (
+            <Outlet />
+          )}
         </div>
       </div>
     </div>

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -98,18 +98,20 @@ function FestivalEdition() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <ScheduleRevealControl
-          editionId={currentEdition.id}
-          level={currentEdition.schedule_reveal_level ?? "draft"}
-          editionPublished={currentEdition.published ?? false}
-        />
-        <PhaseOverrideControl
-          editionId={currentEdition.id}
-          override={currentEdition.phase_override ?? null}
-          derivedPhase={derivedPhase}
-        />
-      </div>
+      <Card>
+        <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+          <ScheduleRevealControl
+            editionId={currentEdition.id}
+            level={currentEdition.schedule_reveal_level ?? "draft"}
+            editionPublished={currentEdition.published ?? false}
+          />
+          <PhaseOverrideControl
+            editionId={currentEdition.id}
+            override={currentEdition.phase_override ?? null}
+            derivedPhase={derivedPhase}
+          />
+        </CardContent>
+      </Card>
       <div className="w-full">
         <div className="sticky top-16 md:top-20 z-10 grid w-full grid-cols-4 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
           <Link

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -120,7 +120,7 @@ function FestivalEdition() {
         </CardHeader>
       </Card>
       <div className="w-full">
-        <div className="grid w-full grid-cols-4 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
+        <div className="sticky top-0 z-10 grid w-full grid-cols-4 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
           <Link
             to="/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
             params={{ festivalSlug, editionSlug }}

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useParams, useLocation, Outlet } from "@tanstack/react-router";
+import { useParams, Outlet } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link2, Loader2, MapPin, Music, Settings, Upload } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
@@ -43,7 +43,6 @@ function FestivalEdition() {
   const { festivalSlug, editionSlug } = useParams({
     from: "/admin/festivals/$festivalSlug/editions/$editionSlug",
   });
-  const location = useLocation();
 
   const { data: festival } = useSuspenseQuery(
     festivalBySlugQuery(festivalSlug),
@@ -80,55 +79,44 @@ function FestivalEdition() {
     );
   }
 
-  const isOnSets = location.pathname.includes("/sets");
-  const isOnStages = location.pathname.includes("/stages");
-  const isOnImport = location.pathname.includes("/import");
-  const isOnLinks = location.pathname.includes("/links");
-  const isOnSettings = location.pathname.includes("/settings");
-
   return (
     <div className="space-y-6">
       <div className="w-full">
         <div className="sticky top-16 md:top-20 z-10 grid w-full grid-cols-5 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
           <EditionNavLink
-            to="/admin/festivals/$festivalSlug/editions/$editionSlug/stages"
+            to="stages"
             festivalSlug={festivalSlug}
             editionSlug={editionSlug}
             icon={<MapPin className="h-4 w-4" />}
             label="Stages"
-            isActive={isOnStages}
           />
           <EditionNavLink
-            to="/admin/festivals/$festivalSlug/editions/$editionSlug/sets"
+            to="sets"
             festivalSlug={festivalSlug}
             editionSlug={editionSlug}
             icon={<Music className="h-4 w-4" />}
             label="Sets"
-            isActive={isOnSets}
           />
           <EditionNavLink
-            to="/admin/festivals/$festivalSlug/editions/$editionSlug/import"
+            to="import"
             festivalSlug={festivalSlug}
             editionSlug={editionSlug}
             icon={<Upload className="h-4 w-4" />}
             label="Import"
-            isActive={isOnImport}
           />
           <EditionNavLink
-            to="/admin/festivals/$festivalSlug/editions/$editionSlug/links"
+            to="links"
             festivalSlug={festivalSlug}
             editionSlug={editionSlug}
             icon={<Link2 className="h-4 w-4" />}
             label="Links"
-            isActive={isOnLinks}
           />
           <EditionNavLink
-            to="/admin/festivals/$festivalSlug/editions/$editionSlug/settings"
+            to="settings"
             festivalSlug={festivalSlug}
             editionSlug={editionSlug}
             icon={<Settings className="h-4 w-4" />}
             label="Settings"
-            isActive={isOnSettings}
           />
         </div>
 

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useParams, useLocation, Outlet, Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link2, Loader2, MapPin, Music, Upload } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { cn } from "@/lib/utils";
@@ -98,27 +98,18 @@ function FestivalEdition() {
 
   return (
     <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex flex-wrap items-center justify-between gap-3">
-            <span className="flex items-center gap-2">
-              Edition: {currentEdition.name}
-            </span>
-            <div className="flex flex-wrap items-center gap-2">
-              <ScheduleRevealControl
-                editionId={currentEdition.id}
-                level={currentEdition.schedule_reveal_level ?? "draft"}
-                editionPublished={currentEdition.published ?? false}
-              />
-              <PhaseOverrideControl
-                editionId={currentEdition.id}
-                override={currentEdition.phase_override ?? null}
-                derivedPhase={derivedPhase}
-              />
-            </div>
-          </CardTitle>
-        </CardHeader>
-      </Card>
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <ScheduleRevealControl
+          editionId={currentEdition.id}
+          level={currentEdition.schedule_reveal_level ?? "draft"}
+          editionPublished={currentEdition.published ?? false}
+        />
+        <PhaseOverrideControl
+          editionId={currentEdition.id}
+          override={currentEdition.phase_override ?? null}
+          derivedPhase={derivedPhase}
+        />
+      </div>
       <div className="w-full">
         <div className="sticky top-16 md:top-20 z-10 grid w-full grid-cols-4 gap-2 bg-white/10 backdrop-blur-md p-1 rounded-lg">
           <Link

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/settings.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/settings.tsx
@@ -1,8 +1,7 @@
 import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Card, CardContent } from "@/components/ui/card";
-import { Loader2 } from "lucide-react";
-import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
+import { editionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
 import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
 import { getFestivalPhase } from "@/lib/festivalPhase";
 import { ScheduleRevealControl } from "@/pages/admin/festivals/ScheduleRevealControl";
@@ -28,23 +27,9 @@ function FestivalEditionSettings() {
   const { data: festival } = useSuspenseQuery(
     festivalBySlugQuery(festivalSlug),
   );
-  const editionQuery = useFestivalEditionBySlugQuery({
-    editionSlug,
-    festivalId: festival.id,
-  });
-
-  if (editionQuery.isLoading || !editionQuery.data) {
-    return (
-      <Card>
-        <CardContent className="flex items-center justify-center p-8">
-          <Loader2 className="h-6 w-6 animate-spin mr-2" />
-          <span>Loading settings...</span>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  const currentEdition = editionQuery.data;
+  const { data: currentEdition } = useSuspenseQuery(
+    editionBySlugQuery({ festivalId: festival.id, editionSlug }),
+  );
 
   const derivedPhase = getFestivalPhase({
     revealLevel: currentEdition.schedule_reveal_level ?? "draft",

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/settings.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/settings.tsx
@@ -1,0 +1,73 @@
+import { createFileRoute, useParams } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Card, CardContent } from "@/components/ui/card";
+import { Loader2 } from "lucide-react";
+import { useFestivalEditionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
+import { festivalBySlugQuery } from "@/api/festivals/useFestivalBySlug";
+import { getFestivalPhase } from "@/lib/festivalPhase";
+import { ScheduleRevealControl } from "@/pages/admin/festivals/ScheduleRevealControl";
+import { PhaseOverrideControl } from "@/pages/admin/festivals/PhaseOverrideControl";
+import { pageMeta } from "@/lib/pageHead";
+
+export const Route = createFileRoute(
+  "/admin/festivals/$festivalSlug/editions/$editionSlug/settings",
+)({
+  component: FestivalEditionSettings,
+  head: ({ match }) => ({
+    meta: pageMeta({
+      title: "Settings",
+      prefix: `Admin - ${match.context.festival?.name}`,
+    }),
+  }),
+});
+
+function FestivalEditionSettings() {
+  const { festivalSlug, editionSlug } = useParams({
+    from: "/admin/festivals/$festivalSlug/editions/$editionSlug/settings",
+  });
+  const { data: festival } = useSuspenseQuery(
+    festivalBySlugQuery(festivalSlug),
+  );
+  const editionQuery = useFestivalEditionBySlugQuery({
+    editionSlug,
+    festivalId: festival.id,
+  });
+
+  if (editionQuery.isLoading || !editionQuery.data) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center p-8">
+          <Loader2 className="h-6 w-6 animate-spin mr-2" />
+          <span>Loading settings...</span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const currentEdition = editionQuery.data;
+
+  const derivedPhase = getFestivalPhase({
+    revealLevel: currentEdition.schedule_reveal_level ?? "draft",
+    startDate: currentEdition.start_date,
+    endDate: currentEdition.end_date,
+    timezone: festival.timezone,
+    now: new Date(),
+  });
+
+  return (
+    <Card>
+      <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+        <ScheduleRevealControl
+          editionId={currentEdition.id}
+          level={currentEdition.schedule_reveal_level ?? "draft"}
+          editionPublished={currentEdition.published ?? false}
+        />
+        <PhaseOverrideControl
+          editionId={currentEdition.id}
+          override={currentEdition.phase_override ?? null}
+          derivedPhase={derivedPhase}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/settings.tsx
+++ b/src/routes/admin/festivals/$festivalSlug/editions/$editionSlug/settings.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useParams } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Card, CardContent } from "@/components/ui/card";
 import { editionBySlugQuery } from "@/api/editions/useFestivalEditionBySlug";
@@ -21,9 +21,7 @@ export const Route = createFileRoute(
 });
 
 function FestivalEditionSettings() {
-  const { festivalSlug, editionSlug } = useParams({
-    from: "/admin/festivals/$festivalSlug/editions/$editionSlug/settings",
-  });
+  const { festivalSlug, editionSlug } = Route.useParams();
   const { data: festival } = useSuspenseQuery(
     festivalBySlugQuery(festivalSlug),
   );


### PR DESCRIPTION
Simplifies deeply nested admin festival navigation into a single breadcrumb bar, moves festival info editing onto the festivals table, and adds an edition Settings tab — cutting the scrolling needed to manage festivals and editions.

## Verification
- Open a festival with multiple editions; the editions table shows in full until one is selected, then collapses behind a Festival > Edition breadcrumb.
- Click the Festival breadcrumb segment; the editions table re-expands.
- On the festivals table, click a row's Info action; the dialog opens with map/description/socials/links, and a "Missing info" badge shows next to the name when info text is empty.
- On an edition page, switch to the Settings tab; schedule reveal and phase override controls show, then switch back to Stages to return to content.
- Scroll within Stages/Sets/Import/Links; the tab bar stays visible (sticky) below the fixed top bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEc4QPwL77LtsXrhcTdDJn)_