### PR TITLE
feat(link-wizard): surface more candidates with follower ranking

### DIFF
--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import type { Candidate } from "@/api/artistSearch/types";
@@ -17,6 +17,10 @@ export function CandidateCards({
   onSelectCandidate,
 }: CandidateCardsProps) {
   const [showMore, setShowMore] = useState(false);
+
+  useEffect(() => {
+    setShowMore(false);
+  }, [candidates]);
 
   if (isLoading) {
     return (

--- a/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
+++ b/src/pages/admin/festivals/LinkWizard/CandidateCards.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { Candidate } from "@/api/artistSearch/types";
 import type { SelectableField } from "@/api/artistSearch/mergeCandidateSelection";
 import { CandidateCard } from "./CandidateCard";
@@ -14,6 +16,8 @@ export function CandidateCards({
   isLoading,
   onSelectCandidate,
 }: CandidateCardsProps) {
+  const [showMore, setShowMore] = useState(false);
+
   if (isLoading) {
     return (
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
@@ -28,15 +32,42 @@ export function CandidateCards({
     return null;
   }
 
+  const sortedCandidates = sortCandidatesByFollowers(candidates);
+  const displayedCandidates = showMore
+    ? sortedCandidates
+    : sortedCandidates.slice(0, 3);
+  const hasMore = sortedCandidates.length > 3;
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-      {candidates.slice(0, 3).map((candidate) => (
-        <CandidateCard
-          key={candidate.url}
-          candidate={candidate}
-          onSelect={onSelectCandidate}
-        />
-      ))}
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {displayedCandidates.map((candidate) => (
+          <CandidateCard
+            key={candidate.url}
+            candidate={candidate}
+            onSelect={onSelectCandidate}
+          />
+        ))}
+      </div>
+      {hasMore && !showMore && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setShowMore(true)}
+        >
+          Show more
+        </Button>
+      )}
     </div>
   );
+}
+
+function sortCandidatesByFollowers(candidates: Candidate[]): Candidate[] {
+  return [...candidates].sort((a, b) => {
+    if (a.followers === null && b.followers === null) return 0;
+    if (a.followers === null) return 1;
+    if (b.followers === null) return -1;
+    return b.followers - a.followers;
+  });
 }

--- a/supabase/functions/search-artist-links/soundcloud-adapter.ts
+++ b/supabase/functions/search-artist-links/soundcloud-adapter.ts
@@ -23,7 +23,7 @@ export async function searchSoundCloud(
     try {
       console.log(`[searchSoundCloud] Searching for artist: ${artistName}`);
 
-      const endpoint = `/users?q=${encodeURIComponent(artistName)}&limit=3`;
+      const endpoint = `/users?q=${encodeURIComponent(artistName)}&limit=10`;
       const response = await fetchSoundCloudAPI(
         endpoint,
         accessToken,

--- a/supabase/functions/search-artist-links/spotify-adapter.ts
+++ b/supabase/functions/search-artist-links/spotify-adapter.ts
@@ -15,7 +15,7 @@ export async function searchSpotify(
       console.log(`[searchSpotify] Searching for artist: ${artistName}`);
 
       const query = encodeURIComponent(artistName);
-      const endpoint = `https://api.spotify.com/v1/search?type=artist&q=${query}&limit=3`;
+      const endpoint = `https://api.spotify.com/v1/search?type=artist&q=${query}&limit=10`;
 
       const response = await fetch(endpoint, {
         headers: {


### PR DESCRIPTION
Raises per-provider search limit from 3 to 10 in Spotify and SoundCloud adapters, and sorts candidates by follower count (descending, nulls last) client-side to surface better-ranked candidates without overwhelming the UI.
Displays only first 3 candidates by default with a "Show more" button to reveal all fetched candidates at once.

Closes #347

## Verification
- Search for an artist in Link Wizard and verify first 3 candidates are sorted by followers descending
- Verify candidates with null followers appear at the end of the sorted list
- Click "Show more" button and verify all 10 fetched candidates are displayed at once
- Run `pnpm test` and `pnpm run lint` to verify no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_015MfZ5GedRwGhQ3ae4HCrtE)_