### PR TITLE
ci(deploy): split deploy.yml into deploy-staging and deploy-prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,51 @@
+name: Deploy Prod
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - "supabase/functions/**"
+      - ".github/workflows/deploy-prod.yml"
+      - ".github/workflows/_db_migrate.yml"
+      - ".github/workflows/_deploy_edge_functions.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve changes
+    runs-on: ubuntu-latest
+    outputs:
+      migrations: ${{ steps.filter.outputs.migrations || 'true' }}
+      functions: ${{ steps.filter.outputs.functions || 'true' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            migrations:
+              - 'supabase/migrations/**'
+            functions:
+              - 'supabase/functions/**'
+
+  migrate:
+    needs: resolve
+    if: needs.resolve.outputs.migrations == 'true'
+    uses: ./.github/workflows/_db_migrate.yml
+    with:
+      target: prod
+    secrets: inherit
+
+  functions:
+    needs: resolve
+    if: needs.resolve.outputs.functions == 'true'
+    uses: ./.github/workflows/_deploy_edge_functions.yml
+    with:
+      target: prod
+    secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/deploy-staging.yml"
       - ".github/workflows/_db_migrate.yml"
       - ".github/workflows/_deploy_edge_functions.yml"
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -20,13 +21,14 @@ jobs:
     name: Resolve changes
     runs-on: ubuntu-latest
     outputs:
-      migrations: ${{ steps.filter.outputs.migrations }}
-      functions: ${{ steps.filter.outputs.functions }}
+      migrations: ${{ steps.filter.outputs.migrations || 'true' }}
+      functions: ${{ steps.filter.outputs.functions || 'true' }}
     steps:
       - uses: actions/checkout@v5
 
       - uses: dorny/paths-filter@v4
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             migrations:
@@ -37,7 +39,7 @@ jobs:
   gate:
     name: Require staging label for migrations
     needs: resolve
-    if: needs.resolve.outputs.migrations == 'true'
+    if: github.event_name == 'pull_request' && needs.resolve.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Fail if this PR touches migrations without holding the staging label
@@ -49,7 +51,7 @@ jobs:
   check-lock:
     name: Verify staging lock ownership
     needs: resolve
-    if: contains(github.event.pull_request.labels.*.name, 'staging')
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'staging')
     runs-on: ubuntu-latest
     outputs:
       is_holder: ${{ steps.check.outputs.is_holder }}
@@ -74,7 +76,11 @@ jobs:
 
   migrate:
     needs: [resolve, gate, check-lock]
-    if: needs.resolve.outputs.migrations == 'true' && needs.check-lock.outputs.is_holder == 'true'
+    if: >
+      always() &&
+      needs.resolve.result == 'success' &&
+      needs.resolve.outputs.migrations == 'true' &&
+      (github.event_name != 'pull_request' || (needs.check-lock.result == 'success' && needs.check-lock.outputs.is_holder == 'true'))
     uses: ./.github/workflows/_db_migrate.yml
     with:
       target: staging
@@ -91,7 +97,7 @@ jobs:
   comment:
     name: Update PR comment
     needs: [resolve, migrate, functions]
-    if: always() && needs.resolve.result == 'success'
+    if: always() && needs.resolve.result == 'success' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -64,7 +64,13 @@ jobs:
           set -euo pipefail
           OTHERS=$(gh pr list --repo "$REPO" --label staging --state open --json number \
             --jq "[.[] | select(.number != $PR)] | length")
-          echo "is_holder=$([[ "$OTHERS" -eq 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          IS_HOLDER=$([[ "$OTHERS" -eq 0 ]] && echo true || echo false)
+          echo "is_holder=$IS_HOLDER" >> "$GITHUB_OUTPUT"
+
+          if [[ "$IS_HOLDER" == "false" && "${{ needs.resolve.outputs.migrations }}" == "true" ]]; then
+            echo "::error::This PR touches supabase/migrations/** and holds the 'staging' label, but another open PR already holds the staging lock. Migrations will not be pushed until that PR merges or releases the label."
+            exit 1
+          fi
 
   migrate:
     needs: [resolve, gate, check-lock]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,30 +1,15 @@
-name: Deploy
+name: Deploy Staging
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "supabase/migrations/**"
-      - "supabase/functions/**"
-      - ".github/workflows/deploy.yml"
-      - ".github/workflows/_db_migrate.yml"
-      - ".github/workflows/_deploy_edge_functions.yml"
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "supabase/migrations/**"
       - "supabase/functions/**"
-      - ".github/workflows/deploy.yml"
+      - ".github/workflows/deploy-staging.yml"
       - ".github/workflows/_db_migrate.yml"
       - ".github/workflows/_deploy_edge_functions.yml"
-  workflow_dispatch:
-    inputs:
-      target:
-        description: "Which environment to deploy"
-        required: true
-        type: choice
-        options: [staging, prod]
 
 permissions:
   contents: read
@@ -32,30 +17,16 @@ permissions:
 
 jobs:
   resolve:
-    name: Resolve target & changes
+    name: Resolve changes
     runs-on: ubuntu-latest
     outputs:
-      target: ${{ steps.target.outputs.target }}
-      migrations: ${{ steps.filter.outputs.migrations || 'true' }}
-      functions: ${{ steps.filter.outputs.functions || 'true' }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+      functions: ${{ steps.filter.outputs.functions }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Resolve target
-        id: target
-        run: |
-          case "${{ github.event_name }}" in
-            workflow_dispatch) TARGET="${{ github.event.inputs.target }}" ;;
-            pull_request)      TARGET="staging" ;;
-            push)              TARGET="prod" ;;
-            *) echo "Unknown event"; exit 1 ;;
-          esac
-          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
-          echo "Deploying: $TARGET"
-
       - uses: dorny/paths-filter@v4
         id: filter
