### PR TITLE
feat(edition-views): prototype new identity skins

### DIFF
--- a/docs/design/edition-color-vocabulary.md
+++ b/docs/design/edition-color-vocabulary.md
@@ -1,0 +1,77 @@
+# Semantic color vocabulary for the edition views
+
+Resolution of [#319](https://github.com/chiptus/UpLine/issues/319), part of the visual-identity wayfinder map [#317](https://github.com/chiptus/UpLine/issues/317).
+
+This names the **roles** colors play in the voter-facing edition views, independent of which palette fills them. The direction spec (#321) and the tokenization migration (#230) are written in this language.
+
+## Ground rules
+
+- **Reuse and retheme the existing shadcn token names** where a role already exists (`background`, `foreground`, `muted-foreground`, `border`, `ring`, `popover`, `accent`, `destructive`). New names are added only for roles shadcn doesn't cover. No `ed-*` namespace.
+- **No numeric ramps.** Each role is one value per theme; "lighter/darker" variants are expressed as alpha on the base token (Tailwind `/NN` over an HSL var) or as an explicit `-soft` companion, not as `-100…-900` scales.
+- Values below reference today's hardcoded classes only to define the mapping; the actual palette is chosen in #320/#321.
+
+## Token set
+
+### Ground & text hierarchy
+
+| Token                                              | Role                                         | Absorbs today                                            |
+| -------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------- |
+| `background` (+ existing `--app-gradient-from/to`) | Page ground; the gradient composes over it.  | Explore's hardcoded `from-purple-900 to-black`           |
+| `foreground`                                       | Primary text/icons on the ground             | `text-white`, `text-purple-50`, `text-purple-100`        |
+| `muted-foreground`                                 | Secondary text                               | `text-purple-200`, `text-purple-100/80`                  |
+| `subtle-foreground` **(new)**                      | Tertiary: labels, hint icons, faint metadata | `text-purple-300`, `text-purple-200/60`, `text-gray-400` |
+
+### Surfaces
+
+| Token                      | Role                                      | Absorbs today                                    |
+| -------------------------- | ----------------------------------------- | ------------------------------------------------ |
+| `surface` **(new)**        | Resting raised layer (chips, cards)       | `bg-white/5`, `bg-purple-900/60`                 |
+| `surface-raised` **(new)** | Emphasized layer                          | `bg-white/10`, `bg-white/15`, `bg-purple-800/50` |
+| `surface-active` **(new)** | Hover/pressed/selected layer              | `bg-white/20`, `bg-white/30`                     |
+| `popover` (existing)       | Solid floating sheets, dropdowns, drawers | `bg-gray-800`, `bg-gray-900`, `bg-gray-900/95`   |
+
+### Borders & focus
+
+| Token                     | Role                         | Absorbs today                                                              |
+| ------------------------- | ---------------------------- | -------------------------------------------------------------------------- |
+| `border`                  | Default hairline             | `border-purple-400/20`, `border-purple-400/30`                             |
+| `border-strong` **(new)** | Emphasis / selected outlines | `border-purple-400/40`–`/50`, `border-purple-400`, `border-white/50`–`/80` |
+| `ring`                    | Focus/selection ring         | `ring-purple-400`, `ring-white`                                            |
+
+### Brand accent (interactive)
+
+| Token                          | Role                                             | Absorbs today                                      |
+| ------------------------------ | ------------------------------------------------ | -------------------------------------------------- |
+| `accent` / `accent-foreground` | Primary interactive fill: selected toggles, CTAs | `bg-purple-600`, `bg-purple-700`, `bg-purple-400`  |
+| `accent-soft` **(new)**        | Translucent accent wash for selected/hover chips | `bg-purple-600/30`–`/60`, `bg-purple-400/10`–`/30` |
+| `text-accent`                  | Accent-colored text/icons                        | `text-purple-400`                                  |
+
+(`accent` is repurposed from shadcn's neutral hover-gray to the brand accent; edition views don't use the old meaning.)
+
+### Status roles
+
+| Token                          | Role                                                                                                     | Absorbs today                                                                |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `live` / `live-foreground`     | Happening-now: hero Live dot, Now button, current-time indicator — **unifies** today's fuchsia/red split | `bg-fuchsia-400`, `text-fuchsia-100/200`, hero `bg-red-500` + `text-red-200` |
+| `notice` / `notice-foreground` | Attention, non-urgent: new-data refresh, tab-indicator dots, festival-mode badge, empty-state sparkle    | `bg-amber-400`, orange refresh/badge classes, `text-yellow-400`              |
+| `destructive` (existing)       | Dangerous/clearing actions                                                                               | `text-red-400`/`300`, `bg-red-400/10`                                        |
+
+### Vote triad
+
+Vote colors become token families consumed by `src/lib/voteConfig.ts` (shared with SetDetails/groups, which shift along):
+
+| Family                                      | Vote            | Initial value  |
+| ------------------------------------------- | --------------- | -------------- |
+| `vote-must` / `-foreground` / `-soft`       | Must Go (+2)    | today's orange |
+| `vote-interested` / `-foreground` / `-soft` | Interested (+1) | today's blue   |
+| `vote-skip` / `-foreground` / `-soft`       | Won't Go (−1)   | today's gray   |
+
+`-soft` is the translucent card/chip wash; `-foreground` is legible text/icon on the ground.
+
+### Stays literal
+
+Third-party brand colors (Spotify green, SoundCloud orange, etc. in `SocialPlatformUtils.tsx`) remain hardcoded — they belong to those brands, not this identity.
+
+## Audit snapshot (2026-08-20)
+
+~350 hardcoded color-class occurrences across 60 files under `src/pages/EditionView` (the map's "~54/29" was stale). Top offenders: `text-purple-300` (43), `text-purple-100` (41), `text-purple-200` (29), `border-purple-400/30` (24), `text-white` (23), `bg-white/10` (20). Full frequency table in the #319 resolution comment.

--- a/src/pages/EditionView/prototype/NOTES.md
+++ b/src/pages/EditionView/prototype/NOTES.md
@@ -5,8 +5,11 @@ ground, Unbounded display, lime accent — plus the soft-border light mode) hold
 against the real edition views, with real data and chrome?
 
 **How to run:** `pnpm run dev`, open any edition view, use the floating
-PROTOTYPE bar at the bottom (or ←/→ keys) to cycle
-`current` → `festival-dark` → `festival-light`. Shareable via `?identity=`.
+PROTOTYPE bar at the top (or ←/→ keys) to cycle
+`current` → `festival-dark` → `festival-light` → `hybrid-dark` (comparison
+only — the #320 decision is Festival v2). Shareable via `?identity=`. On
+production/preview builds the switcher stays hidden unless the URL carries
+`?proto=1` or an `?identity=` value (so it works on Vercel PR previews).
 
 **What this is NOT:** the implementation. It brute-forces overrides of today's
 hardcoded palette classes with scoped CSS. The real rollout is specced in #321

--- a/src/pages/EditionView/prototype/NOTES.md
+++ b/src/pages/EditionView/prototype/NOTES.md
@@ -7,9 +7,10 @@ against the real edition views, with real data and chrome?
 **How to run:** `pnpm run dev`, open any edition view, use the floating
 PROTOTYPE bar at the top (or ←/→ keys) to cycle
 `current` → `festival-dark` → `festival-light` → `hybrid-dark` (comparison
-only — the #320 decision is Festival v2). Shareable via `?identity=`. On
-production/preview builds the switcher stays hidden unless the URL carries
-`?proto=1` or an `?identity=` value (so it works on Vercel PR previews).
+only — the #320 decision is Festival v2). Shareable via `?identity=`.
+The switcher is deliberately NOT production-gated: this branch exists to be
+shown to non-technical reviewers via the Vercel PR preview and is never
+merged as-is.
 
 **What this is NOT:** the implementation. It brute-forces overrides of today's
 hardcoded palette classes with scoped CSS. The real rollout is specced in #321

--- a/src/pages/EditionView/prototype/NOTES.md
+++ b/src/pages/EditionView/prototype/NOTES.md
@@ -1,0 +1,17 @@
+# PROTOTYPE — Festival v2 identity on the real edition views
+
+**Question:** Does the identity decided in #320 (Festival v2 dark — violet poster
+ground, Unbounded display, lime accent — plus the soft-border light mode) hold up
+against the real edition views, with real data and chrome?
+
+**How to run:** `pnpm run dev`, open any edition view, use the floating
+PROTOTYPE bar at the bottom (or ←/→ keys) to cycle
+`current` → `festival-dark` → `festival-light`. Shareable via `?identity=`.
+
+**What this is NOT:** the implementation. It brute-forces overrides of today's
+hardcoded palette classes with scoped CSS. The real rollout is specced in #321
+using the token vocabulary from `docs/design/edition-color-vocabulary.md`.
+
+**Verdict:** _(fill in after review, then delete this directory, the switcher
+wiring in `src/routes/festivals/$festivalSlug/editions/$editionSlug.tsx`, and
+capture the answer in #321)_

--- a/src/pages/EditionView/prototype/NOTES.md
+++ b/src/pages/EditionView/prototype/NOTES.md
@@ -16,6 +16,14 @@ merged as-is.
 hardcoded palette classes with scoped CSS. The real rollout is specced in #321
 using the token vocabulary from `docs/design/edition-color-vocabulary.md`.
 
-**Verdict:** _(fill in after review, then delete this directory, the switcher
-wiring in `src/routes/festivals/$festivalSlug/editions/$editionSlug.tsx`, and
-capture the answer in #321)_
+**Verdict (2026-08-22):** Festival v2 holds up on real screens and is
+confirmed for both modes: `festival-dark` (violet ground, lime accent,
+Unbounded) and `festival-light` (olive-green #4c7a00 accent, soft borders on
+#fafaf7). One skeleton, two color themes — typography does NOT change between
+modes. The hybrid variants (coral, Bricolage/Public Sans) and the
+`unified-light` comparison were reviewed and rejected; this also settles
+#320's open light-accent question in favor of green. Border radius was
+softened from the mockups' 18/14px to 12/10px and stays an open knob for
+#321 (single `--radius` token). Next: spec in #321, then delete this
+directory and its wiring in
+`src/routes/festivals/$festivalSlug/editions/$editionSlug.tsx`.

--- a/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
+++ b/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
@@ -9,6 +9,7 @@ const VARIANTS = [
   "festival-dark",
   "festival-light",
   "hybrid-dark",
+  "hybrid-light",
 ] as const;
 export type IdentityVariant = (typeof VARIANTS)[number];
 
@@ -17,6 +18,7 @@ const LABELS: Record<IdentityVariant, string> = {
   "festival-dark": "Festival v2 — dark",
   "festival-light": "Festival v2 — light (soft borders)",
   "hybrid-dark": "Hybrid — dark (coral on neutral)",
+  "hybrid-light": "Hybrid — light (coral, soft borders)",
 };
 
 export function useIdentityVariant(): IdentityVariant {
@@ -41,6 +43,8 @@ export function identityClass(variant: IdentityVariant) {
   if (variant === "festival-dark") return "proto-festival-v2";
   if (variant === "festival-light") return "proto-festival-v2 proto-light";
   if (variant === "hybrid-dark") return "proto-festival-v2 proto-hybrid";
+  if (variant === "hybrid-light")
+    return "proto-festival-v2 proto-hybrid proto-light";
   return "";
 }
 

--- a/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
+++ b/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
@@ -4,13 +4,19 @@ import "./festival-v2-identity.css";
 // PROTOTYPE — throwaway switcher for #320's decided identity. Delete with the
 // rest of src/pages/EditionView/prototype/ once the verdict is captured.
 
-const VARIANTS = ["current", "festival-dark", "festival-light"] as const;
+const VARIANTS = [
+  "current",
+  "festival-dark",
+  "festival-light",
+  "hybrid-dark",
+] as const;
 export type IdentityVariant = (typeof VARIANTS)[number];
 
 const LABELS: Record<IdentityVariant, string> = {
   current: "Current identity",
   "festival-dark": "Festival v2 — dark",
   "festival-light": "Festival v2 — light (soft borders)",
+  "hybrid-dark": "Hybrid — dark (coral on neutral)",
 };
 
 export function useIdentityVariant(): IdentityVariant {
@@ -34,6 +40,7 @@ export function useIdentityVariant(): IdentityVariant {
 export function identityClass(variant: IdentityVariant) {
   if (variant === "festival-dark") return "proto-festival-v2";
   if (variant === "festival-light") return "proto-festival-v2 proto-light";
+  if (variant === "hybrid-dark") return "proto-festival-v2 proto-hybrid";
   return "";
 }
 

--- a/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
+++ b/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from "react";
+import "./festival-v2-identity.css";
+
+// PROTOTYPE — throwaway switcher for #320's decided identity. Delete with the
+// rest of src/pages/EditionView/prototype/ once the verdict is captured.
+
+const VARIANTS = ["current", "festival-dark", "festival-light"] as const;
+export type IdentityVariant = (typeof VARIANTS)[number];
+
+const LABELS: Record<IdentityVariant, string> = {
+  current: "Current identity",
+  "festival-dark": "Festival v2 — dark",
+  "festival-light": "Festival v2 — light (soft borders)",
+};
+
+export function useIdentityVariant(): IdentityVariant {
+  const [variant, setVariant] = useState(readVariant);
+
+  useEffect(() => {
+    function onChange() {
+      setVariant(readVariant());
+    }
+    window.addEventListener("proto-identity-change", onChange);
+    window.addEventListener("popstate", onChange);
+    return () => {
+      window.removeEventListener("proto-identity-change", onChange);
+      window.removeEventListener("popstate", onChange);
+    };
+  }, []);
+
+  return variant;
+}
+
+export function identityClass(variant: IdentityVariant) {
+  if (variant === "festival-dark") return "proto-festival-v2";
+  if (variant === "festival-light") return "proto-festival-v2 proto-light";
+  return "";
+}
+
+export function PrototypeIdentitySwitcher() {
+  const variant = useIdentityVariant();
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === "ArrowLeft") cycle(-1);
+      if (e.key === "ArrowRight") cycle(1);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  if (import.meta.env.PROD) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 76,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 9999,
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        background: "#111",
+        color: "#fff",
+        borderRadius: 999,
+        padding: "8px 14px",
+        fontSize: 13,
+        fontFamily: "system-ui, sans-serif",
+        boxShadow: "0 6px 24px rgba(0,0,0,0.4)",
+        border: "1px solid rgba(255,255,255,0.25)",
+      }}
+    >
+      <button
+        onClick={() => cycle(-1)}
+        style={arrowStyle}
+        aria-label="Previous identity variant"
+      >
+        ←
+      </button>
+      <span style={{ minWidth: 200, textAlign: "center" }}>
+        PROTOTYPE · {LABELS[variant]}
+      </span>
+      <button
+        onClick={() => cycle(1)}
+        style={arrowStyle}
+        aria-label="Next identity variant"
+      >
+        →
+      </button>
+    </div>
+  );
+}
+
+const arrowStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.15)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 999,
+  width: 26,
+  height: 26,
+  cursor: "pointer",
+};
+
+function readVariant(): IdentityVariant {
+  const v = new URLSearchParams(window.location.search).get("identity");
+  return (VARIANTS as readonly string[]).includes(v ?? "")
+    ? (v as IdentityVariant)
+    : "current";
+}
+
+function cycle(dir: number) {
+  const current = readVariant();
+  const next =
+    VARIANTS[
+      (VARIANTS.indexOf(current) + dir + VARIANTS.length) % VARIANTS.length
+    ];
+  const url = new URL(window.location.href);
+  if (next === "current") url.searchParams.delete("identity");
+  else url.searchParams.set("identity", next);
+  window.history.replaceState(null, "", url);
+  window.dispatchEvent(new Event("proto-identity-change"));
+}

--- a/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
+++ b/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
@@ -49,6 +49,7 @@ export function PrototypeIdentitySwitcher() {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      if (import.meta.env.PROD && !isProtoEnabled()) return;
       const target = e.target as HTMLElement | null;
       if (
         target &&

--- a/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
+++ b/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
@@ -49,7 +49,6 @@ export function PrototypeIdentitySwitcher() {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (import.meta.env.PROD && !isProtoEnabled()) return;
       const target = e.target as HTMLElement | null;
       if (
         target &&
@@ -65,8 +64,6 @@ export function PrototypeIdentitySwitcher() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
-
-  if (import.meta.env.PROD && !isProtoEnabled()) return null;
 
   return (
     <div
@@ -120,11 +117,6 @@ const arrowStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
-function isProtoEnabled() {
-  const params = new URLSearchParams(window.location.search);
-  return params.has("proto") || params.has("identity");
-}
-
 function readVariant(): IdentityVariant {
   const v = new URLSearchParams(window.location.search).get("identity");
   return (VARIANTS as readonly string[]).includes(v ?? "")
@@ -139,12 +131,8 @@ function cycle(dir: number) {
       (VARIANTS.indexOf(current) + dir + VARIANTS.length) % VARIANTS.length
     ];
   const url = new URL(window.location.href);
-  if (next === "current") {
-    url.searchParams.delete("identity");
-    url.searchParams.set("proto", "1");
-  } else {
-    url.searchParams.set("identity", next);
-  }
+  if (next === "current") url.searchParams.delete("identity");
+  else url.searchParams.set("identity", next);
   window.history.replaceState(null, "", url);
   window.dispatchEvent(new Event("proto-identity-change"));
 }

--- a/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
+++ b/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
@@ -10,6 +10,7 @@ const VARIANTS = [
   "festival-light",
   "hybrid-dark",
   "hybrid-light",
+  "unified-light",
 ] as const;
 export type IdentityVariant = (typeof VARIANTS)[number];
 
@@ -19,6 +20,7 @@ const LABELS: Record<IdentityVariant, string> = {
   "festival-light": "Festival v2 — light (soft borders)",
   "hybrid-dark": "Hybrid — dark (coral on neutral)",
   "hybrid-light": "Hybrid — light (coral, soft borders)",
+  "unified-light": "Unified — light (coral colors, festival type)",
 };
 
 export function useIdentityVariant(): IdentityVariant {
@@ -45,6 +47,8 @@ export function identityClass(variant: IdentityVariant) {
   if (variant === "hybrid-dark") return "proto-festival-v2 proto-hybrid";
   if (variant === "hybrid-light")
     return "proto-festival-v2 proto-hybrid proto-light";
+  if (variant === "unified-light")
+    return "proto-festival-v2 proto-light proto-coral";
   return "";
 }
 

--- a/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
+++ b/src/pages/EditionView/prototype/PrototypeIdentitySwitcher.tsx
@@ -65,13 +65,13 @@ export function PrototypeIdentitySwitcher() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  if (import.meta.env.PROD) return null;
+  if (import.meta.env.PROD && !isProtoEnabled()) return null;
 
   return (
     <div
       style={{
         position: "fixed",
-        bottom: 76,
+        top: 12,
         left: "50%",
         transform: "translateX(-50%)",
         zIndex: 9999,
@@ -119,6 +119,11 @@ const arrowStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
+function isProtoEnabled() {
+  const params = new URLSearchParams(window.location.search);
+  return params.has("proto") || params.has("identity");
+}
+
 function readVariant(): IdentityVariant {
   const v = new URLSearchParams(window.location.search).get("identity");
   return (VARIANTS as readonly string[]).includes(v ?? "")
@@ -133,8 +138,12 @@ function cycle(dir: number) {
       (VARIANTS.indexOf(current) + dir + VARIANTS.length) % VARIANTS.length
     ];
   const url = new URL(window.location.href);
-  if (next === "current") url.searchParams.delete("identity");
-  else url.searchParams.set("identity", next);
+  if (next === "current") {
+    url.searchParams.delete("identity");
+    url.searchParams.set("proto", "1");
+  } else {
+    url.searchParams.set("identity", next);
+  }
   window.history.replaceState(null, "", url);
   window.dispatchEvent(new Event("proto-identity-change"));
 }

--- a/src/pages/EditionView/prototype/festival-v2-identity.css
+++ b/src/pages/EditionView/prototype/festival-v2-identity.css
@@ -173,3 +173,11 @@
 .proto-festival-v2.proto-hybrid.proto-light.bg-app-gradient {
   background: #fafaf7;
 }
+
+/* ---- unified light: hybrid's coral light colors, Festival v2 typography ---- */
+
+.proto-festival-v2.proto-light.proto-coral {
+  --proto-accent: #d32a17;
+  --proto-accent-fg: #ffffff;
+  --proto-live: #c1180a;
+}

--- a/src/pages/EditionView/prototype/festival-v2-identity.css
+++ b/src/pages/EditionView/prototype/festival-v2-identity.css
@@ -3,7 +3,7 @@
    Brute-force overrides of today's hardcoded palette classes — NOT the real
    implementation (that's #321's spec + rollout). Delete after the verdict. */
 
-@import url("https://fonts.googleapis.com/css2?family=Unbounded:wght@500;700&family=Space+Grotesk:wght@400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Unbounded:wght@500;700&family=Space+Grotesk:wght@400;500;700&family=Bricolage+Grotesque:wght@600;800&family=Public+Sans:wght@400;500;600;700&display=swap");
 
 .proto-festival-v2 {
   --proto-text: #fbf7ff;
@@ -124,4 +124,33 @@
   background-color: #ffffff;
   border-color: var(--proto-border);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
+}
+
+/* ---- hybrid variant: quiet near-black ground, coral accent, Bricolage display ---- */
+
+.proto-festival-v2.proto-hybrid {
+  --proto-text: #eef0f4;
+  --proto-muted: #b9bfcb;
+  --proto-subtle: #8d94a3;
+  --proto-surface: rgba(255, 255, 255, 0.045);
+  --proto-raised: rgba(255, 255, 255, 0.085);
+  --proto-border: rgba(255, 255, 255, 0.13);
+  --proto-accent: #ff5c48;
+  --proto-accent-fg: #2b0700;
+  --proto-solid: #1c1f27;
+  --proto-live: #ff5c48;
+
+  font-family: "Public Sans", "Segoe UI", system-ui, sans-serif;
+}
+
+.proto-festival-v2.proto-hybrid.bg-app-gradient {
+  background: #14161d;
+}
+
+.proto-festival-v2.proto-hybrid h1,
+.proto-festival-v2.proto-hybrid h2 {
+  font-family: "Bricolage Grotesque", Georgia, system-ui, sans-serif;
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-weight: 800;
 }

--- a/src/pages/EditionView/prototype/festival-v2-identity.css
+++ b/src/pages/EditionView/prototype/festival-v2-identity.css
@@ -154,3 +154,22 @@
   letter-spacing: -0.01em;
   font-weight: 800;
 }
+
+/* ---- hybrid light: same soft light ground, coral-red accent ---- */
+
+.proto-festival-v2.proto-hybrid.proto-light {
+  --proto-text: #1a1c22;
+  --proto-muted: #484d59;
+  --proto-subtle: #676d7a;
+  --proto-surface: #ffffff;
+  --proto-raised: #ffffff;
+  --proto-border: #dcdfe3;
+  --proto-accent: #d32a17;
+  --proto-accent-fg: #ffffff;
+  --proto-solid: #ffffff;
+  --proto-live: #c1180a;
+}
+
+.proto-festival-v2.proto-hybrid.proto-light.bg-app-gradient {
+  background: #fafaf7;
+}

--- a/src/pages/EditionView/prototype/festival-v2-identity.css
+++ b/src/pages/EditionView/prototype/festival-v2-identity.css
@@ -87,10 +87,10 @@
 }
 
 .proto-festival-v2 .rounded-lg {
-  border-radius: 18px;
+  border-radius: 12px;
 }
 .proto-festival-v2 .rounded-md {
-  border-radius: 14px;
+  border-radius: 10px;
 }
 
 /* ---- light variant: soft borders grafted from the neutral direction ---- */

--- a/src/pages/EditionView/prototype/festival-v2-identity.css
+++ b/src/pages/EditionView/prototype/festival-v2-identity.css
@@ -1,0 +1,127 @@
+/* PROTOTYPE — throwaway skin for #320's decided identity (Festival v2).
+   Scoped under .proto-festival-v2 on the EditionLayout root; toggled via ?identity=.
+   Brute-force overrides of today's hardcoded palette classes — NOT the real
+   implementation (that's #321's spec + rollout). Delete after the verdict. */
+
+@import url("https://fonts.googleapis.com/css2?family=Unbounded:wght@500;700&family=Space+Grotesk:wght@400;500;700&display=swap");
+
+.proto-festival-v2 {
+  --proto-text: #fbf7ff;
+  --proto-muted: #d9c9f2;
+  --proto-subtle: #a893cc;
+  --proto-surface: rgba(255, 255, 255, 0.06);
+  --proto-raised: rgba(255, 255, 255, 0.1);
+  --proto-border: rgba(255, 255, 255, 0.18);
+  --proto-accent: #c6f542;
+  --proto-accent-fg: #1a2400;
+  --proto-solid: #241040;
+  --proto-live: #ff4fa3;
+
+  font-family: "Space Grotesk", "Segoe UI", system-ui, sans-serif;
+  color: var(--proto-text);
+}
+
+.proto-festival-v2.bg-app-gradient {
+  background: radial-gradient(
+      120% 70% at 50% -10%,
+      #3d1160 0%,
+      #1c0733 55%,
+      #120522 100%
+    )
+    fixed;
+}
+
+.proto-festival-v2 h1,
+.proto-festival-v2 h2 {
+  font-family: "Unbounded", "Arial Black", system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.proto-festival-v2 .text-white,
+.proto-festival-v2 .text-purple-100 {
+  color: var(--proto-text);
+}
+.proto-festival-v2 .text-purple-200,
+.proto-festival-v2 [class*="text-purple-100/"],
+.proto-festival-v2 .text-purple-300 {
+  color: var(--proto-muted);
+}
+.proto-festival-v2 .text-purple-400,
+.proto-festival-v2 [class*="text-purple-200/"],
+.proto-festival-v2 .text-gray-400 {
+  color: var(--proto-subtle);
+}
+
+.proto-festival-v2 [class*="border-purple-400"],
+.proto-festival-v2 [class*="border-white/"] {
+  border-color: var(--proto-border);
+}
+
+.proto-festival-v2 .bg-purple-600,
+.proto-festival-v2 .bg-purple-700 {
+  background: var(--proto-accent);
+  color: var(--proto-accent-fg);
+}
+.proto-festival-v2 .bg-purple-600 *,
+.proto-festival-v2 .bg-purple-700 * {
+  color: var(--proto-accent-fg);
+}
+
+.proto-festival-v2 [class*="bg-purple-600/"],
+.proto-festival-v2 [class*="bg-purple-800/"],
+.proto-festival-v2 .bg-gray-800,
+.proto-festival-v2 .bg-gray-900,
+.proto-festival-v2 [class*="bg-gray-900/"] {
+  background-color: var(--proto-solid);
+}
+
+.proto-festival-v2 [class*="bg-purple-400/"],
+.proto-festival-v2 [class*="bg-white/1"] {
+  background-color: var(--proto-surface);
+}
+.proto-festival-v2 [class*="bg-white/2"],
+.proto-festival-v2 [class*="bg-white/3"],
+.proto-festival-v2 .bg-purple-400 {
+  background-color: var(--proto-raised);
+}
+
+.proto-festival-v2 .rounded-lg {
+  border-radius: 18px;
+}
+.proto-festival-v2 .rounded-md {
+  border-radius: 14px;
+}
+
+/* ---- light variant: soft borders grafted from the neutral direction ---- */
+
+.proto-festival-v2.proto-light {
+  --proto-text: #1a1c22;
+  --proto-muted: #484d59;
+  --proto-subtle: #676d7a;
+  --proto-surface: #ffffff;
+  --proto-raised: #ffffff;
+  --proto-border: #dcdfe3;
+  --proto-accent: #4c7a00;
+  --proto-accent-fg: #ffffff;
+  --proto-solid: #ffffff;
+  --proto-live: #d61f7e;
+
+  color: var(--proto-text);
+}
+
+.proto-festival-v2.proto-light.bg-app-gradient {
+  background: #fafaf7;
+}
+
+.proto-festival-v2.proto-light [class*="bg-purple-400/"],
+.proto-festival-v2.proto-light [class*="bg-white/"],
+.proto-festival-v2.proto-light [class*="bg-purple-600/"],
+.proto-festival-v2.proto-light [class*="bg-purple-800/"],
+.proto-festival-v2.proto-light .bg-gray-800,
+.proto-festival-v2.proto-light .bg-gray-900,
+.proto-festival-v2.proto-light [class*="bg-gray-900/"] {
+  background-color: #ffffff;
+  border-color: var(--proto-border);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
+}

--- a/src/routes/festivals/$festivalSlug/editions/$editionSlug.tsx
+++ b/src/routes/festivals/$festivalSlug/editions/$editionSlug.tsx
@@ -10,6 +10,12 @@ import { getEffectiveFestivalPhase } from "@/lib/festivalPhase";
 import { getDefaultTab } from "@/pages/EditionView/TabNavigation/defaultTab";
 import { tabRoutes } from "@/pages/EditionView/TabNavigation/tabRoutes";
 import { pageMeta } from "@/lib/pageHead";
+import {
+  PrototypeIdentitySwitcher,
+  identityClass,
+  useIdentityVariant,
+} from "@/pages/EditionView/prototype/PrototypeIdentitySwitcher";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute(
   "/festivals/$festivalSlug/editions/$editionSlug",
@@ -67,6 +73,7 @@ export const Route = createFileRoute(
 
 function EditionLayout() {
   const { festival, edition } = useFestivalEdition();
+  const identityVariant = useIdentityVariant();
 
   if (!edition) {
     return (
@@ -77,7 +84,12 @@ function EditionLayout() {
   }
 
   return (
-    <div className="min-h-screen bg-app-gradient">
+    <div
+      className={cn(
+        "min-h-screen bg-app-gradient",
+        identityClass(identityVariant),
+      )}
+    >
       <div className="container mx-auto px-4 py-4 md:py-8 pb-20 md:pb-8">
         <EditionHeader
           title={`${festival.name} - ${edition.name}`}
@@ -93,6 +105,7 @@ function EditionLayout() {
           </ErrorBoundary>
         </div>
       </div>
+      <PrototypeIdentitySwitcher />
     </div>
   );
 }


### PR DESCRIPTION
Demo branch — not for merge. Adds the #319 semantic color vocabulary doc and a `?identity=` switcher applying #320's decided identity (Festival v2 dark, soft-border light, plus a hybrid comparison) to the real edition views via throwaway scoped CSS.
The switcher is deliberately ungated so the Vercel PR preview can be shown to non-technical reviewers; the prototype is deleted once the verdict lands in #321.

## Verification
- Open any edition view (locally or on the Vercel preview); the floating PROTOTYPE pill at the top cycles current → festival-dark → festival-light → hybrid-dark (←/→ keys too), and `?identity=festival-dark` survives reload.
- With no `identity` param, edition views render as on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtnAr22sTrdCMn9rcKrwQn