### PR TITLE
feat(link-wizard): add link-out and description

### DIFF
--- a/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Users } from "lucide-react";
+import { Users, ExternalLink } from "lucide-react";
 import type { Candidate } from "@/api/artistSearch/types";
 import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 
@@ -27,15 +27,40 @@ export function CandidateCard({ candidate, onSelect }: CandidateCardProps) {
             className="w-full h-24 object-cover rounded"
           />
         )}
-        <div>
-          <p className="font-medium text-sm line-clamp-2">{candidate.name}</p>
+        <div className="space-y-1">
+          <div className="flex items-start gap-2">
+            <p className="font-medium text-sm line-clamp-2 flex-1">
+              {candidate.name}
+            </p>
+            <a
+              href={candidate.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-shrink-0 mt-0.5"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </Button>
+            </a>
+          </div>
           {candidate.followers !== null && (
-            <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
               <Users className="h-3 w-3" />
               {formatFollowers(candidate.followers)}
             </div>
           )}
         </div>
+        {candidate.description && (
+          <p className="text-sm text-muted-foreground line-clamp-3">
+            {candidate.description}
+          </p>
+        )}
         {candidate.genres.length > 0 && (
           <div className="flex flex-wrap gap-1">
             {candidate.genres.slice(0, 2).map((genre) => (

--- a/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCard.tsx
@@ -32,22 +32,22 @@ export function CandidateCard({ candidate, onSelect }: CandidateCardProps) {
             <p className="font-medium text-sm line-clamp-2 flex-1">
               {candidate.name}
             </p>
-            <a
-              href={candidate.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex-shrink-0 mt-0.5"
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0 flex-shrink-0 mt-0.5"
+              asChild
               onClick={(e) => e.stopPropagation()}
             >
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-6 w-6 p-0"
+              <a
+                href={candidate.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`View ${candidate.name} on provider profile`}
               >
                 <ExternalLink className="h-4 w-4" />
-              </Button>
-            </a>
+              </a>
+            </Button>
           </div>
           {candidate.followers !== null && (
             <div className="flex items-center gap-1 text-xs text-muted-foreground">


### PR DESCRIPTION
Adds external link button on CandidateCard to open candidate URL in new tab without staging selection. Also renders candidate description with line-clamp-3 truncation.

## Verification
- Click the external link icon button; candidate URL opens in new tab
- Click external link icon button; candidate is not selected/staged  
- Candidate with description displays text truncated to 3 lines via line-clamp-3
- Candidate without description shows no description text/space

Closes #346

---
_Generated by [Claude Code](https://claude.ai/code/session_015MfZ5GedRwGhQ3ae4HCrtE)_