-        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             migrations:
@@ -66,7 +37,7 @@ jobs:
   gate:
     name: Require staging label for migrations
     needs: resolve
-    if: github.event_name == 'pull_request' && needs.resolve.outputs.migrations == 'true'
+    if: needs.resolve.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Fail if this PR touches migrations without holding the staging label
@@ -77,8 +48,8 @@ jobs:
 
   check-lock:
     name: Verify staging lock ownership
-    needs: [resolve, gate]
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'staging')
+    needs: resolve
+    if: contains(github.event.pull_request.labels.*.name, 'staging')
     runs-on: ubuntu-latest
     outputs:
       is_holder: ${{ steps.check.outputs.is_holder }}
@@ -97,10 +68,10 @@ jobs:
 
   migrate:
     needs: [resolve, gate, check-lock]
-    if: needs.resolve.outputs.migrations == 'true' && (github.event_name != 'pull_request' || needs.check-lock.outputs.is_holder == 'true')
+    if: needs.resolve.outputs.migrations == 'true' && needs.check-lock.outputs.is_holder == 'true'
     uses: ./.github/workflows/_db_migrate.yml
     with:
-      target: ${{ needs.resolve.outputs.target }}
+      target: staging
     secrets: inherit
 
   functions:
@@ -108,13 +79,13 @@ jobs:
     if: needs.resolve.outputs.functions == 'true'
     uses: ./.github/workflows/_deploy_edge_functions.yml
     with:
-      target: ${{ needs.resolve.outputs.target }}
+      target: staging
     secrets: inherit
 
   comment:
     name: Update PR comment
     needs: [resolve, migrate, functions]
-    if: always() && github.event_name == 'pull_request' && needs.resolve.result == 'success'
+    if: always() && needs.resolve.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -124,7 +95,7 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TARGET: ${{ needs.resolve.outputs.target }}
+          TARGET: staging
           MIGRATE_RESULT: ${{ needs.migrate.result }}
           FUNCTIONS_RESULT: ${{ needs.functions.result }}
         run: .github/scripts/post-deploy-comment.sh

--- a/.github/workflows/staging-db-commands.yml
+++ b/.github/workflows/staging-db-commands.yml
@@ -88,7 +88,7 @@ jobs:
 
       - uses: supabase/setup-cli@v3
 
-      # The job name comes from how deploy.yml calls the reusable _db_migrate.yml
+      # The job name comes from how deploy-staging.yml calls the reusable _db_migrate.yml
       # workflow: "<calling job id> / <called job's name>". If either changes, this
       # lookup silently stops matching.
       - name: Find the latest failed staging-push run for this PR
@@ -100,7 +100,7 @@ jobs:
         run: |
           set -euo pipefail
           JOB_ID=""
-          for RUN_ID in $(gh run list --repo "$REPO" --workflow deploy.yml --branch "$BRANCH" --event pull_request --json databaseId --jq '.[].databaseId'); do
+          for RUN_ID in $(gh run list --repo "$REPO" --workflow deploy-staging.yml --branch "$BRANCH" --event pull_request --json databaseId --jq '.[].databaseId'); do
             FOUND=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
               --jq '.jobs[] | select(.name == "migrate / Push migrations (staging)" and .conclusion == "failure") | .id' | head -n1)
             if [[ -n "$FOUND" ]]; then


### PR DESCRIPTION
Splits the combined deploy workflow so prod's `migrate`/`functions` jobs never depend on `gate`/`check-lock`. Those two jobs only apply to the PR/staging flow but were previously in `migrate`'s `needs:`, and GitHub auto-skips a job when any of its `needs` was skipped — regardless of its own `if:` condition — so pushes straight to main silently skipped migrations whenever `gate`/`check-lock` were skipped (which is always, on a push event).

## Verification
- Open a PR touching `supabase/migrations/**` without the `staging` label; `deploy-staging.yml`'s `gate` job fails as before.
- Add the `staging` label (as sole holder) to that PR; `deploy-staging.yml`'s `migrate` job runs and pushes to staging.
- Push a commit with a new migration directly to `main`; `deploy-prod.yml`'s `migrate` job runs unconditionally and pushes to prod.
- Run `/staging-db-commands` retry flow on a PR; it correctly finds failed runs from `deploy-staging.yml` (updated `--workflow` reference).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvgaJ2kENhJPXeTEMQBvPK)_