### PR TITLE
refactor(edition): tokenize chrome colors

### DIFF
--- a/src/pages/EditionView/EditionHero.tsx
+++ b/src/pages/EditionView/EditionHero.tsx
@@ -24,9 +24,9 @@ export function EditionHero({
           className="h-16 md:h-24 lg:h-28 w-auto max-w-xs md:max-w-sm object-contain rounded"
         />
       ) : (
-        <Music className="h-10 w-10 md:h-14 md:w-14 text-purple-400" />
+        <Music className="h-10 w-10 md:h-14 md:w-14 text-accent" />
       )}
-      <h1 className="text-2xl md:text-4xl font-bold text-white tracking-tight">
+      <h1 className="text-2xl md:text-4xl font-bold text-foreground tracking-tight">
         {title}
       </h1>
       <LiveIndicator />
@@ -41,12 +41,12 @@ function LiveIndicator() {
   return (
     <span
       role="status"
-      className="flex items-center gap-1.5 text-sm text-red-200"
+      className="flex items-center gap-1.5 text-sm text-live-foreground"
       aria-label="Festival is live now"
     >
       <span
         aria-hidden="true"
-        className="h-2 w-2 shrink-0 rounded-full bg-red-500 animate-pulse"
+        className="h-2 w-2 shrink-0 rounded-full bg-live animate-pulse"
       />
       Live
     </span>

--- a/src/pages/EditionView/TabNavigation/DesktopTabButton.tsx
+++ b/src/pages/EditionView/TabNavigation/DesktopTabButton.tsx
@@ -18,7 +18,7 @@ export function DesktopTabButton({ config }: TabButtonProps) {
           `flex items-center justify-center gap-2
           px-6 py-3 rounded-lg
           transition-all duration-200 active:scale-95
-          bg-purple-600 text-white shadow-lg`,
+          bg-accent text-accent-foreground shadow-lg`,
         ),
       }}
       inactiveProps={{
@@ -26,7 +26,7 @@ export function DesktopTabButton({ config }: TabButtonProps) {
           `flex items-center justify-center gap-2
           px-6 py-3 rounded-lg
           transition-all duration-200 active:scale-95
-          text-purple-200 hover:text-white hover:bg-white/10`,
+          text-muted-foreground hover:text-foreground hover:bg-surface-raised`,
         ),
       }}
     >

--- a/src/pages/EditionView/TabNavigation/MobileTabButton.tsx
+++ b/src/pages/EditionView/TabNavigation/MobileTabButton.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { Link, useParams, useMatchRoute } from "@tanstack/react-router";
 import { TabButtonProps } from "./types";
 import { tabRoutes } from "./tabRoutes";
@@ -14,18 +15,28 @@ export function MobileTabButton({ config }: TabButtonProps) {
       key={config.key}
       to={tabRoutes[config.key]}
       params={{ festivalSlug, editionSlug }}
-      className={`flex-1 flex flex-col items-center justify-center
-        py-2 px-1 transition-colors duration-200 min-h-16
-        ${isActive ? "text-purple-400" : "text-gray-400 active:text-purple-300"}`}
+      className={cn(
+        "flex-1 flex flex-col items-center justify-center",
+        "py-2 px-1 transition-colors duration-200 min-h-16",
+        isActive
+          ? "text-accent"
+          : "text-subtle-foreground active:text-subtle-foreground",
+      )}
     >
       <span className="relative inline-flex mb-1">
         <config.icon
-          className={`h-6 w-6 ${isActive ? "text-purple-400" : "text-gray-400"}`}
+          className={cn(
+            "h-6 w-6",
+            isActive ? "text-accent" : "text-subtle-foreground",
+          )}
         />
         {config.Indicator && <config.Indicator />}
       </span>
       <span
-        className={`text-xs font-medium text-center leading-tight ${isActive ? "text-purple-400" : "text-gray-400"}`}
+        className={cn(
+          "text-xs font-medium text-center leading-tight",
+          isActive ? "text-accent" : "text-subtle-foreground",
+        )}
       >
         {config.shortLabel}
       </span>

--- a/src/pages/EditionView/TabNavigation/ScheduleTabIndicator.tsx
+++ b/src/pages/EditionView/TabNavigation/ScheduleTabIndicator.tsx
@@ -7,7 +7,7 @@ export function ScheduleTabIndicator() {
     <span
       aria-label="Schedule not fully revealed"
       title="Schedule not yet fully revealed"
-      className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-amber-400"
+      className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-notice"
     />
   );
 }

--- a/src/pages/EditionView/TabNavigation/TabNavigation.tsx
+++ b/src/pages/EditionView/TabNavigation/TabNavigation.tsx
@@ -42,7 +42,7 @@ export function MainTabNavigation() {
     <>
       {/* Desktop: Horizontal tabs at top */}
       <div className="hidden md:block mb-6">
-        <div className="bg-white/10 backdrop-blur-md rounded-lg p-2">
+        <div className="bg-surface-raised backdrop-blur-md rounded-lg p-2">
           <div className="flex gap-1 justify-center">
             {visibleTabs.map((config) => (
               <DesktopTabButton key={config.key} config={config} />
@@ -55,7 +55,7 @@ export function MainTabNavigation() {
       <div
         data-testid="mobile-tab-bar"
         className={cn(
-          "md:hidden fixed bottom-0 left-0 right-0 z-50 bg-gray-900/95 backdrop-blur-md border-t border-purple-400/20 safe-area-pb transition-transform duration-200",
+          "md:hidden fixed bottom-0 left-0 right-0 z-50 bg-popover backdrop-blur-md border-t border-border safe-area-pb transition-transform duration-200",
           hideBottomBar && "translate-y-full",
         )}
       >


### PR DESCRIPTION
Migrates edition chrome (hero + tab navigation) from literal Tailwind colors to the `.edition-view` semantic tokens (#356), with no visual change beyond the unifications the vocabulary doc sanctions (`docs/design/edition-color-vocabulary.md`, "absorbs today" tables):
inactive tabs gray-400 → `subtle-foreground` (purple-300), mobile tab bar `bg-gray-900/95` → `popover` (solid gray-800), hero fallback icon `text-purple-400` → `text-accent` (purple-600, logo-less editions only), hero live dot red → `live` family (fuchsia).

## Verification
- Open an edition view; hero and tab bar match production except the sanctioned shifts above (inactive tabs read light-purple instead of gray, mobile bar slightly lighter).
- Hover/click desktop and mobile tabs; active/inactive/hover behavior unchanged.
- During a live set, the hero live indicator shows the fuchsia pulse dot.

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtnAr22sTrdCMn9rcKrwQn