### PR TITLE
fix(functions): allow getupline.com subdomains in CORS

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -28,6 +28,17 @@ function isAllowedStagingOrigin(origin: string): boolean {
   return origin.endsWith(".vercel.app");
 }
 
+// Festival subdomains (e.g. own-spirit.getupline.com) are legitimate prod
+// origins alongside the bare domain — see src/lib/subdomain.ts.
+function isAllowedGetuplineOrigin(origin: string): boolean {
+  try {
+    const hostname = new URL(origin).hostname;
+    return hostname === "getupline.com" || hostname.endsWith(".getupline.com");
+  } catch {
+    return false;
+  }
+}
+
 export function buildCorsHeaders(req: Request): Record<string, string> {
   const prodOrigin = normalizeOrigin(
     Deno.env.get("APP_URL") ?? DEFAULT_PROD_ORIGIN,
@@ -36,9 +47,9 @@ export function buildCorsHeaders(req: Request): Record<string, string> {
   const requestOrigin = req.headers.get("Origin");
 
   const allowOrigin =
-    !isProdEnvironment() &&
     requestOrigin &&
-    isAllowedStagingOrigin(requestOrigin)
+    (isAllowedGetuplineOrigin(requestOrigin) ||
+      (!isProdEnvironment() && isAllowedStagingOrigin(requestOrigin)))
       ? requestOrigin
       : prodOrigin;
 

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -32,8 +32,13 @@ function isAllowedStagingOrigin(origin: string): boolean {
 // origins alongside the bare domain — see src/lib/subdomain.ts.
 function isAllowedGetuplineOrigin(origin: string): boolean {
   try {
-    const hostname = new URL(origin).hostname;
-    return hostname === "getupline.com" || hostname.endsWith(".getupline.com");
+    const url = new URL(origin);
+    if (url.protocol !== "https:") return false;
+
+    return (
+      url.hostname === "getupline.com" ||
+      url.hostname.endsWith(".getupline.com")
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
Festival subdomains (e.g. own-spirit.getupline.com) were blocked by edge function CORS since buildCorsHeaders() only allowed the bare getupline.com origin.
Now any *.getupline.com origin, including the bare domain, is echoed back in Access-Control-Allow-Origin.

## Verification
- From own-spirit.getupline.com (or any *.getupline.com subdomain), invoke search-artist-links from the admin panel and confirm no CORS error and a successful response.
- From getupline.com itself, confirm requests still succeed.
- From an unrelated origin, confirm Access-Control-Allow-Origin still falls back to the default prod origin (request is not echoed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpzaNuLUj21eTjkzFZLdZP)_